### PR TITLE
Fix audit bugs: NaN handling, groupby inflation, TCE types, pseudocounts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ jobs:
           uv venv
           source .venv/bin/activate
           uv pip install pytest pytest-cov coveralls pylint ruff
-          uv pip install -r requirements.txt
-          uv pip install seaborn matplotlib tqdm adjustText
           uv pip install .
       - name: Cache pyensembl data
         uses: actions/cache@v4

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -17,8 +17,8 @@ from .version import print_name_and_version
 from .load_dataset import load_all_dataframes
 from .gene_sets_cancer import (
     therapy_target_gene_id_to_name,
-    pMHC_TCE_target_gene_names,
-    surface_TCE_target_gene_names,
+    pMHC_TCE_target_gene_id_to_name,
+    surface_TCE_target_gene_id_to_name,
     cancer_types,
     cancer_type_gene_sets,
 )
@@ -144,8 +144,8 @@ def plot_expression(
                 "TCR-T": therapy_target_gene_id_to_name("TCR-T"),
                 "CAR-T": therapy_target_gene_id_to_name("CAR-T"),
                 "bispecifics": therapy_target_gene_id_to_name("bispecific-antibodies"),
-                "pMHC-TCEs": pMHC_TCE_target_gene_names(),
-                "surface-TCEs": surface_TCE_target_gene_names(),
+                "pMHC-TCEs": pMHC_TCE_target_gene_id_to_name(),
+                "surface-TCEs": surface_TCE_target_gene_id_to_name(),
                 "ADCs": therapy_target_gene_id_to_name("ADC"),
                 "Radio": therapy_target_gene_id_to_name("radioligand"),
             },

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -164,6 +164,9 @@ def plot_expression(
             always_label_genes=forced_labels,
         )
 
+    import matplotlib.pyplot as _plt
+    _plt.close("all")
+
     # Scatter plots: sample vs pan-cancer reference
     scatter_pdf = (
         "%s-vs-cancer.pdf" % prefix if prefix else "vs-cancer.pdf"
@@ -195,6 +198,8 @@ def plot_expression(
         save_dpi=output_dpi,
     )
 
+    _plt.close("all")
+
     # Cancer type signature plots
     genes_png = "%s-cancer-types-genes.png" % prefix if prefix else "cancer-types-genes.png"
     plot_cancer_type_genes(df_expr, save_to_filename=genes_png, save_dpi=output_dpi)
@@ -202,7 +207,9 @@ def plot_expression(
     disjoint_png = "%s-cancer-types-disjoint.png" % prefix if prefix else "cancer-types-disjoint.png"
     plot_cancer_type_disjoint_genes(df_expr, save_to_filename=disjoint_png, save_dpi=output_dpi)
 
-    # PCA and MDS with three normalization methods
+    _plt.close("all")
+
+    # PCA, MDS, UMAP with three normalization methods
     embedding_pngs = []
     for method in ["zscore", "hk", "rank"]:
         pca_png = "%s-pca-%s.png" % (prefix, method) if prefix else "pca-%s.png" % method

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -322,7 +322,7 @@ def pan_cancer_expression(genes=None, normalize=None, log_transform=False):
             for col in value_cols:
                 vals = df[col].astype(float)
                 hk_median = vals[hk_mask].median()
-                if hk_median > 0:
+                if not (np.isnan(hk_median) or hk_median <= 0):
                     df[col] = vals / hk_median
                 else:
                     df[col] = np.nan
@@ -569,6 +569,39 @@ def surface_TCE_target_gene_names():
 def surface_TCE_target_gene_ids():
     """Surface-antigen-targeting TCE Ensembl gene IDs."""
     return _extract_genes_from_df(_tce_filtered_df(pmhc=False), _ID_COLS)
+
+
+def _tce_gene_id_to_name(pmhc):
+    """Paired {Ensembl_Gene_ID: Symbol} dict from TCE data."""
+    df = _tce_filtered_df(pmhc=pmhc)
+    sym_col = next((c for c in _NAME_COLS if c in df.columns), None)
+    id_col = next((c for c in _ID_COLS if c in df.columns), None)
+    if sym_col is None or id_col is None:
+        names = _extract_genes_from_df(df, _NAME_COLS)
+        ids = _extract_genes_from_df(df, _ID_COLS)
+        return {gid: gid for gid in ids} if ids else {n: n for n in names}
+    result = {}
+    for _, row in df.iterrows():
+        syms_raw = str(row[sym_col]).strip() if row[sym_col] is not None else ""
+        ids_raw = str(row[id_col]).strip() if row[id_col] is not None else ""
+        if not syms_raw or syms_raw.lower() in ("nan", "none"):
+            continue
+        syms = [s.strip() for s in syms_raw.split(";") if s.strip()]
+        ids = [i.strip() for i in ids_raw.split(";") if i.strip() and i.strip().startswith("ENSG")]
+        for i, sym in enumerate(syms):
+            if i < len(ids):
+                result[ids[i]] = sym
+    return result
+
+
+def pMHC_TCE_target_gene_id_to_name():
+    """pMHC-targeting TCE: {Ensembl_Gene_ID: Symbol}."""
+    return _tce_gene_id_to_name(pmhc=True)
+
+
+def surface_TCE_target_gene_id_to_name():
+    """Surface-antigen-targeting TCE: {Ensembl_Gene_ID: Symbol}."""
+    return _tce_gene_id_to_name(pmhc=False)
 
 
 # ---------- Deprecated therapy wrappers ----------

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -1685,6 +1685,7 @@ def plot_cancer_type_genes(
         ax=ax,
         arrowprops=dict(arrowstyle="-", color="#999999", alpha=0.25),
         expand=(1.03, 1.2),
+        expand_axes=False,
     )
     ax.set_yticks(y_ticks)
     ax.set_yticklabels(y_labels, fontsize=9)

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -520,8 +520,8 @@ def _prepare_sample_vs_cancer_data(
     hk_ids = housekeeping_gene_ids()
     hk_mask = df[gene_id_col].isin(hk_ids)
     hk_median_tpm = df.loc[hk_mask, tpm_col].astype(float).median()
-    if hk_median_tpm <= 0:
-        hk_median_tpm = 1.0  # fallback
+    if not (hk_median_tpm > 0):  # catches NaN and <= 0
+        hk_median_tpm = 1.0
 
     gene_to_category = _create_gene_to_category_list_mapping(cat_to_ids)
     name_from_df = dict(zip(df[gene_id_col].astype(str), df[gene_name_col].astype(str)))
@@ -1286,31 +1286,36 @@ def _sample_expression_by_symbol(df_gene_expr):
     raw_values = df[tpm_col].astype(float)
     hk_mask = df[gene_id_col].isin(housekeeping_gene_ids())
     hk_median = df.loc[hk_mask, tpm_col].astype(float).median()
-    if hk_median <= 0:
+    if not (hk_median > 0):  # catches NaN and <= 0
         hk_median = 1.0
     hk_values = raw_values / hk_median
 
+    # Resolve symbols from Ensembl IDs via pan-cancer reference
+    ref_lookup = pan_cancer_expression()[["Ensembl_Gene_ID", "Symbol"]].drop_duplicates(
+        subset="Ensembl_Gene_ID"
+    )
+    id_to_symbol = dict(zip(ref_lookup["Ensembl_Gene_ID"], ref_lookup["Symbol"]))
     if "canonical_gene_name" in df.columns:
-        symbols = df["canonical_gene_name"].fillna("").astype(str)
+        fallback = df["canonical_gene_name"].fillna("").astype(str)
     else:
-        ref = pan_cancer_expression()[["Ensembl_Gene_ID", "Symbol"]].drop_duplicates(
-            subset="Ensembl_Gene_ID"
-        )
-        id_to_symbol = dict(zip(ref["Ensembl_Gene_ID"], ref["Symbol"]))
         fallback = df[gene_name_col].fillna("").astype(str)
-        symbols = df[gene_id_col].map(id_to_symbol).fillna(fallback)
+    symbols = df[gene_id_col].map(id_to_symbol).fillna(fallback)
 
     expr_df = pd.DataFrame(
         {
+            "gene_id": df[gene_id_col],
             "Symbol": symbols,
             "sample_raw": raw_values,
             "sample_hk": hk_values,
         }
     )
     expr_df = expr_df[expr_df["Symbol"].astype(str).str.strip().ne("")]
-    grouped = expr_df.groupby("Symbol", as_index=False, sort=False)[
-        ["sample_raw", "sample_hk"]
-    ].sum()
+    # Aggregate by Ensembl ID (unique), then map to symbol.
+    # Use max (not sum) to avoid inflating expression when multiple
+    # rows share an ID (e.g., isoform-level quantification).
+    grouped = expr_df.groupby("gene_id", as_index=False, sort=False).agg(
+        {"Symbol": "first", "sample_raw": "max", "sample_hk": "max"}
+    )
     return (
         dict(zip(grouped["Symbol"], grouped["sample_raw"])),
         dict(zip(grouped["Symbol"], grouped["sample_hk"])),
@@ -1376,7 +1381,7 @@ def _compute_cancer_type_signature_stats(
                 equal = np.sum(np.isclose(ref_vals, sample_hk, atol=1e-6))
                 percentile = float((below + 0.5 * equal) / n)
             percentiles.append(percentile)
-            log_diff = abs(np.log2(sample_hk + 0.001) - np.log2(cohort_hk + 0.001))
+            log_diff = abs(np.log2(sample_hk + 1) - np.log2(cohort_hk + 1))
             gene_details.append(
                 {
                     "gene": gene,
@@ -1419,7 +1424,7 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
     ----------
     method : str
         ``"zscore"`` — z-score of log2(1+raw) across cancer types (default).
-        ``"hk"`` — log2(HK-normalized + 0.001).
+        ``"hk"`` — log2(HK-normalized + 1).
         ``"rank"`` — percentile rank within each gene across cancer types.
     """
     import numpy as np
@@ -1437,7 +1442,7 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
     if method == "hk":
         hk_mask = df[gene_id_col].isin(housekeeping_gene_ids())
         hk_median = df.loc[hk_mask, tpm_col].astype(float).median()
-        if hk_median <= 0:
+        if not (hk_median > 0):  # catches NaN and <= 0
             hk_median = 1.0
         sample_by_id = dict(zip(
             df[gene_id_col].astype(str), df[tpm_col].astype(float) / hk_median,
@@ -1481,7 +1486,7 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
         matrix = np.vstack([z_ref.T, z_sample[None, :]])
     elif method == "hk":
         combined = np.vstack([ref_vals.T, sample_vals[None, :]])
-        matrix = np.log2(combined + 0.001)
+        matrix = np.log2(combined + 1)
     elif method == "rank":
         combined = np.vstack([ref_vals.T, sample_vals[None, :]])  # (34, genes)
         ranked = np.apply_along_axis(
@@ -1797,7 +1802,7 @@ def plot_cohort_heatmap(
     ref_dedup = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
     present = [s for s in gene_symbols if s in ref_dedup.index]
     matrix = ref_dedup.loc[present, fpkm_cols].astype(float)
-    matrix = np.log2(matrix + 0.001)
+    matrix = np.log2(matrix + 1)
 
     if zscore:
         row_mean = matrix.mean(axis=1)
@@ -1900,7 +1905,7 @@ def plot_cohort_pca(
         feature_matrix.append(vals)
 
     X = np.array(feature_matrix)
-    X = np.log2(X + 0.001)
+    X = np.log2(X + 1)
 
     pca = PCA(n_components=2)
     coords = pca.fit_transform(X)
@@ -1957,7 +1962,7 @@ def plot_cohort_therapy_targets(
     ref_dedup = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
     present = [s for s in target_symbols if s in ref_dedup.index]
     matrix = ref_dedup.loc[present, fpkm_cols].astype(float)
-    matrix = np.log2(matrix + 0.001)
+    matrix = np.log2(matrix + 1)
 
     if zscore:
         row_mean = matrix.mean(axis=1)
@@ -2029,7 +2034,7 @@ def _plot_geneset_by_cancer_heatmap(
     matrix = matrix.loc[sort_order]
     present = list(sort_order)
 
-    matrix = np.log2(matrix + 0.001)
+    matrix = np.log2(matrix + 1)
 
     if zscore:
         row_mean = matrix.mean(axis=1)
@@ -2098,7 +2103,7 @@ def plot_cohort_ctas(
     matrix = matrix.loc[matrix.mean(axis=1).sort_values(ascending=False).index]
     present = list(matrix.index)
 
-    matrix = np.log2(matrix + 0.1)  # +0.1 offset for CTAs (many are truly 0)
+    matrix = np.log2(matrix + 1)
 
     if zscore:
         row_mean = matrix.mean(axis=1)
@@ -2110,7 +2115,7 @@ def plot_cohort_ctas(
     else:
         cmap, vmin, vmax = "magma_r", -3, 8
         subtitle = "log2 FPKM"
-        cbar_label = "log2(FPKM + 0.1)"
+        cbar_label = "log2(FPKM + 1)"
     matrix.columns = codes_clean
 
     fig, ax = plt.subplots(figsize=figsize)

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -1343,7 +1343,6 @@ def _compute_cancer_type_signature_stats(
     ref = pan_cancer_expression(normalize="housekeeping")
     ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
     fpkm_cols = [c for c in ref.columns if c.startswith("FPKM_")]
-    codes = [c.replace("FPKM_", "") for c in fpkm_cols]
 
     # Z-score matrix across cancer types for gene selection
     expr_matrix = ref_by_sym[fpkm_cols].astype(float)

--- a/pirlygenes/plot_data_helpers.py
+++ b/pirlygenes/plot_data_helpers.py
@@ -303,7 +303,7 @@ def prepare_gene_expr_df(
     if TPM_offset:
         tpm_values = tpm_values + float(TPM_offset)
     gene_to_tpm = dict(zip(expr_gene_ids, tpm_values))
-    gene_to_log_tpm = dict(zip(expr_gene_ids, np.log10(10.0**-4 + tpm_values)))
+    gene_to_log_tpm = dict(zip(expr_gene_ids, np.log2(1 + tpm_values)))
 
     # categories for each ID (from sets)
     gene_to_categories = _create_gene_to_category_list_mapping(cat_to_gene_id_list)

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -125,8 +125,8 @@ def test_cli_plot_expression_and_main(monkeypatch):
     monkeypatch.setattr(cli_mod, "plot_cancer_type_mds", lambda *a, **k: mds_calls.append(k))
     monkeypatch.setattr(cli_mod, "plot_cancer_type_umap", lambda *a, **k: umap_calls.append(k))
     monkeypatch.setattr(cli_mod, "therapy_target_gene_id_to_name", lambda t: {"ENSG_MOCK": t})
-    monkeypatch.setattr(cli_mod, "pMHC_TCE_target_gene_names", lambda: {"PMHC"})
-    monkeypatch.setattr(cli_mod, "surface_TCE_target_gene_names", lambda: {"SURF"})
+    monkeypatch.setattr(cli_mod, "pMHC_TCE_target_gene_id_to_name", lambda: {"ENSG_PMHC": "PMHC"})
+    monkeypatch.setattr(cli_mod, "surface_TCE_target_gene_id_to_name", lambda: {"ENSG_SURF": "SURF"})
 
     cli_mod.plot_expression(
         "input.csv",


### PR DESCRIPTION
## Summary
Fixes from a systematic audit of gene sets, lookups, joins, filters, and normalization.

### 1. NaN HK median (critical)
`NaN <= 0` evaluates to `False`, so when no housekeeping genes are found in the sample, `hk_median` is NaN and all downstream values become NaN. Fixed with `not (x > 0)` which catches both NaN and <= 0. Four locations in plot.py + gene_sets_cancer.py.

### 2. groupby sum inflates expression (critical)
`_sample_expression_by_symbol` grouped by gene symbol and summed TPM. With 1,351 symbols having multiple rows in a typical sample (isoforms, multi-mapped), this doubles/triples their reported expression. Fixed to aggregate by Ensembl ID using max.

### 3. TCE gene set type mismatch (critical)
`pMHC_TCE_target_gene_names()` and `surface_TCE_target_gene_names()` return `set({"PRAME", ...})` but cli.py passes them where `dict({ENSG: symbol})` is expected. Added `pMHC_TCE_target_gene_id_to_name()` and `surface_TCE_target_gene_id_to_name()` and updated cli.py to use them.

### 4. Standardize log pseudocounts (cleanup)
Mixed `log2(x+0.001)`, `log2(x+0.1)`, and `log10(x+0.0001)` across the codebase. Standardized to `log2(x+1)` everywhere — `log2(0+1)=0` is a cleaner baseline than `log2(0+0.001)=-10`.

## Test plan
- [x] All 33 tests pass
- [x] PRAD sample still ranks #1 in cancer type scoring (0.900)
- [x] New TCE id_to_name functions return correct {ENSG: symbol} dicts
- [x] ACTB TPM not inflated (max, not sum)