### PR TITLE
Add 9-point tumor expression estimation with lineage purity calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Local data, evaluation, and output artifacts
+eval/
+pfo002/
+out-all-figures.pdf
+notebooks/*.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -43,7 +43,8 @@ from .plot import (
     default_gene_sets,
     _select_embedding_genes_bottleneck,
     estimate_tumor_expression,
-    plot_purity_adjusted_targets,
+    estimate_tumor_expression_ranges,
+    plot_tumor_expression_ranges,
     CANCER_TYPE_ALIASES,
     CANCER_TYPE_NAMES,
 )
@@ -310,21 +311,29 @@ def analyze(
                 always_label_genes=forced_labels,
             )
 
-    # Purity-adjusted tumor expression analysis
-    print("[plot] Generating purity-adjusted expression analysis...")
+    # Purity-adjusted tumor expression analysis (9-point ranges)
+    print("[plot] Generating tumor expression range analysis...")
     adj_png = "%s-purity-adjusted.png" % prefix if prefix else "purity-adjusted.png"
-    purity_est = analysis["purity"]["overall_estimate"]
+    purity_dict = analysis["purity"]
     try:
-        plot_purity_adjusted_targets(
+        ranges_df = estimate_tumor_expression_ranges(
             df_expr,
             cancer_type=analysis["cancer_type"],
-            purity=purity_est,
+            purity_result=purity_dict,
+        )
+        plot_tumor_expression_ranges(
+            ranges_df,
+            purity_result=purity_dict,
+            cancer_type=analysis["cancer_type"],
+            top_n=15,
             save_to_filename=adj_png,
             save_dpi=output_dpi,
+            figsize=(12, 14),
         )
         _plt.close("all")
 
-        # Generate therapeutic target report
+        # Generate therapeutic target report (legacy single-point for table)
+        purity_est = purity_dict["overall_estimate"]
         adj_df = estimate_tumor_expression(
             df_expr,
             cancer_type=analysis["cancer_type"],
@@ -333,6 +342,8 @@ def analyze(
         _generate_target_report(adj_df, analysis, prefix)
     except Exception as e:
         print(f"[warn] Purity-adjusted analysis failed: {e}")
+        import traceback
+        traceback.print_exc()
         adj_png = None
 
     # Collect all figures into one PDF (native resolution)
@@ -518,6 +529,78 @@ def _generate_text_reports(analysis, gene_meta, prefix):
         if isinstance(comp, dict):
             enrichment = comp.get("enrichment", 0)
             lines.append(f"- **{comp_name.title()}** enrichment: {enrichment:.1f}x vs TCGA")
+
+    # Lineage gene narrative
+    lineage = components.get("lineage", {})
+    lineage_genes = lineage.get("per_gene", [])
+    if lineage_genes:
+        lines.append("")
+        lines.append("### Lineage Gene Calibration\n")
+        lines.append(
+            "Purity was refined using cancer-type lineage genes — genes with "
+            "known high expression in this tumor type and low TME background. "
+            "Each gene independently estimates purity by comparing the sample's "
+            "HK-normalized expression to the TCGA reference (adjusted for "
+            "TCGA cohort purity).\n"
+        )
+
+        # Sort genes into clusters
+        sorted_genes = sorted(lineage_genes, key=lambda g: g["purity"], reverse=True)
+        median_p = lineage.get("purity")
+
+        # Identify retained vs de-differentiated
+        if median_p is not None and median_p > 0:
+            retained = [g for g in sorted_genes if g["purity"] >= median_p * 0.5]
+            lost = [g for g in sorted_genes if g["purity"] < median_p * 0.5]
+        else:
+            retained = sorted_genes
+            lost = []
+
+        # Not found in sample
+        from .tumor_purity import LINEAGE_GENES
+        cancer_code_local = purity.get("cancer_type", cancer_code)
+        all_lineage = LINEAGE_GENES.get(cancer_code_local, [])
+        found_names = {g["gene"] for g in lineage_genes}
+        not_found = [g for g in all_lineage if g not in found_names]
+
+        lines.append("| Gene | Purity est. | Interpretation |")
+        lines.append("|------|------------|----------------|")
+        for g in sorted_genes:
+            if g in retained:
+                interp = "retained — reliable"
+            else:
+                interp = "likely de-differentiated"
+            lines.append(
+                f"| {g['gene']} | {g['purity']:.1%} | {interp} |"
+            )
+        for g in not_found:
+            lines.append(f"| {g} | — | not detected |")
+
+        lines.append("")
+
+        if retained:
+            retained_names = ", ".join(g["gene"] for g in retained)
+            lines.append(
+                f"**Reliable cluster** ({lineage['purity']:.0%}, "
+                f"IQR {lineage['lower']:.0%}\u2013{lineage['upper']:.0%}): "
+                f"{retained_names}. "
+                "These genes are expressed at levels consistent with their "
+                "TCGA reference, indicating retained tumor lineage identity."
+            )
+        if lost:
+            lost_names = ", ".join(g["gene"] for g in lost)
+            lines.append(
+                f"\n**Possible de-differentiation**: {lost_names}. "
+                "These genes give much lower purity estimates, suggesting "
+                "the tumor may have lost expression of these markers — "
+                "common in metastatic or treatment-resistant disease. "
+                "These are excluded from the purity estimate."
+            )
+        if not_found:
+            lines.append(
+                f"\n**Not detected**: {', '.join(not_found)}."
+            )
+
     lines.append("")
 
     # MHC expression

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -1491,6 +1491,371 @@ def estimate_tumor_expression(
     return result
 
 
+def estimate_tumor_expression_ranges(
+    df_gene_expr,
+    cancer_type,
+    purity_result,
+):
+    """Estimate tumor-specific expression with uncertainty bounds.
+
+    For each gene, computes a 3×3 grid of estimates by crossing
+    (low, med, high) TME background with (low, med, high) purity:
+
+        tumor_expr = max(0, (observed - (1-purity) * tme_bg) / purity)
+
+    TME bounds come from the 25th / 50th / 75th percentile of expression
+    across TME reference tissues for each gene.  Purity bounds come from
+    the ``overall_lower`` / ``overall_estimate`` / ``overall_upper`` fields
+    of ``estimate_tumor_purity()``.
+
+    Parameters
+    ----------
+    df_gene_expr : DataFrame
+        Sample gene expression with TPM column.
+    cancer_type : str
+        TCGA cancer type code or name.
+    purity_result : dict
+        Return value of ``estimate_tumor_purity()``.
+
+    Returns
+    -------
+    DataFrame with columns: symbol, category, observed_tpm,
+        tme_lo, tme_med, tme_hi,
+        est_1 … est_9 (the 3×3 grid, ascending order),
+        median_est, therapies, is_surface, is_cta.
+    """
+    import numpy as np
+    import pandas as pd
+    from .gene_sets_cancer import (
+        CTA_gene_id_to_name,
+        therapy_target_gene_id_to_name,
+        surface_protein_gene_ids,
+        cancer_surfaceome_gene_id_to_name,
+    )
+
+    from .gene_sets_cancer import housekeeping_gene_ids
+    from .tumor_purity import TCGA_MEDIAN_PURITY
+
+    cancer_code = resolve_cancer_type(cancer_type)
+
+    # --- Sample expression (raw TPM and HK-normalized) ---
+    sample_raw, sample_hk = _sample_expression_by_symbol(df_gene_expr)
+
+    # Sample HK median (for converting back from fold-HK to TPM)
+    hk_ids = housekeeping_gene_ids()
+    ref_full = pan_cancer_expression()
+    ref_flat = ref_full.drop_duplicates(subset="Ensembl_Gene_ID")
+    id_to_sym = dict(zip(ref_flat["Ensembl_Gene_ID"], ref_flat["Symbol"]))
+    hk_syms = {id_to_sym[gid] for gid in hk_ids if gid in id_to_sym}
+    sample_hk_vals = [sample_raw[s] for s in hk_syms if sample_raw.get(s, 0) > 0]
+    sample_hk_median = float(np.median(sample_hk_vals)) if sample_hk_vals else 1.0
+
+    # --- Reference data ---
+    ref_dedup = ref_full.drop_duplicates(subset="Symbol").set_index("Symbol")
+    ntpm_cols = [c for c in ref_full.columns if c.startswith("nTPM_")]
+    fpkm_cols = [c for c in ref_full.columns if c.startswith("FPKM_")]
+    ntpm_nonrepro = [
+        c for c in ntpm_cols
+        if c.replace("nTPM_", "") not in _REPRODUCTIVE_TISSUES
+    ]
+
+    # TME tissues (curated immune + stromal)
+    tme_cols = [c for c in ntpm_nonrepro if c.replace("nTPM_", "") in _TME_TISSUES]
+
+    # --- HK-normalize reference columns ---
+    # Each column (nTPM tissue or FPKM cancer type) gets its own HK median
+    hk_in_ref = sorted(hk_syms & set(ref_dedup.index))
+    ref_hk_medians = {}
+    for col in tme_cols + fpkm_cols:
+        ref_hk_medians[col] = ref_dedup.loc[hk_in_ref, col].astype(float).median()
+
+    # TME reference in HK-fold space: per gene, per tissue
+    # tme_hk[gene, tissue] = gene_nTPM / tissue_HK_median
+    # We compute quantiles across tissues for each gene in the main loop.
+
+    # --- Purity-adjusted TCGA (HK-normalized, then deconvolved) ---
+    # For each FPKM cancer-type column, compute:
+    #   tcga_hk = FPKM / FPKM_HK_median
+    #   tme_hk  = median TME tissue fold (same as sample TME reference)
+    #   tcga_tumor_hk = (tcga_hk - (1-tcga_purity) * tme_hk) / tcga_purity
+    # We'll compute this per-gene in the loop.
+
+    # --- Purity bounds ---
+    p_lo = max(purity_result.get("overall_lower") or 0.01, 0.01)
+    p_med = max(purity_result.get("overall_estimate") or 0.05, 0.01)
+    p_hi = max(purity_result.get("overall_upper") or p_med, 0.01)
+    p_lo, p_med, p_hi = sorted([p_lo, p_med, p_hi])
+
+    # --- Gene category lookups ---
+    cta_symbols = set(CTA_gene_id_to_name().values())
+
+    _all_therapy_keys = [
+        "ADC", "ADC-approved", "CAR-T", "CAR-T-approved",
+        "TCR-T", "TCR-T-approved", "bispecific-antibodies",
+        "bispecific-antibodies-approved", "radioligand",
+    ]
+    gene_therapies = {}
+    for tt in _all_therapy_keys:
+        try:
+            tmap = therapy_target_gene_id_to_name(tt)
+            base = tt.replace("-approved", "").replace("-trials", "")
+            for gid, gname in tmap.items():
+                gene_therapies.setdefault(gname, set()).add(base)
+        except Exception:
+            pass
+
+    try:
+        surf_ids = surface_protein_gene_ids()
+        cancer_surf = cancer_surfaceome_gene_id_to_name()
+        eid_to_sym = dict(zip(ref_flat["Ensembl_Gene_ID"], ref_flat["Symbol"]))
+        surf_symbols = {eid_to_sym.get(eid, "") for eid in surf_ids}
+        surf_symbols |= set(cancer_surf.values())
+        surf_symbols.discard("")
+    except Exception:
+        surf_symbols = set()
+
+    # --- Compute 9-point estimates for every expressed gene ---
+    rows = []
+    for symbol in sample_raw:
+        if symbol not in ref_dedup.index:
+            continue
+        observed = sample_raw[symbol]
+        if observed < 0.01:
+            continue
+
+        # HK-normalize sample
+        sample_fold = observed / sample_hk_median
+
+        # TME background in HK-fold space (quantiles across tissues)
+        tme_folds = []
+        for col in tme_cols:
+            hk_m = ref_hk_medians.get(col, 0)
+            if hk_m > 0:
+                tme_folds.append(float(ref_dedup.loc[symbol, col]) / hk_m)
+        if not tme_folds:
+            tme_folds = [0.0]
+        tme_fold_lo = float(np.percentile(tme_folds, 25))
+        tme_fold_med = float(np.median(tme_folds))
+        tme_fold_hi = float(np.percentile(tme_folds, 75))
+
+        # 3×3 grid in HK-fold space, then convert back to TPM
+        estimates = []
+        for bg in [tme_fold_lo, tme_fold_med, tme_fold_hi]:
+            for p in [p_lo, p_med, p_hi]:
+                tumor_fold = max(0.0, (sample_fold - (1 - p) * bg) / p)
+                tumor_tpm = tumor_fold * sample_hk_median
+                estimates.append(tumor_tpm)
+        estimates.sort()
+        median_est = float(np.median(estimates))
+
+        # Ratio vs purity-adjusted TCGA median for matched cancer type
+        cancer_col = f"FPKM_{cancer_code}"
+        if cancer_col in ref_dedup.columns and cancer_col in ref_hk_medians:
+            cancer_hk_m = ref_hk_medians[cancer_col]
+            if cancer_hk_m > 0:
+                tcga_fold = float(ref_dedup.loc[symbol, cancer_col]) / cancer_hk_m
+                tcga_p = TCGA_MEDIAN_PURITY.get(cancer_code, 0.7)
+                tcga_tumor_fold = max(0.0, (tcga_fold - (1 - tcga_p) * tme_fold_med) / tcga_p)
+                our_tumor_fold = median_est / sample_hk_median
+                if tcga_tumor_fold > 0.001:
+                    vs_tcga = float(our_tumor_fold / tcga_tumor_fold)
+                elif our_tumor_fold > 0.001:
+                    vs_tcga = float("inf")
+                else:
+                    vs_tcga = None
+            else:
+                vs_tcga = None
+        else:
+            vs_tcga = None
+
+        # Categorize
+        is_cta = symbol in cta_symbols
+        is_surface = symbol in surf_symbols
+        therapies = gene_therapies.get(symbol, set())
+
+        if is_cta:
+            category = "CTA"
+        elif therapies:
+            category = "therapy_target"
+        elif is_surface:
+            category = "surface"
+        else:
+            category = "other"
+
+        eid = ref_dedup.loc[symbol, "Ensembl_Gene_ID"] if "Ensembl_Gene_ID" in ref_dedup.columns else ""
+
+        rows.append({
+            "gene_id": eid,
+            "symbol": symbol,
+            "category": category,
+            "observed_tpm": round(observed, 2),
+            "tme_fold_lo": round(tme_fold_lo, 4),
+            "tme_fold_med": round(tme_fold_med, 4),
+            "tme_fold_hi": round(tme_fold_hi, 4),
+            **{f"est_{i+1}": round(estimates[i], 2) for i in range(9)},
+            "median_est": round(median_est, 2),
+            "pct_cancer_median": round(vs_tcga, 2) if vs_tcga is not None else None,
+            "is_surface": is_surface,
+            "is_cta": is_cta,
+            "therapies": ", ".join(sorted(therapies)) if therapies else "",
+        })
+
+    result = pd.DataFrame(rows)
+    if not result.empty:
+        result = result.sort_values("median_est", ascending=False).reset_index(drop=True)
+    return result
+
+
+def plot_tumor_expression_ranges(
+    df_ranges,
+    purity_result,
+    cancer_type,
+    top_n=15,
+    categories=None,
+    save_to_filename=None,
+    save_dpi=300,
+    figsize=None,
+):
+    """Strip plot of 9-point tumor expression estimates per gene.
+
+    Parameters
+    ----------
+    df_ranges : DataFrame
+        Output of ``estimate_tumor_expression_ranges()``.
+    purity_result : dict
+        Output of ``estimate_tumor_purity()``.
+    cancer_type : str
+        Cancer type code for title.
+    top_n : int
+        Max genes per category panel.
+    categories : list of str, optional
+        Which categories to plot. Default: CTA, therapy_target, surface.
+    save_to_filename : str, optional
+        Path to save the figure.
+    """
+    import numpy as np
+
+    if categories is None:
+        categories = ["therapy_target", "CTA", "surface"]
+
+    cancer_code = resolve_cancer_type(cancer_type)
+    p_lo = max(purity_result.get("overall_lower") or 0.01, 0.01)
+    p_med = max(purity_result.get("overall_estimate") or 0.05, 0.01)
+    p_hi = max(purity_result.get("overall_upper") or p_med, 0.01)
+
+    cat_titles = {
+        "CTA": "Cancer-Testis Antigens",
+        "therapy_target": "Therapeutic Targets",
+        "surface": "Surface Proteins",
+        "other": "Other Tumor Genes",
+    }
+    cat_colors = {
+        "CTA": "#e74c3c",
+        "therapy_target": "#3498db",
+        "surface": "#2ecc71",
+        "other": "#95a5a6",
+    }
+    n_panels = len(categories)
+    if figsize is None:
+        figsize = (14, max(4, 2.5 * n_panels))
+
+    fig, axes = plt.subplots(
+        n_panels, 2, figsize=figsize, squeeze=False,
+        gridspec_kw={"width_ratios": [3, 1]},
+    )
+    est_cols = [f"est_{i+1}" for i in range(9)]
+
+    for ax_idx, cat in enumerate(categories):
+        ax_strip = axes[ax_idx, 0]
+        ax_pct = axes[ax_idx, 1]
+        sub = df_ranges[df_ranges["category"] == cat].head(top_n).copy()
+        # Sort by median descending (top gene at top of plot)
+        sub = sub.sort_values("median_est", ascending=True).reset_index(drop=True)
+
+        if sub.empty:
+            ax_strip.set_title(cat_titles.get(cat, cat))
+            ax_strip.text(0.5, 0.5, "No genes", ha="center", va="center",
+                          transform=ax_strip.transAxes, fontsize=10, color="gray")
+            ax_pct.set_visible(False)
+            continue
+
+        color = cat_colors.get(cat, "#95a5a6")
+        y_positions = np.arange(len(sub))
+
+        # --- Left panel: 9-point strip plot ---
+        for i, (_, row) in enumerate(sub.iterrows()):
+            vals = [row[c] for c in est_cols]
+            vals_plot = [max(v, 0.01) for v in vals]
+            median_v = max(row["median_est"], 0.01)
+
+            ax_strip.scatter(vals_plot, [i] * 9, color=color, alpha=0.4, s=25, zorder=3)
+            ax_strip.scatter([median_v], [i], color=color, marker="D", s=50,
+                             edgecolors="black", linewidths=0.5, zorder=5)
+            ax_strip.plot([min(vals_plot), max(vals_plot)], [i, i],
+                          color=color, alpha=0.3, linewidth=2, zorder=2)
+
+        # Build labels with therapy info
+        labels = []
+        for _, row in sub.iterrows():
+            label = row["symbol"]
+            if row["therapies"]:
+                label += f"  [{row['therapies']}]"
+            labels.append(label)
+
+        ax_strip.set_yticks(y_positions)
+        ax_strip.set_yticklabels(labels, fontsize=8)
+        ax_strip.set_xscale("log")
+        ax_strip.set_xlabel("Tumor-specific expression (TPM)", fontsize=8)
+        ax_strip.set_title(cat_titles.get(cat, cat), fontsize=10, fontweight="bold",
+                           color=color)
+        ax_strip.set_ylim(-0.5, len(sub) - 0.5)
+        ax_strip.grid(axis="x", alpha=0.2)
+
+        # --- Right panel: % of cancer type median (log scale) ---
+        for i, (_, row) in enumerate(sub.iterrows()):
+            pct = row.get("pct_cancer_median")
+            if pct is None or (isinstance(pct, float) and (np.isinf(pct) or np.isnan(pct))):
+                # No TCGA reference (e.g. CTAs with zero expression)
+                ax_pct.annotate("novel", (0.5, i), fontsize=7, color="gray",
+                                ha="center", va="center",
+                                transform=ax_pct.get_yaxis_transform())
+                continue
+            pct_display = pct * 100  # convert ratio to percentage
+            bar_color = color if pct >= 0.5 else "#d4a017"  # amber if below 50%
+            ax_pct.barh(i, max(pct_display, 0.1), color=bar_color, alpha=0.7, height=0.6)
+            # Label
+            if pct_display >= 1000:
+                lbl = f"{pct_display / 100:.0f}×"
+            elif pct_display >= 100:
+                lbl = f"{pct_display:.0f}%"
+            else:
+                lbl = f"{pct_display:.0f}%"
+            ax_pct.text(max(pct_display, 0.1) * 1.15, i, lbl, fontsize=7,
+                        va="center", color="black")
+
+        ax_pct.set_xscale("log")
+        ax_pct.axvline(100, color="black", linestyle="--", alpha=0.4, linewidth=1)
+        ax_pct.set_yticks([])
+        ax_pct.set_xlabel(f"% of {cancer_code} median", fontsize=8)
+        ax_pct.set_title(f"vs {cancer_code}", fontsize=9, color="gray")
+        ax_pct.set_ylim(-0.5, len(sub) - 0.5)
+        ax_pct.grid(axis="x", alpha=0.15)
+
+    # Suptitle with purity info
+    fig.suptitle(
+        f"Tumor expression estimates — {cancer_code}\n"
+        f"Purity: {p_lo:.0%} / {p_med:.0%} / {p_hi:.0%} (low / est / high)",
+        fontsize=11, fontweight="bold", y=1.02,
+    )
+    plt.tight_layout()
+
+    if save_to_filename:
+        fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+        print(f"Saved {save_to_filename}")
+
+    return fig
+
+
 def plot_purity_adjusted_targets(
     df_gene_expr,
     cancer_type,
@@ -1711,6 +2076,15 @@ _CURATED_CTAS = [
 ]
 
 _STROMAL_TISSUES = {"smooth_muscle", "skeletal_muscle", "heart_muscle", "adipose_tissue"}
+
+# Immune/lymphoid tissues that represent TME infiltrate.  Curated to
+# exclude epithelial organs that merely contain resident immune cells
+# (which would inflate the TME background estimate).
+_IMMUNE_TISSUES = {
+    "bone_marrow", "lymph_node", "spleen", "thymus", "tonsil", "appendix",
+}
+
+_TME_TISSUES = _STROMAL_TISSUES | _IMMUNE_TISSUES
 
 # Clinically important genes with low TME background.  The data-driven
 # algorithm may miss these because their best z-score peaks in a sibling

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -127,6 +127,147 @@ def _geneset_hk_ratio(genes, hk_symbols, expr_by_symbol):
     return gs_sum / hk_sum
 
 
+# Lineage genes per cancer type — genes retained in metastases and specific
+# enough to calibrate purity.  Only genes with low TME background and high
+# expression in the origin tissue should be listed.
+LINEAGE_GENES = {
+    # Genitourinary
+    "PRAD": ["STEAP1", "STEAP2", "FOLH1", "TMPRSS2", "KLK3", "KLK2", "NKX3-1", "HOXB13", "AR"],
+    "BLCA": ["UPK1A", "UPK2", "UPK3A", "KRT20", "GATA3", "PPARG"],
+    "TGCT": ["POU5F1", "NANOG", "SOX17", "TFAP2C", "KIT"],
+    # Breast / gynecologic
+    "BRCA": ["ESR1", "GATA3", "FOXA1", "TFF1", "TFF3", "AGR2"],
+    "OV":   ["PAX8", "WT1", "MUC16", "MSLN", "FOLR1"],
+    "UCEC": ["PAX8", "ESR1", "PGR", "MSX1", "HOXA10"],
+    "UCS":  ["PAX8", "ESR1", "PGR", "MSX1"],
+    "CESC": ["TP63", "SOX2", "KRT17", "CDKN2A", "DSG3"],
+    # Lung
+    "LUAD": ["NKX2-1", "NAPSA", "SFTPB", "SFTPC"],
+    "LUSC": ["TP63", "SOX2", "KRT5", "KRT14"],
+    "MESO": ["MSLN", "WT1", "CALB2", "BAP1"],
+    # GI
+    "COAD": ["CDX2", "MUC2", "VIL1", "CDH17"],
+    "READ": ["CDX2", "MUC2", "VIL1", "CDH17"],
+    "STAD": ["MUC5AC", "MUC6", "CDX2", "CLDN18"],
+    "ESCA": ["TP63", "SOX2", "KRT5", "KRT14", "CDX2"],
+    "LIHC": ["ALB", "APOB", "HNF4A", "AFP"],
+    "CHOL": ["KRT7", "KRT19", "SOX9", "HNF1B", "EPCAM"],
+    "PAAD": ["PDX1", "PTF1A", "KRT19", "MUC1"],
+    # Kidney
+    "KIRC": ["CA9", "PAX8", "NDUFA4L2"],
+    "KIRP": ["PAX8", "PAX2", "AMACR"],
+    "KICH": ["KIT", "PAX8", "FOXI1"],
+    # CNS
+    "GBM":  ["GFAP", "OLIG2", "SOX2"],
+    "LGG":  ["GFAP", "OLIG2", "IDH1", "ATRX"],
+    # Endocrine
+    "THCA": ["TG", "TPO", "PAX8", "NIS"],
+    "ACC":  ["CYP11B1", "CYP11B2", "CYP21A2", "STAR", "NR5A1"],
+    "PCPG": ["TH", "DBH", "CHGA", "CHGB", "PHOX2B"],
+    # Skin / soft tissue
+    "SKCM": ["MLANA", "PMEL", "TYR", "DCT", "MITF"],
+    "UVM":  ["MLANA", "PMEL", "TYR", "MITF"],
+    "SARC": ["DES", "ACTA2", "MYOD1", "MYOG"],
+    # Hematologic
+    "LAML": ["MPO", "CD34", "KIT", "FLT3"],
+    "DLBC": ["CD19", "CD20", "PAX5", "BCL6", "IRF4"],
+    "THYM": ["CD3D", "CD3E", "CD3G", "LCK", "ZAP70"],
+    # Head and neck
+    "HNSC": ["TP63", "SOX2", "KRT5", "KRT14", "CDKN2A"],
+}
+
+
+def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga_purity):
+    """Estimate purity from cancer-type lineage genes using HK-normalized ratios.
+
+    For each lineage gene, computes:
+        sample_ratio = gene_sample / HK_sample
+        ref_ratio    = gene_TCGA  / HK_TCGA
+        tme_ratio    = median(gene_tissue / HK_tissue) across TME tissues
+        true_tumor_ratio = (ref_ratio - (1-tcga_purity) * tme_ratio) / tcga_purity
+        purity = (sample_ratio - tme_ratio) / (true_tumor_ratio - tme_ratio)
+
+    Returns list of dicts with per-gene purity estimates.
+    """
+    genes = LINEAGE_GENES.get(cancer_code, [])
+    if not genes:
+        return []
+
+    ref = pan_cancer_expression()
+    ref_dedup = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
+    ntpm_cols = [c for c in ref.columns if c.startswith("nTPM_")]
+    _repro = {"testis", "epididymis", "seminal_vesicle", "placenta", "ovary"}
+    ntpm_nonrepro = [c for c in ntpm_cols if c.replace("nTPM_", "") not in _repro]
+
+    # Curated TME tissues (immune organs + stromal/connective)
+    _tme = {
+        "bone_marrow", "lymph_node", "spleen", "thymus", "tonsil", "appendix",
+        "smooth_muscle", "skeletal_muscle", "heart_muscle", "adipose_tissue",
+    }
+    tme_cols = [c for c in ntpm_nonrepro if c.replace("nTPM_", "") in _tme]
+
+    # HK symbols in reference
+    hk_in_ref = [s for s in hk_syms if s in ref_dedup.index]
+
+    # HK medians per column
+    cancer_col = f"FPKM_{cancer_code}"
+    if cancer_col not in ref_dedup.columns:
+        return []
+    ref_hk_cancer = ref_dedup.loc[hk_in_ref, cancer_col].astype(float).median()
+    if ref_hk_cancer <= 0:
+        return []
+
+    tme_hk_medians = {}
+    for col in tme_cols:
+        tme_hk_medians[col] = ref_dedup.loc[hk_in_ref, col].astype(float).median()
+
+    # Sample HK (median of expressed HK genes)
+    sample_hk_vals = [sample_tpm[g] for g in hk_syms if sample_tpm.get(g, 0) > 0]
+    sample_hk_med = float(np.median(sample_hk_vals)) if sample_hk_vals else 0.0
+    if sample_hk_med <= 0:
+        return []
+
+    results = []
+    for gene in genes:
+        if gene not in ref_dedup.index:
+            continue
+        s_tpm = sample_tpm.get(gene, 0)
+        if s_tpm <= 0:
+            continue
+
+        sample_ratio = s_tpm / sample_hk_med
+        ref_ratio = float(ref_dedup.loc[gene, cancer_col]) / ref_hk_cancer
+
+        # TME ratio: median across TME tissues (HK-normalized)
+        tme_ratios = []
+        for col in tme_cols:
+            hk_m = tme_hk_medians[col]
+            if hk_m > 0:
+                tme_ratios.append(float(ref_dedup.loc[gene, col]) / hk_m)
+        tme_ratio = float(np.median(tme_ratios)) if tme_ratios else 0.0
+
+        # Deconvolve TCGA to get true tumor ratio
+        true_tumor_ratio = (ref_ratio - (1 - tcga_purity) * tme_ratio) / tcga_purity
+
+        if true_tumor_ratio <= tme_ratio:
+            continue
+
+        purity = (sample_ratio - tme_ratio) / (true_tumor_ratio - tme_ratio)
+        purity = float(np.clip(purity, 0, 1))
+
+        results.append({
+            "gene": gene,
+            "sample_tpm": s_tpm,
+            "sample_ratio": float(sample_ratio),
+            "ref_ratio": float(ref_ratio),
+            "tme_ratio": float(tme_ratio),
+            "tumor_ratio": float(true_tumor_ratio),
+            "purity": purity,
+        })
+
+    return results
+
+
 def _select_tumor_specific_genes(cancer_code, n=30):
     """Select genes highly expressed in cancer but NOT in matched normal tissue.
 
@@ -284,23 +425,48 @@ def estimate_tumor_purity(df_gene_expr, cancer_type=None):
         0, 1,
     ))
 
+    # ---- Component 3: Lineage gene refinement ----
+    lineage_per_gene = _lineage_purity_estimates(
+        cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga_purity,
+    )
+    lineage_purities = sorted(g["purity"] for g in lineage_per_gene if g["purity"] > 0)
+    if len(lineage_purities) >= 3:
+        # Use upper-half median: genes giving LOW estimates likely
+        # de-differentiated (lost expression) rather than indicating
+        # low purity.  Genes giving HIGH estimates are reliable —
+        # their signal can't be explained by gene loss.
+        mid = len(lineage_purities) // 2
+        upper_half = lineage_purities[mid:]
+        lineage_purity = float(np.median(upper_half))
+        lineage_lower = float(np.percentile(upper_half, 25))
+        lineage_upper = float(np.percentile(upper_half, 75))
+    else:
+        lineage_purity = lineage_lower = lineage_upper = None
+
     # ---- Combine estimates ----
     estimates = []
     if sig_purity is not None:
         estimates.append(sig_purity)
     if stromal_genes:
         estimates.append(estimate_purity)
+    if lineage_purity is not None:
+        estimates.append(lineage_purity)
 
     if estimates:
         overall = float(np.median(estimates))
-        all_bounds = []
-        if sig_lower is not None:
-            all_bounds.extend([sig_lower, sig_upper])
-        all_bounds.append(estimate_purity)
-        if sig_purity is not None:
-            all_bounds.append(sig_purity)
-        overall_lower = float(min(all_bounds))
-        overall_upper = float(max(all_bounds))
+        # Bounds: use lineage IQR when available (tighter), else signature + ESTIMATE
+        if lineage_lower is not None:
+            overall_lower = lineage_lower
+            overall_upper = lineage_upper
+        else:
+            all_bounds = []
+            if sig_lower is not None:
+                all_bounds.extend([sig_lower, sig_upper])
+            all_bounds.append(estimate_purity)
+            if sig_purity is not None:
+                all_bounds.append(sig_purity)
+            overall_lower = float(min(all_bounds))
+            overall_upper = float(max(all_bounds))
     else:
         overall = overall_lower = overall_upper = None
 
@@ -319,6 +485,13 @@ def estimate_tumor_purity(df_gene_expr, cancer_type=None):
                 "lower": sig_lower,
                 "upper": sig_upper,
                 "per_gene": per_gene,
+            },
+            "lineage": {
+                "genes": [g["gene"] for g in lineage_per_gene],
+                "purity": lineage_purity,
+                "lower": lineage_lower,
+                "upper": lineage_upper,
+                "per_gene": lineage_per_gene,
             },
             "stromal": {
                 "enrichment": stromal_enrichment,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -147,7 +147,8 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_mod, "_select_embedding_genes_bottleneck", lambda **k: (None, {
         "per_type": {}, "n_genes": 0, "n_types": 0, "method": "bottleneck", "tme_tissues": [],
     }))
-    monkeypatch.setattr(cli_mod, "plot_purity_adjusted_targets", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod, "estimate_tumor_expression_ranges", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(cli_mod, "plot_tumor_expression_ranges", lambda *a, **k: None)
     monkeypatch.setattr(cli_mod, "estimate_tumor_expression", lambda *a, **k: pd.DataFrame())
 
     out_dir = str(tmp_path / "test-output")

--- a/tests/test_tumor_expression.py
+++ b/tests/test_tumor_expression.py
@@ -1,0 +1,270 @@
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for lineage-based purity estimation and 9-point tumor expression ranges."""
+
+import numpy as np
+
+from pirlygenes.tumor_purity import (
+    LINEAGE_GENES,
+    TCGA_MEDIAN_PURITY,
+    _lineage_purity_estimates,
+)
+
+
+# ── LINEAGE_GENES coverage ────────────────────────────────────────
+
+def test_lineage_genes_covers_all_tcga_types():
+    """Every TCGA cancer type with a known purity should have lineage genes."""
+    missing = [ct for ct in TCGA_MEDIAN_PURITY if ct not in LINEAGE_GENES]
+    assert missing == [], f"Cancer types without lineage genes: {missing}"
+
+
+def test_lineage_genes_values_are_nonempty_lists():
+    for ct, genes in LINEAGE_GENES.items():
+        assert isinstance(genes, list), f"{ct}: expected list, got {type(genes)}"
+        assert len(genes) >= 2, f"{ct}: need at least 2 lineage genes, got {len(genes)}"
+
+
+def test_lineage_genes_has_no_duplicates():
+    for ct, genes in LINEAGE_GENES.items():
+        assert len(genes) == len(set(genes)), f"{ct} has duplicate genes"
+
+
+# ── _lineage_purity_estimates edge cases ──────────────────────────
+
+def test_lineage_unknown_cancer_type_returns_empty():
+    result = _lineage_purity_estimates("FAKE_TYPE", {}, {}, [], 0.7)
+    assert result == []
+
+
+def test_lineage_empty_sample_returns_empty():
+    result = _lineage_purity_estimates("PRAD", {}, {}, [], 0.69)
+    assert result == []
+
+
+# ── Upper-half median estimator ───────────────────────────────────
+
+def test_upper_half_median_ignores_low_outliers():
+    """Simulates de-differentiated genes pulling down the median."""
+    # 9 genes: 4 de-differentiated (low), 5 retained (high)
+    purities = [0.003, 0.004, 0.013, 0.025, 0.061, 0.078, 0.098, 0.104, 0.206]
+    mid = len(purities) // 2
+    upper_half = purities[mid:]
+    estimate = float(np.median(upper_half))
+    lower = float(np.percentile(upper_half, 25))
+    upper = float(np.percentile(upper_half, 75))
+
+    # Estimate should be in the retained cluster, not dragged down
+    assert estimate > 0.05, f"Estimate {estimate} should be > 5%"
+    assert lower > 0.03, f"Lower {lower} should be > 3%"
+    assert upper < 0.25, f"Upper {upper} should be < 25%"
+
+
+# ── estimate_tumor_expression_ranges ──────────────────────────────
+
+def test_ranges_dataframe_columns():
+    """Verify the output DataFrame has all expected columns."""
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    import pandas as pd
+
+    # Minimal expression data with just a few genes
+    df = pd.DataFrame({
+        "ensembl_gene_id": ["ENSG00000169398", "ENSG00000160752"],
+        "gene_symbol": ["PTK2", "IL34"],
+        "TPM": [50.0, 10.0],
+    })
+    purity_result = {
+        "overall_lower": 0.05,
+        "overall_estimate": 0.10,
+        "overall_upper": 0.15,
+    }
+    result = estimate_tumor_expression_ranges(df, "PRAD", purity_result)
+    assert isinstance(result, pd.DataFrame)
+
+    expected_cols = [
+        "gene_id", "symbol", "category", "observed_tpm",
+        "tme_fold_lo", "tme_fold_med", "tme_fold_hi",
+        "est_1", "est_5", "est_9", "median_est",
+        "pct_cancer_median", "is_surface", "is_cta", "therapies",
+    ]
+    for col in expected_cols:
+        assert col in result.columns, f"Missing column: {col}"
+
+
+def test_ranges_nine_estimates_are_sorted():
+    """Each gene's 9 estimates should be in ascending order."""
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    import pandas as pd
+
+    df = pd.DataFrame({
+        "ensembl_gene_id": ["ENSG00000169398"],
+        "gene_symbol": ["PTK2"],
+        "TPM": [100.0],
+    })
+    purity_result = {
+        "overall_lower": 0.05,
+        "overall_estimate": 0.10,
+        "overall_upper": 0.20,
+    }
+    result = estimate_tumor_expression_ranges(df, "PRAD", purity_result)
+    if not result.empty:
+        row = result.iloc[0]
+        ests = [row[f"est_{i+1}"] for i in range(9)]
+        assert ests == sorted(ests), f"Estimates not sorted: {ests}"
+
+
+def test_ranges_all_estimates_nonnegative():
+    """No tumor expression estimate should be negative."""
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    import pandas as pd
+
+    df = pd.DataFrame({
+        "ensembl_gene_id": ["ENSG00000169398"],
+        "gene_symbol": ["PTK2"],
+        "TPM": [0.5],  # very low expression
+    })
+    purity_result = {
+        "overall_lower": 0.05,
+        "overall_estimate": 0.10,
+        "overall_upper": 0.15,
+    }
+    result = estimate_tumor_expression_ranges(df, "PRAD", purity_result)
+    if not result.empty:
+        row = result.iloc[0]
+        for i in range(9):
+            assert row[f"est_{i+1}"] >= 0, f"est_{i+1} is negative"
+
+
+def test_ranges_empty_input():
+    """Empty expression data should produce empty DataFrame."""
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    import pandas as pd
+
+    df = pd.DataFrame({
+        "ensembl_gene_id": [],
+        "gene_symbol": [],
+        "TPM": [],
+    })
+    purity_result = {
+        "overall_lower": 0.05,
+        "overall_estimate": 0.10,
+        "overall_upper": 0.15,
+    }
+    result = estimate_tumor_expression_ranges(df, "PRAD", purity_result)
+    assert len(result) == 0
+
+
+def test_ranges_pct_cancer_median_steap1_near_one():
+    """STEAP1 at ~TCGA PRAD levels should have pct_cancer_median near 1.0."""
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression, housekeeping_gene_ids
+    import pandas as pd
+
+    # Construct a fake sample where STEAP1 is at roughly the same
+    # HK-normalized level as TCGA PRAD.
+    ref = pan_cancer_expression()
+    ref_dedup = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
+    hk_ids = housekeeping_gene_ids()
+    ref_flat = ref.drop_duplicates(subset="Ensembl_Gene_ID")
+    id_to_sym = dict(zip(ref_flat["Ensembl_Gene_ID"], ref_flat["Symbol"]))
+    hk_syms = {id_to_sym[gid] for gid in hk_ids if gid in id_to_sym}
+    hk_in_ref = sorted(hk_syms & set(ref_dedup.index))
+
+    # STEAP1 TCGA PRAD fold
+    prad_hk = ref_dedup.loc[hk_in_ref, "FPKM_PRAD"].astype(float).median()
+    steap1_prad = float(ref_dedup.loc["STEAP1", "FPKM_PRAD"])
+    steap1_fold = steap1_prad / prad_hk
+
+    # Build a sample with the same fold, at 100% purity (so we can check)
+    sample_hk_med = 500.0
+    steap1_tpm = steap1_fold * sample_hk_med
+
+    # Need some HK genes too
+    rows = []
+    for sym in list(hk_in_ref)[:10]:
+        eid = ref_flat[ref_flat["Symbol"] == sym]["Ensembl_Gene_ID"].iloc[0]
+        rows.append({"ensembl_gene_id": eid, "gene_symbol": sym, "TPM": sample_hk_med})
+    # Add STEAP1
+    rows.append({
+        "ensembl_gene_id": "ENSG00000205542",
+        "gene_symbol": "STEAP1",
+        "TPM": steap1_tpm,
+    })
+    df = pd.DataFrame(rows)
+
+    purity_result = {
+        "overall_lower": 0.90,
+        "overall_estimate": 1.0,
+        "overall_upper": 1.0,
+    }
+    result = estimate_tumor_expression_ranges(df, "PRAD", purity_result)
+    steap_row = result[result["symbol"] == "STEAP1"]
+    if not steap_row.empty:
+        pct = steap_row.iloc[0]["pct_cancer_median"]
+        # Should be close to 1.0 (within 50% either direction)
+        assert pct is not None, "pct_cancer_median should not be None"
+        assert 0.5 < pct < 2.0, f"Expected ~1.0, got {pct}"
+
+
+# ── _TME_TISSUES consistency ─────────────────────────────────────
+
+def test_tme_tissues_are_valid():
+    """All curated TME tissues should exist in the reference data."""
+    from pirlygenes.plot import _TME_TISSUES
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression
+
+    ref = pan_cancer_expression()
+    ntpm_cols = {c.replace("nTPM_", "") for c in ref.columns if c.startswith("nTPM_")}
+    for tissue in _TME_TISSUES:
+        assert tissue in ntpm_cols, f"TME tissue {tissue!r} not in reference nTPM columns"
+
+
+# ── CLI lineage narrative ─────────────────────────────────────────
+
+def test_lineage_narrative_generation():
+    """The lineage narrative should handle all three cases: retained, lost, not found."""
+    from pirlygenes.tumor_purity import LINEAGE_GENES
+
+    # Simulate a purity result with lineage component
+    lineage_per_gene = [
+        {"gene": "STEAP1", "purity": 0.098, "sample_tpm": 90.0,
+         "sample_ratio": 0.16, "ref_ratio": 1.1, "tme_ratio": 0.01, "tumor_ratio": 1.6},
+        {"gene": "KLK3", "purity": 0.003, "sample_tpm": 139.0,
+         "sample_ratio": 0.25, "ref_ratio": 50.0, "tme_ratio": 0.0, "tumor_ratio": 73.0},
+    ]
+    purity = {
+        "cancer_type": "PRAD",
+        "overall_estimate": 0.098,
+        "overall_lower": 0.078,
+        "overall_upper": 0.104,
+        "components": {
+            "lineage": {
+                "genes": ["STEAP1", "KLK3"],
+                "purity": 0.098,
+                "lower": 0.078,
+                "upper": 0.104,
+                "per_gene": lineage_per_gene,
+            },
+            "stromal": {"enrichment": 4.3, "n_genes": 141},
+            "immune": {"enrichment": 2.5, "n_genes": 141},
+        },
+    }
+
+    # The narrative code in cli.py uses these fields
+    lineage = purity["components"]["lineage"]
+    sorted_genes = sorted(lineage["per_gene"], key=lambda g: g["purity"], reverse=True)
+    median_p = lineage["purity"]
+
+    retained = [g for g in sorted_genes if g["purity"] >= median_p * 0.5]
+    lost = [g for g in sorted_genes if g["purity"] < median_p * 0.5]
+
+    all_lineage = LINEAGE_GENES.get("PRAD", [])
+    found_names = {g["gene"] for g in lineage_per_gene}
+    not_found = [g for g in all_lineage if g not in found_names]
+
+    assert len(retained) == 1  # STEAP1
+    assert retained[0]["gene"] == "STEAP1"
+    assert len(lost) == 1  # KLK3
+    assert lost[0]["gene"] == "KLK3"
+    assert len(not_found) > 0  # Missing genes from PRAD lineage set
+    assert "FOLH1" in not_found


### PR DESCRIPTION
## Summary

- **Lineage gene purity calibration**: Per-cancer-type gene sets (all 33 TCGA types) that estimate purity from cancer-specific markers. Uses upper-half median to resist de-differentiation artifacts in metastatic samples. For the test PRAD lymph node met: purity narrowed from 0.5–17% → 8–10% by anchoring on STEAP1/STEAP2/FOLH1/TMPRSS2 cluster.

- **HK-normalized deconvolution**: All expression comparisons (sample TPM, reference nTPM, TCGA FPKM) are normalized to fold-over-housekeeping before TME subtraction, fixing the TPM-vs-FPKM unit mismatch.

- **9-point tumor expression ranges**: 3×3 grid crossing (lo/med/hi) TME background × (lo/med/hi) purity for each gene. Visualized as log-scale strip plots with median diamond.

- **% of cancer type median**: Replaces the broken cross-cancer percentile with purity-adjusted ratio vs matched cancer type (e.g. STEAP1 = 103% of PRAD median, KLK3 = 4% → de-differentiated).

- **Curated TME tissues**: Replaced PTPRC-based tissue selection (which included epithelial organs like colon/lung) with curated set of 6 immune + 4 stromal tissues.

- **Lineage narrative in reports**: Analysis report explains which genes were retained, de-differentiated, or not detected.

Filed #13 for `--met-site` follow-up (site-specific TME weighting).

## Test plan

- [x] 13 new unit tests (lineage coverage, estimator properties, edge cases, output shape, STEAP1 calibration, TME tissue validity, narrative generation)
- [x] Full test suite passes (46/46)
- [x] End-to-end CLI run on PRAD lymph node met sample
- [x] Lint clean (ruff)