### PR TITLE
Update README and docs for v3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,59 @@ Gene lists and expression data for cancer immunotherapy
 ```bash
 pip install pirlygenes
 
-# Generate all plots for a sample
-pirlygenes plot-expression gene_expression_salmon.tsv
+# Full sample analysis: cancer type, purity, targets, embeddings
+pirlygenes analyze gene_expression.tsv
 
-# Prostate-cancer-specific analysis
-pirlygenes plot-expression gene_expression_salmon.tsv --cancer-type prostate
+# Specify cancer type and output directory
+pirlygenes analyze gene_expression.tsv --cancer-type prostate --output-dir results/
+
+# Force-label specific genes in plots
+pirlygenes analyze gene_expression.tsv --cancer-type PRAD --label-genes "FOLH1,STEAP1,CD276"
 
 # List all bundled datasets and cancer types
 pirlygenes data
+
+# Multi-sample cohort analysis
+pirlygenes plot-cancer-cohorts sample1.tsv sample2.tsv sample3.tsv --cancer-type PRAD
 ```
+
+## The `analyze` command
+
+The main entry point for single-sample analysis. Takes a gene expression file (CSV, TSV, or Excel with a TPM column) and produces a comprehensive output directory with:
+
+- **Cancer type identification** — auto-detected or specified, scored against 33 TCGA types
+- **Tumor purity estimation** — three methods combined: cancer-type signature genes, ESTIMATE stromal/immune enrichment, and lineage gene calibration
+- **Purity-adjusted expression** — 9-point tumor expression ranges crossing (low/med/high) TME background with (low/med/high) purity, with % of cancer type median comparison
+- **Therapeutic target analysis** — CTAs, ADC/CAR-T/TCR-T/bispecific/radioligand targets, surface proteins
+- **Tissue context** — normal tissue similarity scoring
+- **PCA/MDS embeddings** — sample positioned among 33 TCGA cancer types
+- **Combined PDF** with all figures
+
+See [docs/analyze-command.md](docs/analyze-command.md) for full output file reference.
+
+### Tumor purity estimation
+
+Purity is estimated by combining three independent methods:
+
+1. **Signature genes** — 30 cancer-type-specific genes selected by z-score across TCGA; per-gene HK-ratio compared to TCGA reference (calibrated for cohort purity)
+2. **ESTIMATE enrichment** — stromal and immune gene set enrichment ratios vs TCGA
+3. **Lineage gene calibration** — cancer-type-specific lineage markers (e.g. STEAP1/2, KLK3 for prostate) that anchor purity to known biology. Uses upper-half median to resist de-differentiation artifacts in metastatic samples
+
+All comparisons are HK-normalized (fold-over-housekeeping) for cross-platform robustness (TPM, FPKM, nTPM).
+
+### 9-point expression ranges
+
+For each gene, tumor-specific expression is estimated as:
+
+```
+tumor = (observed - (1-purity) * tme_background) / purity
+```
+
+The TME background is the median expression across curated immune + stromal reference tissues (bone marrow, lymph node, spleen, thymus, tonsil, appendix, smooth muscle, skeletal muscle, heart muscle, adipose tissue), HK-normalized.
+
+Uncertainty is captured by a 3x3 grid: (25th/50th/75th percentile TME) x (lower/estimate/upper purity). The median of these 9 estimates is the point estimate; the full range is shown in the strip plot.
+
+Each gene's estimate is compared to the purity-adjusted TCGA median for the matched cancer type (e.g. "STEAP1 = 103% of PRAD median"), providing a biologically meaningful reference point.
 
 ## Pan-cancer expression data
 
@@ -99,6 +143,25 @@ from pirlygenes.gene_sets_cancer import (
 
 # CSPA mass-spec validated only
 validated = surface_protein_gene_names(validated_only=True)  # 1,410 genes
+```
+
+### Tumor purity estimation
+
+```python
+from pirlygenes.tumor_purity import estimate_tumor_purity
+
+result = estimate_tumor_purity(df_expr, cancer_type="PRAD")
+print(result["overall_estimate"])  # e.g. 0.10
+print(result["components"]["lineage"]["per_gene"])  # per-gene purity estimates
+```
+
+### Purity-adjusted expression
+
+```python
+from pirlygenes.plot import estimate_tumor_expression_ranges
+
+ranges = estimate_tumor_expression_ranges(df_expr, "PRAD", purity_result)
+# DataFrame with est_1..est_9 (9-point grid), median_est, pct_cancer_median
 ```
 
 ### Plotting

--- a/docs/analyze-command.md
+++ b/docs/analyze-command.md
@@ -12,7 +12,7 @@ or Excel) and produces:
 
 ```bash
 pirlygenes analyze input.csv \
-    --output-image-prefix out \
+    --output-dir results/ \
     --cancer-type PRAD \          # optional, auto-detected if omitted
     --label-genes "FOLH1,PSMA" \  # genes to always label in plots
     --output-dpi 200
@@ -25,8 +25,9 @@ pirlygenes analyze input.csv \
 | File | Contents |
 |------|----------|
 | `{prefix}-summary.md` | One-paragraph natural language summary |
-| `{prefix}-analysis.md` | Structured analysis: cancer type, purity, MHC, tissue context, embedding genes |
+| `{prefix}-analysis.md` | Structured analysis: cancer type, purity (with lineage gene calibration), MHC, tissue context, embedding genes |
 | `{prefix}-targets.md` | Therapeutic target analysis with purity-adjusted expression |
+| `README.md` | Output directory index |
 
 ### Figures (in `figures/` subdir)
 
@@ -36,26 +37,98 @@ pirlygenes analyze input.csv \
 | `{prefix}-purity.png` | Tumor purity estimation detail |
 | `{prefix}-immune.png` | Immune gene expression strip plot |
 | `{prefix}-tumor.png` | Tumor marker gene expression |
-| `{prefix}-antigens.png` | Antigen gene expression |
+| `{prefix}-antigens.png` | Antigen gene expression (CTAs + surface) |
 | `{prefix}-treatments.png` | Therapy target gene expression |
 | `{prefix}-target-safety.png` | Therapy target normal tissue expression |
-| `{prefix}-purity-adjusted.png` | Purity-adjusted expression by target category |
+| `{prefix}-target-tissues.pdf` | Per-gene tissue expression heatmaps |
+| `{prefix}-purity-adjusted.png` | 9-point tumor expression ranges with % of cancer type median |
 | `{prefix}-cancer-types-genes.png` | Gene set heatmap vs TCGA cancer types |
 | `{prefix}-cancer-types-disjoint.png` | Disjoint gene counts per cancer type |
-| `{prefix}-pca-bottleneck.png` | PCA embedding among TCGA cancer types |
-| `{prefix}-mds-bottleneck.png` | MDS embedding among TCGA cancer types |
+| `{prefix}-pca-bottleneck.png` | PCA embedding (bottleneck gene set) |
+| `{prefix}-mds-bottleneck.png` | MDS embedding (bottleneck gene set) |
+| `{prefix}-pca-tme.png` | PCA embedding (TME-low gene set — preferred at low purity) |
+| `{prefix}-mds-tme.png` | MDS embedding (TME-low gene set — preferred at low purity) |
+| `{prefix}-vs-cancer/` | Per-category scatter plots: sample vs TCGA cancer type |
+| `{prefix}-vs-cancer.pdf` | Combined scatter plot PDF |
+| `{prefix}-all-figures.pdf` | All figures in one PDF |
 
-## Purity-Adjusted Expression
+## Tumor Purity Estimation
 
-For each gene, the observed TPM is corrected for TME contamination:
+Purity is estimated by combining three independent methods:
+
+### 1. Signature genes
+
+30 cancer-type-specific genes are selected by z-score across TCGA
+cancer types. Each gene's HK-normalized ratio (gene / housekeeping
+median) in the sample is compared to the same ratio in the TCGA
+reference, calibrated for known TCGA cohort purity (Aran et al. 2015).
+
+### 2. ESTIMATE enrichment
+
+Stromal and immune gene sets (Yoshihara et al. 2013) are scored as
+enrichment ratios vs the TCGA reference. High stromal/immune
+enrichment implies lower tumor purity.
+
+### 3. Lineage gene calibration
+
+Cancer-type-specific lineage genes (e.g. STEAP1, STEAP2, FOLH1, KLK3
+for prostate) independently estimate purity using HK-normalized ratios.
+Lineage genes are curated for all 33 TCGA cancer types.
+
+The **upper-half median** of per-gene purity estimates is used to
+resist de-differentiation artifacts: in metastatic tumors, some
+lineage genes lose expression (e.g. KLK3 in prostate met), giving
+artificially low purity estimates. These de-differentiated genes are
+identified and excluded from the purity estimate, but reported in the
+analysis with their interpretation.
+
+The analysis report (`{prefix}-analysis.md`) includes a lineage gene
+calibration table showing each gene's purity estimate and whether it
+was classified as "retained — reliable" or "likely de-differentiated".
+
+## Purity-Adjusted Expression (9-Point Ranges)
+
+For each gene, tumor-specific expression is estimated as:
 
 ```
-tumor_expr = (observed_TPM - (1 - purity) * tme_reference) / purity
+tumor_expr = max(0, (observed - (1-purity) * tme_background) / purity)
 ```
 
-Where `tme_reference` is the mean expression across immune and stromal
-tissues in the HPA normal tissue atlas. This estimate is then compared
-to the TCGA distribution for the inferred cancer type.
+All values are HK-normalized (fold-over-housekeeping) before
+subtraction, then converted back to TPM scale. This corrects for
+unit differences between sample TPM, reference nTPM, and TCGA FPKM.
+
+### TME reference
+
+TME background is computed from curated immune and stromal tissues in
+the HPA normal tissue atlas:
+
+- **Immune**: bone marrow, lymph node, spleen, thymus, tonsil, appendix
+- **Stromal**: smooth muscle, skeletal muscle, heart muscle, adipose tissue
+
+Per-gene TME background is reported as 25th / 50th / 75th percentile
+across these tissues (HK-normalized).
+
+### 9-point grid
+
+Uncertainty is captured by crossing 3 TME levels (25th/50th/75th
+percentile) with 3 purity levels (lower/estimate/upper bound),
+producing 9 estimates per gene. The median of the 9 is the point
+estimate.
+
+### % of cancer type median
+
+Each gene's median tumor estimate is compared to the purity-adjusted
+TCGA median for the matched cancer type. This answers "how does this
+tumor's expression compare to a typical tumor of this type?"
+
+For example:
+- STEAP1 = 103% of PRAD median → at expected level
+- KLK3 = 4% of PRAD median → lost expression (de-differentiated)
+- CD74 = 33x PRAD median → likely TME-driven, not tumor
+
+TCGA values are themselves purity-adjusted using published cohort
+purity estimates (Aran et al. 2015).
 
 ## Therapeutic Target Categories
 
@@ -74,3 +147,25 @@ The target report (`targets.md`) categorizes genes as:
 
 MHC-I status is assessed to determine viability of intracellular
 targeting approaches.
+
+## Other Commands
+
+### `pirlygenes data`
+
+Lists all bundled datasets and available cancer types.
+
+### `pirlygenes plot-cancer-cohorts`
+
+Multi-sample cohort analysis. Takes multiple expression files and
+produces comparative heatmaps, PCA/MDS embeddings, therapy target
+summaries, and CTA/surface protein panels across the cohort.
+
+```bash
+pirlygenes plot-cancer-cohorts sample1.tsv sample2.tsv sample3.tsv \
+    --cancer-type PRAD \
+    --output-image-prefix cohort
+```
+
+### `pirlygenes plot-expression` (deprecated)
+
+Legacy single-sample plotting command. Use `pirlygenes analyze` instead.


### PR DESCRIPTION
## Summary

- Replace deprecated `plot-expression` with `analyze` command in Quick Start
- Document new features: lineage purity calibration, 9-point expression ranges, HK-normalized TME deconvolution, % of cancer type median
- Add `estimate_tumor_purity` and `estimate_tumor_expression_ranges` to Python API section
- Document `plot-cancer-cohorts` command
- Update output files table with all current outputs (TME embeddings, vs-cancer scatter, target-tissues PDF)
- Mark `plot-expression` as deprecated

## Test plan
- [x] No code changes — docs only
- [x] 46/46 tests still pass