### PR TITLE
[codex] Improve purity panel integration and reporting

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1011,6 +1011,11 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
         f"(HLA-A={hla_a:.0f}, HLA-B={hla_b:.0f}, B2M={b2m:.0f} TPM). "
         f"Analysis mode: **{_sample_mode_display(sample_mode)}**."
     )
+    if purity.get("components", {}).get("integration", {}).get("signature_deprioritized"):
+        summary += (
+            " The tumor-specific signature panel was materially weaker and less stable than "
+            "the lineage panel, so it was downweighted rather than used as a hard lower anchor."
+        )
     if fit_quality.get("message"):
         summary += f" {fit_quality['message']}"
     if constraints:
@@ -1065,6 +1070,8 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
         lines.append(f"**RNA degradation**: {deg['level']}")
         lines.append(f"- Mitochondrial fraction: {deg['mt_fraction']:.1%}")
         lines.append(f"- Ribosomal protein fraction: {deg['rp_fraction']:.1%}")
+        if deg.get("long_short_ratio") is not None:
+            lines.append(f"- Long/short transcript index: {deg['long_short_ratio']:.2f}")
         if deg.get("matched_tissue"):
             lines.append(f"- Matched tissue baseline: {deg['matched_tissue']} "
                          f"(MT={deg['baseline_mt']:.1%}, RP={deg['baseline_rp']:.1%})")
@@ -1206,6 +1213,12 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
         if isinstance(comp, dict):
             enrichment = comp.get("enrichment", 0)
             lines.append(f"- **{comp_name.title()}** enrichment: {enrichment:.1f}x vs TCGA")
+    integration = components.get("integration", {})
+    if integration.get("signature_deprioritized"):
+        lines.append(
+            "- **Integration note**: the tumor-specific signature panel was weaker and less stable "
+            "than the lineage panel, so it was downweighted rather than used as a hard lower bound."
+        )
     if sample_mode == "pure":
         lines.append(
             "- **Interpretation**: in pure-population mode this estimate is a consistency check "

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -2021,13 +2021,31 @@ _signature_panel_cache = {}
 
 
 def _get_cancer_type_signature_panels(n_signature_genes=20):
-    """Return robust per-cancer signature panels used for ranking and plotting."""
-    cache_key = int(n_signature_genes)
+    """Return robust per-cancer signature panels used for ranking and plotting.
+
+    Reuses `_select_tumor_specific_genes_for_panel` from `tumor_purity` so
+    the plotting / ranking paths see the same tier-filtered, family-excluded
+    panels as the purity estimator. When the strict tiers leave a cancer
+    type short of `n_signature_genes`, a z-score fallback is appended — but
+    that fallback still respects the configured family-exclusion regex and
+    the `immune_origin_cancer_types` bypass, so the two paths never silently
+    diverge on borderline cases.
+
+    Cache is keyed on a fingerprint of TUMOR_PURITY_PARAMETERS so tuning
+    parameters in-process invalidates stale panels.
+    """
+    from .tumor_purity import (
+        TUMOR_PURITY_PARAMETERS,
+        _compile_excluded_gene_matcher,
+        _params_fingerprint,
+        _select_tumor_specific_genes_for_panel,
+    )
+
+    params_fp = _params_fingerprint(["tumor_specific_markers"])
+    cache_key = (int(n_signature_genes), params_fp)
     cached = _signature_panel_cache.get(cache_key)
     if cached is not None:
         return {code: list(genes) for code, genes in cached.items()}
-
-    from .tumor_purity import _select_tumor_specific_genes_for_panel
 
     ref = pan_cancer_expression(normalize="housekeeping")
     ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
@@ -2037,6 +2055,14 @@ def _get_cancer_type_signature_panels(n_signature_genes=20):
     gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
     z_matrix = expr_matrix.sub(gene_mean, axis=0).div(gene_std, axis=0).fillna(0)
 
+    is_excluded_default = _compile_excluded_gene_matcher()
+    immune_origin = set(
+        TUMOR_PURITY_PARAMETERS["tumor_specific_markers"].get(
+            "immune_origin_cancer_types", []
+        )
+        or []
+    )
+
     panels = {}
     for col in fpkm_cols:
         code = col.replace("FPKM_", "")
@@ -2045,12 +2071,27 @@ def _get_cancer_type_signature_panels(n_signature_genes=20):
             n=n_signature_genes,
             exclude_lineage=False,
         )
+        if len(genes) >= n_signature_genes:
+            panels[code] = genes[:n_signature_genes]
+            continue
+
+        # Fallback top-up: raw top-N-by-z-score, but still respecting the
+        # configured family exclusion so the plotting panel can't silently
+        # pick up MT-* / rearranged-receptor genes that the purity path
+        # just filtered out. Immune-origin codes skip the filter for the
+        # same reason the purity path does.
+        is_excluded = (
+            (lambda _sym: False) if code in immune_origin else is_excluded_default
+        )
         z_col = z_matrix[col]
         expr_col = expr_matrix[col]
-        fallback = list(z_col[expr_col > 0.01].nlargest(n_signature_genes).index)
-        for gene in fallback:
-            if gene not in genes:
-                genes.append(gene)
+        fallback_candidates = z_col[expr_col > 0.01].nlargest(n_signature_genes * 3)
+        for gene in fallback_candidates.index:
+            if gene in genes:
+                continue
+            if is_excluded(gene):
+                continue
+            genes.append(gene)
             if len(genes) >= n_signature_genes:
                 break
         panels[code] = genes[:n_signature_genes]

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -2017,6 +2017,48 @@ def plot_purity_adjusted_targets(
     return fig
 
 
+_signature_panel_cache = {}
+
+
+def _get_cancer_type_signature_panels(n_signature_genes=20):
+    """Return robust per-cancer signature panels used for ranking and plotting."""
+    cache_key = int(n_signature_genes)
+    cached = _signature_panel_cache.get(cache_key)
+    if cached is not None:
+        return {code: list(genes) for code, genes in cached.items()}
+
+    from .tumor_purity import _select_tumor_specific_genes_for_panel
+
+    ref = pan_cancer_expression(normalize="housekeeping")
+    ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
+    fpkm_cols = [c for c in ref.columns if c.startswith("FPKM_")]
+    expr_matrix = ref_by_sym[fpkm_cols].astype(float)
+    gene_mean = expr_matrix.mean(axis=1)
+    gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
+    z_matrix = expr_matrix.sub(gene_mean, axis=0).div(gene_std, axis=0).fillna(0)
+
+    panels = {}
+    for col in fpkm_cols:
+        code = col.replace("FPKM_", "")
+        genes = _select_tumor_specific_genes_for_panel(
+            code,
+            n=n_signature_genes,
+            exclude_lineage=False,
+        )
+        z_col = z_matrix[col]
+        expr_col = expr_matrix[col]
+        fallback = list(z_col[expr_col > 0.01].nlargest(n_signature_genes).index)
+        for gene in fallback:
+            if gene not in genes:
+                genes.append(gene)
+            if len(genes) >= n_signature_genes:
+                break
+        panels[code] = genes[:n_signature_genes]
+
+    _signature_panel_cache[cache_key] = {
+        code: tuple(genes) for code, genes in panels.items()
+    }
+    return panels
 
 
 def _compute_cancer_type_signature_stats(
@@ -2041,21 +2083,8 @@ def _compute_cancer_type_signature_stats(
     ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
     fpkm_cols = [c for c in ref.columns if c.startswith("FPKM_")]
 
-    # Z-score matrix across cancer types for gene selection
     expr_matrix = ref_by_sym[fpkm_cols].astype(float)
-    gene_mean = expr_matrix.mean(axis=1)
-    gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
-    z_matrix = expr_matrix.sub(gene_mean, axis=0).div(gene_std, axis=0).fillna(0)
-
-    # Select signature genes per cancer type: top N by z-score,
-    # requiring minimum expression in the cancer type
-    sig = {}
-    for col in fpkm_cols:
-        code = col.replace("FPKM_", "")
-        z_col = z_matrix[col]
-        expr_col = expr_matrix[col]
-        valid = z_col[expr_col > 0.01]
-        sig[code] = list(valid.nlargest(n_signature_genes).index)
+    sig = _get_cancer_type_signature_panels(n_signature_genes=n_signature_genes)
 
     stats = []
     for code in sorted(sig.keys()):
@@ -2634,18 +2663,7 @@ def _cancer_type_score_matrix(df_gene_expr, n_signature_genes=20):
     labels = [c.replace("FPKM_", "") for c in fpkm_cols]
 
     expr_matrix = ref_by_sym[fpkm_cols].astype(float)
-    gene_mean = expr_matrix.mean(axis=1)
-    gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
-    z_matrix = expr_matrix.sub(gene_mean, axis=0).div(gene_std, axis=0).fillna(0)
-
-    # Select signature genes per cancer type
-    sig = {}
-    for col in fpkm_cols:
-        code = col.replace("FPKM_", "")
-        z_col = z_matrix[col]
-        expr_col = expr_matrix[col]
-        valid = z_col[expr_col > 0.01]
-        sig[code] = list(valid.nlargest(n_signature_genes).index)
+    sig = _get_cancer_type_signature_panels(n_signature_genes=n_signature_genes)
 
     # Score each reference cancer type against all signatures
     ref_scores = np.zeros((len(labels), len(labels)))

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -151,6 +151,12 @@ TUMOR_PURITY_PARAMETERS = {
     "tumor_specific_markers": {
         "delta_min": 0.02,
         "normal_fraction_max": 0.5,
+        "tme_fraction_max": 0.5,
+        "cancer_expression_min": 0.5,
+        "fallback_expression_min": 0.1,
+        "zscore_min": 1.0,
+        "fallback_zscore_min": 0.25,
+        "specificity_min": 1.5,
     },
     "host_background": {
         "expression_min": 0.05,
@@ -162,6 +168,9 @@ TUMOR_PURITY_PARAMETERS = {
         "signature_only_estimate_floor": 0.05,
         "tumor_anchor_weight": 0.7,
         "estimate_weight": 0.3,
+        "signature_conflict_ratio": 0.75,
+        "signature_stability_min": 0.45,
+        "signature_weight_floor": 0.35,
     },
     "family_scoring": {
         "presence_scale": 0.15,
@@ -178,6 +187,10 @@ TUMOR_PURITY_PARAMETERS = {
         "soft_family_penalty_gain": 0.75,
     },
 }
+
+_SIGNATURE_PANEL_CACHE = {}
+_REARRANGED_GENE_PREFIXES = ("IGH", "IGK", "IGL", "TRA", "TRB", "TRG", "TRD")
+_GENERIC_SIGNATURE_EXCLUDE_PREFIXES = ("MT-", "RPL", "RPS", "HLA-")
 
 
 def get_tumor_purity_parameters():
@@ -440,9 +453,45 @@ def _select_tumor_specific_genes(cancer_code, n=30):
 
     Returns list of gene symbols sorted by tumor specificity.
     """
+    return _select_tumor_specific_genes_for_panel(
+        cancer_code,
+        n=n,
+        exclude_lineage=True,
+    )
+
+
+def _is_excluded_signature_gene(symbol):
+    """Exclude gene families that are brittle or driven by non-tumor admixture."""
+    if not symbol:
+        return True
+    symbol = str(symbol)
+    return symbol.startswith(_REARRANGED_GENE_PREFIXES) or symbol.startswith(
+        _GENERIC_SIGNATURE_EXCLUDE_PREFIXES
+    )
+
+
+def _select_tumor_specific_genes_for_panel(cancer_code, n=30, exclude_lineage=True):
+    """Select robust cancer-signature genes for purity and subtype panels.
+
+    The panel builder is deliberately conservative:
+    - drop rearranged immune receptor loci and generic housekeeping-like genes
+    - require meaningful expression in the target cancer type
+    - score genes by cancer-type specificity *and* visibility above TME / normal
+    - relax thresholds only if the strict tier leaves a type under-covered
+    """
+    cache_key = (cancer_code, int(n), bool(exclude_lineage))
+    cached = _SIGNATURE_PANEL_CACHE.get(cache_key)
+    if cached is not None:
+        return list(cached)
+
     ref = pan_cancer_expression(normalize="housekeeping")
     ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
     fpkm_cols = [c for c in ref.columns if c.startswith("FPKM_")]
+    ntpm_cols = [c for c in ref.columns if c.startswith("nTPM_")]
+    ntpm_nonrepro = [
+        c for c in ntpm_cols
+        if c.replace("nTPM_", "") not in {"testis", "epididymis", "seminal_vesicle", "placenta", "ovary"}
+    ]
 
     cancer_col = f"FPKM_{cancer_code}"
     if cancer_col not in ref_by_sym.columns:
@@ -452,42 +501,110 @@ def _select_tumor_specific_genes(cancer_code, n=30):
     tissue = CANCER_TO_TISSUE.get(cancer_code)
     if tissue and tissue not in normal_tissues:
         normal_tissues.append(tissue)
-    background_tissues = sorted(set(normal_tissues) | _HOST_SITE_BACKGROUND_TISSUES)
-    normal_cols = [f"nTPM_{t}" for t in background_tissues if f"nTPM_{t}" in ref_by_sym.columns]
-    lineage_genes = set(LINEAGE_GENES.get(cancer_code, []))
+    normal_cols = [f"nTPM_{t}" for t in sorted(set(normal_tissues)) if f"nTPM_{t}" in ref_by_sym.columns]
+    tme_cols = [
+        f"nTPM_{t}"
+        for t in sorted(_HOST_SITE_BACKGROUND_TISSUES)
+        if f"nTPM_{t}" in ref_by_sym.columns
+    ]
+    lineage_genes = set(LINEAGE_GENES.get(cancer_code, [])) if exclude_lineage else set()
 
     # Z-score across cancer types for initial ranking
     expr_matrix = ref_by_sym[fpkm_cols].astype(float)
     gene_mean = expr_matrix.mean(axis=1)
     gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
     z_scores = ((expr_matrix[cancer_col] - gene_mean) / gene_std).fillna(0)
+    cancer_hk = expr_matrix[cancer_col]
+    matched_normal_hk = (
+        ref_by_sym[normal_cols].astype(float).max(axis=1)
+        if normal_cols
+        else pd.Series(0.0, index=ref_by_sym.index, dtype=float)
+    )
+    broad_normal_hk = (
+        ref_by_sym[ntpm_nonrepro].astype(float).max(axis=1)
+        if ntpm_nonrepro
+        else pd.Series(0.0, index=ref_by_sym.index, dtype=float)
+    )
+    normal_hk = pd.concat(
+        [matched_normal_hk.rename("matched"), broad_normal_hk.rename("broad")],
+        axis=1,
+    ).max(axis=1)
+    tme_hk = (
+        ref_by_sym[tme_cols].astype(float).max(axis=1)
+        if tme_cols
+        else pd.Series(0.0, index=ref_by_sym.index, dtype=float)
+    )
+    background_hk = pd.concat([normal_hk.rename("normal"), tme_hk.rename("tme")], axis=1).max(axis=1)
 
-    # Candidates: high z-score AND meaningful expression
-    candidates = z_scores[expr_matrix[cancer_col] > 0.01].nlargest(n * 5)
+    score = (
+        z_scores.clip(lower=0.0)
+        * np.log2(cancer_hk + 1.0)
+        * np.log2((cancer_hk + 0.01) / (background_hk + 0.01) + 1.0)
+    )
+    normal_frac = normal_hk / (cancer_hk + 0.001)
+    tme_frac = tme_hk / (cancer_hk + 0.001)
+    specificity = (cancer_hk + 0.001) / (background_hk + 0.001)
+    excluded = ref_by_sym.index.to_series().map(_is_excluded_signature_gene)
+    if lineage_genes:
+        excluded = excluded | ref_by_sym.index.to_series().isin(lineage_genes)
+
+    params = TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]
+    tiers = [
+        {
+            "expr_min": params["cancer_expression_min"],
+            "zscore_min": params["zscore_min"],
+            "normal_frac_max": params["normal_fraction_max"],
+            "tme_frac_max": params["tme_fraction_max"],
+            "specificity_min": params["specificity_min"],
+        },
+        {
+            "expr_min": max(params["fallback_expression_min"], params["cancer_expression_min"] * 0.5),
+            "zscore_min": max(0.0, params["fallback_zscore_min"]),
+            "normal_frac_max": min(0.8, params["normal_fraction_max"] + 0.15),
+            "tme_frac_max": min(0.8, params["tme_fraction_max"] + 0.2),
+            "specificity_min": max(1.1, params["specificity_min"] - 0.3),
+        },
+        {
+            "expr_min": params["fallback_expression_min"],
+            "zscore_min": 0.0,
+            "normal_frac_max": 1.0,
+            "tme_frac_max": 1.0,
+            "specificity_min": 1.0,
+        },
+    ]
 
     markers = []
-    for gene in candidates.index:
-        if gene in lineage_genes:
-            continue
-        cancer_hk = float(ref_by_sym.loc[gene, cancer_col])
-        if normal_cols:
-            normal_hk = float(ref_by_sym.loc[gene, normal_cols].astype(float).max())
-        else:
-            normal_hk = 0.0
-
-        # Require cancer expression to meaningfully exceed the broader
-        # origin-tissue family and generic stromal/immune backgrounds. This
-        # avoids using normal lineage genes as tumor-purity anchors.
-        delta = cancer_hk - normal_hk
-        normal_frac = normal_hk / (cancer_hk + 0.001)
-        if (
-            delta > TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]["delta_min"]
-            and normal_frac <= TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]["normal_fraction_max"]
-        ):
+    seen = set()
+    for tier in tiers:
+        keep = (
+            (cancer_hk > tier["expr_min"])
+            & (z_scores > tier["zscore_min"])
+            & ((cancer_hk - normal_hk) > params["delta_min"])
+            & (normal_frac <= tier["normal_frac_max"])
+            & (tme_frac <= tier["tme_frac_max"])
+            & (specificity >= tier["specificity_min"])
+            & ~excluded
+        )
+        candidates = score[keep].sort_values(ascending=False)
+        for gene in candidates.index:
+            if gene in seen:
+                continue
+            seen.add(gene)
             markers.append(gene)
             if len(markers) >= n:
-                break
+                _SIGNATURE_PANEL_CACHE[cache_key] = tuple(markers[:n])
+                return markers[:n]
 
+    fallback = score[(cancer_hk > params["fallback_expression_min"]) & ~excluded].sort_values(ascending=False)
+    for gene in fallback.index:
+        if gene in seen:
+            continue
+        seen.add(gene)
+        markers.append(gene)
+        if len(markers) >= n:
+            break
+
+    _SIGNATURE_PANEL_CACHE[cache_key] = tuple(markers[:n])
     return markers
 
 
@@ -524,6 +641,7 @@ def _combine_purity_estimates(
     lineage_purity,
     lineage_lower,
     lineage_upper,
+    sig_stability=None,
 ):
     """Combine purity signals while keeping ESTIMATE as context, not destiny.
 
@@ -535,9 +653,28 @@ def _combine_purity_estimates(
     """
     has_sig = sig_purity is not None
     has_lineage = lineage_purity is not None
+    signature_params = TUMOR_PURITY_PARAMETERS["purity_combination"]
+    deprioritize_signature = _signature_conflicts_with_lineage(
+        sig_purity=sig_purity,
+        lineage_purity=lineage_purity,
+        sig_stability=sig_stability,
+    )
 
     if has_sig and has_lineage:
-        tumor_anchor = float(np.sqrt(max(sig_purity, 0.0) * max(lineage_purity, 0.0)))
+        if deprioritize_signature:
+            tumor_anchor = float(lineage_purity)
+        else:
+            sig_weight = float(max(sig_stability or 1.0, signature_params["signature_weight_floor"]))
+            lineage_weight = 1.0
+            tumor_anchor = float(
+                np.exp(
+                    (
+                        sig_weight * np.log(max(sig_purity, 1e-6))
+                        + lineage_weight * np.log(max(lineage_purity, 1e-6))
+                    )
+                    / (sig_weight + lineage_weight)
+                )
+            )
     elif has_lineage:
         tumor_anchor = float(lineage_purity)
     elif has_sig:
@@ -552,13 +689,13 @@ def _combine_purity_estimates(
         if has_sig and has_lineage and estimate_purity <= 0:
             overall = float(tumor_anchor)
         elif has_sig and not has_lineage:
-            estimate_floor = TUMOR_PURITY_PARAMETERS["purity_combination"]["signature_only_estimate_floor"]
+            estimate_floor = signature_params["signature_only_estimate_floor"]
             overall = float(np.sqrt(max(tumor_anchor, 0.0) * max(estimate_purity, estimate_floor)))
         else:
-            estimate_floor = TUMOR_PURITY_PARAMETERS["purity_combination"]["signature_only_estimate_floor"]
+            estimate_floor = signature_params["signature_only_estimate_floor"]
             overall = float(
-                (max(tumor_anchor, 0.0) ** TUMOR_PURITY_PARAMETERS["purity_combination"]["tumor_anchor_weight"])
-                * (max(estimate_purity, estimate_floor) ** TUMOR_PURITY_PARAMETERS["purity_combination"]["estimate_weight"])
+                (max(tumor_anchor, 0.0) ** signature_params["tumor_anchor_weight"])
+                * (max(estimate_purity, estimate_floor) ** signature_params["estimate_weight"])
             )
     elif tumor_anchor is not None:
         overall = float(tumor_anchor)
@@ -570,20 +707,40 @@ def _combine_purity_estimates(
     lower_candidates = [overall]
     upper_candidates = [overall]
 
-    for value in (sig_lower, lineage_lower):
+    for value in (lineage_lower,):
         if value is not None:
             lower_candidates.append(float(value))
-    for value in (sig_upper, lineage_upper):
+    if not deprioritize_signature:
+        for value in (sig_lower,):
+            if value is not None:
+                lower_candidates.append(float(value))
+    for value in (lineage_upper,):
         if value is not None:
             upper_candidates.append(float(value))
+    if not deprioritize_signature:
+        for value in (sig_upper,):
+            if value is not None:
+                upper_candidates.append(float(value))
 
-        if estimate_purity is not None and (estimate_purity > 0 or (has_sig and not has_lineage)):
-            lower_candidates.append(float(estimate_purity))
+    if estimate_purity is not None and (estimate_purity > 0 or (has_sig and not has_lineage)):
+        lower_candidates.append(float(estimate_purity))
 
     overall_lower = float(np.clip(min(lower_candidates), 0.0, 1.0))
     overall_upper = float(np.clip(max(upper_candidates), 0.0, 1.0))
     overall = float(np.clip(overall, overall_lower, overall_upper))
     return overall, overall_lower, overall_upper
+
+
+def _signature_conflicts_with_lineage(sig_purity, lineage_purity, sig_stability):
+    """Return True when a weak signature should not drag down a coherent lineage call."""
+    if sig_purity is None or lineage_purity is None:
+        return False
+    params = TUMOR_PURITY_PARAMETERS["purity_combination"]
+    stability = float(sig_stability if sig_stability is not None else 1.0)
+    return (
+        float(sig_purity) < float(lineage_purity) * params["signature_conflict_ratio"]
+        and stability < params["signature_stability_min"]
+    )
 
 
 # -------------------- main estimation --------------------
@@ -730,7 +887,25 @@ def estimate_tumor_purity(df_gene_expr, cancer_type=None):
         lineage_purity=lineage_purity,
         lineage_lower=lineage_lower,
         lineage_upper=lineage_upper,
+        sig_stability=sig_stability,
     )
+    signature_deprioritized = _signature_conflicts_with_lineage(
+        sig_purity=sig_purity,
+        lineage_purity=lineage_purity,
+        sig_stability=sig_stability,
+    )
+    if signature_deprioritized:
+        integration_source = "lineage"
+    elif sig_purity is not None and lineage_purity is not None:
+        integration_source = "signature+lineage"
+    elif lineage_purity is not None:
+        integration_source = "lineage"
+    elif sig_purity is not None:
+        integration_source = "signature"
+    elif estimate_purity is not None:
+        integration_source = "estimate"
+    else:
+        integration_source = None
 
     return {
         "cancer_type": cancer_code,
@@ -769,6 +944,10 @@ def estimate_tumor_purity(df_gene_expr, cancer_type=None):
                 "n_genes": len(immune_genes),
             },
             "estimate_purity": estimate_purity,
+            "integration": {
+                "source": integration_source,
+                "signature_deprioritized": signature_deprioritized,
+            },
         },
     }
 
@@ -1267,6 +1446,22 @@ def rank_cancer_type_candidates(
             row["code"],
         )
     )
+    if rows:
+        best_family_group = _CANCER_FAMILY_GROUP.get(
+            rows[0].get("family_label"),
+            rows[0].get("family_label"),
+        )
+        if best_family_group and _CANCER_FAMILY_GROUP_CODE_COUNTS.get(best_family_group, 0) > 1:
+            same_family = [
+                row for row in rows[1:]
+                if _CANCER_FAMILY_GROUP.get(row.get("family_label"), row.get("family_label")) == best_family_group
+            ]
+            if same_family:
+                other_rows = [
+                    row for row in rows[1:]
+                    if _CANCER_FAMILY_GROUP.get(row.get("family_label"), row.get("family_label")) != best_family_group
+                ]
+                rows = [rows[0]] + same_family + other_rows
 
     max_support = max((row["support_score"] for row in rows), default=0.0)
     for row in rows:

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -149,14 +149,57 @@ TUMOR_PURITY_PARAMETERS = {
         "detection_fraction_threshold": 0.05,
     },
     "tumor_specific_markers": {
+        # Difference in HK-normalized expression a candidate must clear over
+        # the matched-normal background to be eligible at all. Keeps the
+        # filter meaningful for low-abundance but legitimately tumor-biased
+        # genes.
         "delta_min": 0.02,
+        # Strict tier: maximum share of the cancer signal that can come from
+        # matched-normal tissue / broad host background, and minimum
+        # cancer-vs-background fold change. A lower bound on z-score and
+        # absolute HK-normalized expression in the cancer type itself.
         "normal_fraction_max": 0.5,
         "tme_fraction_max": 0.5,
         "cancer_expression_min": 0.5,
-        "fallback_expression_min": 0.1,
         "zscore_min": 1.0,
-        "fallback_zscore_min": 0.25,
         "specificity_min": 1.5,
+        # Loose tier: if the strict tier leaves a cancer type under-covered,
+        # relax the absolute-expression and z-score floors. Still enforces
+        # `delta_min` and some minimal specificity.
+        "fallback_expression_min": 0.1,
+        "fallback_zscore_min": 0.25,
+        # Tuning knobs on the loose tier. Kept explicit (rather than
+        # hard-coded in the tier construction) so the behavior is visible
+        # without reading the filter code.
+        "fallback_normal_fraction_max": 0.8,
+        "fallback_tme_fraction_max": 0.8,
+        "fallback_specificity_min": 1.1,
+        # Gene-family exclusions, expressed as regex patterns matched with
+        # `re.fullmatch` against gene symbols. The defaults drop:
+        #   - rearranged-receptor V/D/J/C segments (IGHV3-33, TRGV9, ...)
+        #     which are infiltrate-driven and sequence-unstable
+        #   - HLA class II (HLA-D*) which are APC / infiltrate markers
+        #   - RPL*/RPS* ribosomal protein genes
+        #   - MT-* mitochondrial-encoded transcripts (unstable, degradation
+        #     artifact territory)
+        # HLA class I (HLA-A/B/C/E/F/G) and non-receptor IG/TR genes
+        # (IGHMBP2, TRAF*, TRADD, TRAP1, TRAK1, ...) are deliberately not
+        # excluded.
+        "excluded_gene_regexes": [
+            r"(IGH|IGK|IGL|TRA|TRB|TRG|TRD)[VDJC]\d.*",
+            r"HLA-D[A-Z]+\d*",
+            r"(RPL|RPS)\d.*",
+            r"MT-.*",
+        ],
+        # Cancer types where the excluded families above ARE the legitimate
+        # tumor signal. Covers lymphoid (DLBC → B-cell receptor), myeloid
+        # APC-like (LAML — monocytic subtypes retain high HLA-DR / MHC-II;
+        # HLA-DR is a standard AML immunophenotyping marker and only APL/M3
+        # is reliably HLA-DR-negative), and thymic epithelial (THYM, which
+        # also expresses class II). The rearranged-receptor and HLA-D
+        # regexes above are bypassed for these codes so the panel captures
+        # legitimate lineage markers instead of dropping them.
+        "immune_origin_cancer_types": ["DLBC", "LAML", "THYM"],
     },
     "host_background": {
         "expression_min": 0.05,
@@ -189,8 +232,59 @@ TUMOR_PURITY_PARAMETERS = {
 }
 
 _SIGNATURE_PANEL_CACHE = {}
-_REARRANGED_GENE_PREFIXES = ("IGH", "IGK", "IGL", "TRA", "TRB", "TRG", "TRD")
-_GENERIC_SIGNATURE_EXCLUDE_PREFIXES = ("MT-", "RPL", "RPS", "HLA-")
+
+
+def _params_fingerprint(subkeys):
+    """Stable, hashable snapshot of the selected TUMOR_PURITY_PARAMETERS keys.
+
+    Used as part of a cache key so mutating parameters between calls
+    invalidates previously cached panels instead of silently serving stale
+    results (which would surprise anyone tuning parameters in a REPL or test).
+    """
+    snap = []
+    for key in subkeys:
+        value = TUMOR_PURITY_PARAMETERS.get(key, {})
+        # Cheap canonicalization — sort top-level keys and coerce nested
+        # lists to tuples so the result is hashable.
+        flat = tuple(
+            (k, tuple(v) if isinstance(v, list) else v)
+            for k, v in sorted(value.items())
+        )
+        snap.append((key, flat))
+    return tuple(snap)
+
+
+def _compile_excluded_gene_matcher():
+    """Return a predicate `symbol -> bool` from the configured regex list.
+
+    Factored out so the compiled regex is cached per distinct pattern list
+    and re-used across many gene lookups inside a single panel build.
+    """
+    import re
+
+    params = TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]
+    patterns = tuple(params.get("excluded_gene_regexes", ()) or ())
+    if not patterns:
+        return lambda symbol: False
+    joined = "|".join(f"(?:{p})" for p in patterns)
+    regex = re.compile(f"^(?:{joined})$")
+
+    def is_excluded(symbol):
+        if not symbol:
+            return True
+        return bool(regex.fullmatch(str(symbol)))
+
+    return is_excluded
+
+
+def _is_excluded_signature_gene(symbol):
+    """Compatibility wrapper — compiles the matcher per call.
+
+    Kept so external callers (tests, plot.py fallback) can ask without
+    needing to know about the compiled cache. For tight loops prefer
+    `_compile_excluded_gene_matcher()` and call its returned predicate.
+    """
+    return _compile_excluded_gene_matcher()(symbol)
 
 
 def get_tumor_purity_parameters():
@@ -460,97 +554,29 @@ def _select_tumor_specific_genes(cancer_code, n=30):
     )
 
 
-def _is_excluded_signature_gene(symbol):
-    """Exclude gene families that are brittle or driven by non-tumor admixture."""
-    if not symbol:
-        return True
-    symbol = str(symbol)
-    return symbol.startswith(_REARRANGED_GENE_PREFIXES) or symbol.startswith(
-        _GENERIC_SIGNATURE_EXCLUDE_PREFIXES
-    )
+_REPRODUCTIVE_TISSUES_FOR_BROAD_BACKGROUND = (
+    # Reproductive tissues are excluded from the "broad normal" background
+    # because they express a lot of otherwise cancer-specific markers (CT
+    # antigens, lineage programs) that we do want to use as tumor signals.
+    "testis", "epididymis", "seminal_vesicle", "placenta", "ovary",
+)
 
 
-def _select_tumor_specific_genes_for_panel(cancer_code, n=30, exclude_lineage=True):
-    """Select robust cancer-signature genes for purity and subtype panels.
+def _build_signature_panel_tiers():
+    """Return the ordered list of selectivity tiers for panel building.
 
-    The panel builder is deliberately conservative:
-    - drop rearranged immune receptor loci and generic housekeeping-like genes
-    - require meaningful expression in the target cancer type
-    - score genes by cancer-type specificity *and* visibility above TME / normal
-    - relax thresholds only if the strict tier leaves a type under-covered
+    Strict tier first, then a loose fallback tier, then an open tier that
+    still keeps `delta_min` and a minimal specificity floor. Each tier is
+    described by the maximum tolerated share from normal / TME backgrounds
+    and minimum cancer-side expression and specificity.
+
+    Kept as data rather than nested constants so the shape is visible next
+    to the filter code that consumes it.
     """
-    cache_key = (cancer_code, int(n), bool(exclude_lineage))
-    cached = _SIGNATURE_PANEL_CACHE.get(cache_key)
-    if cached is not None:
-        return list(cached)
-
-    ref = pan_cancer_expression(normalize="housekeeping")
-    ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
-    fpkm_cols = [c for c in ref.columns if c.startswith("FPKM_")]
-    ntpm_cols = [c for c in ref.columns if c.startswith("nTPM_")]
-    ntpm_nonrepro = [
-        c for c in ntpm_cols
-        if c.replace("nTPM_", "") not in {"testis", "epididymis", "seminal_vesicle", "placenta", "ovary"}
-    ]
-
-    cancer_col = f"FPKM_{cancer_code}"
-    if cancer_col not in ref_by_sym.columns:
-        return []
-
-    normal_tissues = list(_CANCER_NORMAL_TISSUES.get(cancer_code, []))
-    tissue = CANCER_TO_TISSUE.get(cancer_code)
-    if tissue and tissue not in normal_tissues:
-        normal_tissues.append(tissue)
-    normal_cols = [f"nTPM_{t}" for t in sorted(set(normal_tissues)) if f"nTPM_{t}" in ref_by_sym.columns]
-    tme_cols = [
-        f"nTPM_{t}"
-        for t in sorted(_HOST_SITE_BACKGROUND_TISSUES)
-        if f"nTPM_{t}" in ref_by_sym.columns
-    ]
-    lineage_genes = set(LINEAGE_GENES.get(cancer_code, [])) if exclude_lineage else set()
-
-    # Z-score across cancer types for initial ranking
-    expr_matrix = ref_by_sym[fpkm_cols].astype(float)
-    gene_mean = expr_matrix.mean(axis=1)
-    gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
-    z_scores = ((expr_matrix[cancer_col] - gene_mean) / gene_std).fillna(0)
-    cancer_hk = expr_matrix[cancer_col]
-    matched_normal_hk = (
-        ref_by_sym[normal_cols].astype(float).max(axis=1)
-        if normal_cols
-        else pd.Series(0.0, index=ref_by_sym.index, dtype=float)
-    )
-    broad_normal_hk = (
-        ref_by_sym[ntpm_nonrepro].astype(float).max(axis=1)
-        if ntpm_nonrepro
-        else pd.Series(0.0, index=ref_by_sym.index, dtype=float)
-    )
-    normal_hk = pd.concat(
-        [matched_normal_hk.rename("matched"), broad_normal_hk.rename("broad")],
-        axis=1,
-    ).max(axis=1)
-    tme_hk = (
-        ref_by_sym[tme_cols].astype(float).max(axis=1)
-        if tme_cols
-        else pd.Series(0.0, index=ref_by_sym.index, dtype=float)
-    )
-    background_hk = pd.concat([normal_hk.rename("normal"), tme_hk.rename("tme")], axis=1).max(axis=1)
-
-    score = (
-        z_scores.clip(lower=0.0)
-        * np.log2(cancer_hk + 1.0)
-        * np.log2((cancer_hk + 0.01) / (background_hk + 0.01) + 1.0)
-    )
-    normal_frac = normal_hk / (cancer_hk + 0.001)
-    tme_frac = tme_hk / (cancer_hk + 0.001)
-    specificity = (cancer_hk + 0.001) / (background_hk + 0.001)
-    excluded = ref_by_sym.index.to_series().map(_is_excluded_signature_gene)
-    if lineage_genes:
-        excluded = excluded | ref_by_sym.index.to_series().isin(lineage_genes)
-
     params = TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]
-    tiers = [
+    return [
         {
+            "name": "strict",
             "expr_min": params["cancer_expression_min"],
             "zscore_min": params["zscore_min"],
             "normal_frac_max": params["normal_fraction_max"],
@@ -558,13 +584,18 @@ def _select_tumor_specific_genes_for_panel(cancer_code, n=30, exclude_lineage=Tr
             "specificity_min": params["specificity_min"],
         },
         {
-            "expr_min": max(params["fallback_expression_min"], params["cancer_expression_min"] * 0.5),
+            "name": "loose",
+            "expr_min": max(
+                params["fallback_expression_min"],
+                params["cancer_expression_min"] * 0.5,
+            ),
             "zscore_min": max(0.0, params["fallback_zscore_min"]),
-            "normal_frac_max": min(0.8, params["normal_fraction_max"] + 0.15),
-            "tme_frac_max": min(0.8, params["tme_fraction_max"] + 0.2),
-            "specificity_min": max(1.1, params["specificity_min"] - 0.3),
+            "normal_frac_max": params["fallback_normal_fraction_max"],
+            "tme_frac_max": params["fallback_tme_fraction_max"],
+            "specificity_min": params["fallback_specificity_min"],
         },
         {
+            "name": "open",
             "expr_min": params["fallback_expression_min"],
             "zscore_min": 0.0,
             "normal_frac_max": 1.0,
@@ -573,9 +604,139 @@ def _select_tumor_specific_genes_for_panel(cancer_code, n=30, exclude_lineage=Tr
         },
     ]
 
+
+def _panel_reference_frames(cancer_code, ref_by_sym):
+    """Assemble per-gene expression vectors used by the panel filter.
+
+    Returns a dict with the cancer-side HK-normalized expression, the
+    maximum across matched-normal and broad-normal backgrounds (union), the
+    max across TME tissues, the combined background, and a z-score over
+    cancer types. Returns None if the cancer code has no FPKM column.
+    """
+    fpkm_cols = [c for c in ref_by_sym.columns if c.startswith("FPKM_")]
+    ntpm_cols = [c for c in ref_by_sym.columns if c.startswith("nTPM_")]
+    ntpm_nonrepro = [
+        c for c in ntpm_cols
+        if c.replace("nTPM_", "") not in _REPRODUCTIVE_TISSUES_FOR_BROAD_BACKGROUND
+    ]
+
+    cancer_col = f"FPKM_{cancer_code}"
+    if cancer_col not in ref_by_sym.columns:
+        return None
+
+    matched_tissues = list(_CANCER_NORMAL_TISSUES.get(cancer_code, []))
+    tissue = CANCER_TO_TISSUE.get(cancer_code)
+    if tissue and tissue not in matched_tissues:
+        matched_tissues.append(tissue)
+    normal_cols = [
+        f"nTPM_{t}"
+        for t in sorted(set(matched_tissues))
+        if f"nTPM_{t}" in ref_by_sym.columns
+    ]
+    tme_cols = [
+        f"nTPM_{t}"
+        for t in sorted(_HOST_SITE_BACKGROUND_TISSUES)
+        if f"nTPM_{t}" in ref_by_sym.columns
+    ]
+
+    expr_matrix = ref_by_sym[fpkm_cols].astype(float)
+    gene_mean = expr_matrix.mean(axis=1)
+    gene_std = expr_matrix.std(axis=1).replace(0, np.nan)
+    z_scores = ((expr_matrix[cancer_col] - gene_mean) / gene_std).fillna(0)
+    cancer_hk = expr_matrix[cancer_col]
+
+    def _row_max(cols):
+        if not cols:
+            return pd.Series(0.0, index=ref_by_sym.index, dtype=float)
+        return ref_by_sym[cols].astype(float).max(axis=1)
+
+    matched_normal_hk = _row_max(normal_cols)
+    broad_normal_hk = _row_max(ntpm_nonrepro)
+    normal_hk = pd.concat(
+        [matched_normal_hk.rename("matched"), broad_normal_hk.rename("broad")],
+        axis=1,
+    ).max(axis=1)
+    tme_hk = _row_max(tme_cols)
+    background_hk = pd.concat(
+        [normal_hk.rename("normal"), tme_hk.rename("tme")], axis=1
+    ).max(axis=1)
+
+    return {
+        "z_scores": z_scores,
+        "cancer_hk": cancer_hk,
+        "normal_hk": normal_hk,
+        "tme_hk": tme_hk,
+        "background_hk": background_hk,
+    }
+
+
+def _select_tumor_specific_genes_for_panel(cancer_code, n=30, exclude_lineage=True):
+    """Select robust cancer-signature genes for purity and subtype panels.
+
+    The panel builder is deliberately conservative:
+    - drop rearranged-receptor V/D/J/C segments and MHC class II by default
+      (configurable, bypassed for hematopoietic / immune-origin cancers
+      where those genes are legitimate lineage markers)
+    - require meaningful HK-normalized expression in the target cancer type
+    - score genes by cancer-type specificity AND visibility above the union
+      of matched-normal, broad-normal (minus reproductive tissues), and TME
+    - relax thresholds across three tiers only if the strict tier leaves a
+      type under-covered
+
+    The cache key includes a fingerprint of TUMOR_PURITY_PARAMETERS so
+    tuning parameters in-process invalidates stale panels.
+    """
+    params_fp = _params_fingerprint(["tumor_specific_markers"])
+    cache_key = (cancer_code, int(n), bool(exclude_lineage), params_fp)
+    cached = _SIGNATURE_PANEL_CACHE.get(cache_key)
+    if cached is not None:
+        return list(cached)
+
+    ref = pan_cancer_expression(normalize="housekeeping")
+    ref_by_sym = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
+
+    frames = _panel_reference_frames(cancer_code, ref_by_sym)
+    if frames is None:
+        _SIGNATURE_PANEL_CACHE[cache_key] = tuple()
+        return []
+    z_scores = frames["z_scores"]
+    cancer_hk = frames["cancer_hk"]
+    normal_hk = frames["normal_hk"]
+    tme_hk = frames["tme_hk"]
+    background_hk = frames["background_hk"]
+
+    params = TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]
+
+    # Rank candidates by a compound specificity score: positive z-score,
+    # absolute expression, and cancer-vs-background fold.
+    score = (
+        z_scores.clip(lower=0.0)
+        * np.log2(cancer_hk + 1.0)
+        * np.log2((cancer_hk + 0.01) / (background_hk + 0.01) + 1.0)
+    )
+    normal_frac = normal_hk / (cancer_hk + 0.001)
+    tme_frac = tme_hk / (cancer_hk + 0.001)
+    specificity = (cancer_hk + 0.001) / (background_hk + 0.001)
+
+    # Build the exclusion mask. Immune-origin cancer types (DLBC, LAML, THYM)
+    # bypass the family exclusion entirely — for those, rearranged-receptor
+    # loci and HLA-D genes ARE the lineage signal we want to capture, not
+    # infiltrate contamination to filter out.
+    immune_origin = set(params.get("immune_origin_cancer_types", []) or [])
+    if cancer_code in immune_origin:
+        excluded = pd.Series(False, index=ref_by_sym.index)
+    else:
+        is_excluded = _compile_excluded_gene_matcher()
+        excluded = ref_by_sym.index.to_series().map(is_excluded).astype(bool)
+
+    if exclude_lineage:
+        lineage_genes = set(LINEAGE_GENES.get(cancer_code, []))
+        if lineage_genes:
+            excluded = excluded | ref_by_sym.index.to_series().isin(lineage_genes)
+
     markers = []
     seen = set()
-    for tier in tiers:
+    for tier in _build_signature_panel_tiers():
         keep = (
             (cancer_hk > tier["expr_min"])
             & (z_scores > tier["zscore_min"])
@@ -595,7 +756,12 @@ def _select_tumor_specific_genes_for_panel(cancer_code, n=30, exclude_lineage=Tr
                 _SIGNATURE_PANEL_CACHE[cache_key] = tuple(markers[:n])
                 return markers[:n]
 
-    fallback = score[(cancer_hk > params["fallback_expression_min"]) & ~excluded].sort_values(ascending=False)
+    # Last-resort fallback: still apply the family exclusion so the panel
+    # never quietly regresses to including MT-* / rearranged receptors just
+    # because the tiered filter ran short.
+    fallback = score[
+        (cancer_hk > params["fallback_expression_min"]) & ~excluded
+    ].sort_values(ascending=False)
     for gene in fallback.index:
         if gene in seen:
             continue
@@ -664,7 +830,18 @@ def _combine_purity_estimates(
         if deprioritize_signature:
             tumor_anchor = float(lineage_purity)
         else:
-            sig_weight = float(max(sig_stability or 1.0, signature_params["signature_weight_floor"]))
+            # Weight the signature channel by its own stability. Use
+            # `is not None` rather than truthiness so a stability of exactly
+            # 0.0 is not promoted back to full weight — the earlier
+            # conflict check already gates truly-degenerate cases, but this
+            # branch still has to handle the "low but present stability"
+            # case coherently.
+            raw_sig_weight = (
+                float(sig_stability) if sig_stability is not None else 1.0
+            )
+            sig_weight = max(
+                raw_sig_weight, signature_params["signature_weight_floor"]
+            )
             lineage_weight = 1.0
             tumor_anchor = float(
                 np.exp(
@@ -1292,6 +1469,55 @@ def _get_mhc_expression(sample_tpm_by_symbol):
     return mhc1, mhc2
 
 
+def _resolve_family_group(family_label):
+    """Collapse a specific family label to its top-level group, if any.
+
+    Some families are expressed at two granularities (e.g. `ESCA_SQ` is a
+    specific subtype of the broader `SQUAMOUS` group). When comparing or
+    grouping across candidates we want to treat both as the same family.
+    Families without a group mapping return their own label.
+    """
+    if family_label is None:
+        return None
+    return _CANCER_FAMILY_GROUP.get(family_label, family_label)
+
+
+def _promote_same_family_alternatives(rows):
+    """Surface same-family alternatives immediately after the top candidate.
+
+    Purpose: when the top-ranked candidate belongs to a family with multiple
+    TCGA members (e.g. squamous → HNSC / LUSC / CESC / ESCA, or renal →
+    KIRC / KIRP / KICH), a user reading the ranked list benefits from
+    seeing the sibling subtypes adjacently, even if some out-of-family
+    candidate technically scored higher on the next line. This is a *display*
+    rerank layered on top of the support-score sort — the top pick is
+    preserved and intra-group order still reflects the underlying ranking.
+
+    No-op when the top family has only one code in the cancer set, or when
+    no same-family alternatives remain after the top pick.
+    """
+    if not rows:
+        return rows
+
+    best_family_group = _resolve_family_group(rows[0].get("family_label"))
+    if not best_family_group:
+        return rows
+    if _CANCER_FAMILY_GROUP_CODE_COUNTS.get(best_family_group, 0) <= 1:
+        return rows
+
+    same_family = []
+    other_rows = []
+    for row in rows[1:]:
+        if _resolve_family_group(row.get("family_label")) == best_family_group:
+            same_family.append(row)
+        else:
+            other_rows.append(row)
+    if not same_family:
+        return rows
+
+    return [rows[0]] + same_family + other_rows
+
+
 def rank_cancer_type_candidates(
     df_gene_expr,
     candidate_codes=None,
@@ -1446,22 +1672,7 @@ def rank_cancer_type_candidates(
             row["code"],
         )
     )
-    if rows:
-        best_family_group = _CANCER_FAMILY_GROUP.get(
-            rows[0].get("family_label"),
-            rows[0].get("family_label"),
-        )
-        if best_family_group and _CANCER_FAMILY_GROUP_CODE_COUNTS.get(best_family_group, 0) > 1:
-            same_family = [
-                row for row in rows[1:]
-                if _CANCER_FAMILY_GROUP.get(row.get("family_label"), row.get("family_label")) == best_family_group
-            ]
-            if same_family:
-                other_rows = [
-                    row for row in rows[1:]
-                    if _CANCER_FAMILY_GROUP.get(row.get("family_label"), row.get("family_label")) != best_family_group
-                ]
-                rows = [rows[0]] + same_family + other_rows
+    rows = _promote_same_family_alternatives(rows)
 
     max_support = max((row["support_score"] for row in rows), default=0.0)
     for row in rows:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.18.0"
+__version__ = "3.19.0"
 
 version_string = f"v{__version__}"
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.19.0"
+__version__ = "3.20.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_tumor_expression.py
+++ b/tests/test_tumor_expression.py
@@ -135,12 +135,117 @@ def test_signature_summary_ignores_high_outlier():
 def test_prad_signature_panel_excludes_rearranged_immune_genes():
     panel = _select_tumor_specific_genes("PRAD", n=30)
     assert panel
-    assert not any(
-        gene.startswith(("IGH", "IGK", "IGL", "TRA", "TRB", "TRG", "TRD"))
-        for gene in panel
-    )
+    # Only rearranged V/D/J/C segments should be blocked — prefix-based
+    # checks would also drop unrelated genes like TRAF*, TRAK1, TRAP1.
+    rearranged_prefixes = ("IGH", "IGK", "IGL", "TRA", "TRB", "TRG", "TRD")
+    for gene in panel:
+        for prefix in rearranged_prefixes:
+            if gene.startswith(prefix) and len(gene) > len(prefix):
+                segment_char = gene[len(prefix)]
+                assert segment_char not in "VDJC", (
+                    f"{gene} looks like a rearranged receptor segment"
+                )
     assert "TRGV9" not in panel
     assert "TRGC1" not in panel
+
+
+def test_signature_exclusion_preserves_unrelated_tr_ig_genes():
+    """TRAF*, TRAK1, TRAP1, TRADD, IGHMBP2, IGFBP* should not be excluded."""
+    from pirlygenes.tumor_purity import _compile_excluded_gene_matcher
+
+    is_excluded = _compile_excluded_gene_matcher()
+    for gene in ["TRAF3", "TRAF6", "TRAK1", "TRAP1", "TRADD", "IGHMBP2", "IGFBP3"]:
+        assert not is_excluded(gene), f"{gene} should not be excluded"
+    # HLA class I stays, class II goes
+    for gene in ["HLA-A", "HLA-B", "HLA-C", "HLA-E", "HLA-F", "HLA-G"]:
+        assert not is_excluded(gene), f"{gene} (class I) should not be excluded"
+    for gene in ["HLA-DRA", "HLA-DRB1", "HLA-DPA1", "HLA-DQB1"]:
+        assert is_excluded(gene), f"{gene} (class II) should be excluded"
+    # Rearranged receptors should still be excluded
+    for gene in ["TRGV9", "TRGC1", "IGHV3-33", "IGKV1-5", "TRBV7-9"]:
+        assert is_excluded(gene), f"{gene} (rearranged receptor) should be excluded"
+
+
+def test_dlbc_panel_bypasses_immune_exclusion():
+    """Immune-origin cancers should include lineage markers that would otherwise
+    be filtered as infiltrate contamination."""
+    panel = _select_tumor_specific_genes("DLBC", n=30)
+    assert panel
+    # B-cell lineage markers should be recoverable for DLBC
+    assert any(g.startswith("HLA-D") for g in panel), (
+        f"DLBC panel should include HLA class II markers, got: {panel}"
+    )
+
+
+def test_signature_panel_cache_invalidates_on_param_change():
+    """Mutating TUMOR_PURITY_PARAMETERS should not serve stale panels."""
+    from pirlygenes.tumor_purity import (
+        TUMOR_PURITY_PARAMETERS,
+        _select_tumor_specific_genes_for_panel,
+    )
+
+    panel_with_defaults = _select_tumor_specific_genes_for_panel("PRAD", n=30)
+    params = TUMOR_PURITY_PARAMETERS["tumor_specific_markers"]
+    original = params["excluded_gene_regexes"]
+    try:
+        # Add a pattern that blocks "KLK.*" — any KLK gene previously in
+        # the panel should now be removed.
+        params["excluded_gene_regexes"] = list(original) + [r"KLK.*"]
+        panel_with_klk_blocked = _select_tumor_specific_genes_for_panel("PRAD", n=30)
+        assert not any(g.startswith("KLK") for g in panel_with_klk_blocked), (
+            f"cache should have re-keyed on param change; got {panel_with_klk_blocked}"
+        )
+    finally:
+        params["excluded_gene_regexes"] = original
+
+    # After restoring params the original panel should return.
+    panel_restored = _select_tumor_specific_genes_for_panel("PRAD", n=30)
+    assert panel_restored == panel_with_defaults
+
+
+def test_combine_purity_treats_zero_stability_as_low_weight():
+    """A stability of exactly 0.0 must not collapse to full weight via truthiness.
+
+    Guards against the `sig_stability or 1.0` pattern: 0.0 is not
+    "unknown", it's the strongest possible signal that the signature
+    channel is unreliable. When the conflict gate happens NOT to fire
+    (signature is close to lineage in absolute value), the weighted-log
+    path should still downweight the signature instead of giving it full
+    weight equal to lineage.
+    """
+    # Pick values where the conflict gate does NOT trigger — i.e.
+    # sig/lineage >= signature_conflict_ratio (0.75). This forces the code
+    # through the weighted-log branch where the bug lived.
+    kwargs = dict(
+        sig_lower=0.30,
+        sig_upper=0.70,
+        estimate_purity=None,
+        lineage_purity=0.60,
+        lineage_lower=0.55,
+        lineage_upper=0.65,
+    )
+    overall_zero, _, _ = _combine_purity_estimates(
+        sig_purity=0.50, sig_stability=0.0, **kwargs
+    )
+    overall_unknown, _, _ = _combine_purity_estimates(
+        sig_purity=0.50, sig_stability=None, **kwargs
+    )
+    overall_high, _, _ = _combine_purity_estimates(
+        sig_purity=0.50, sig_stability=0.9, **kwargs
+    )
+    # Stability=0 should pull the anchor closer to lineage (0.60) than
+    # stability=None (which is treated as full signature weight = 1.0).
+    # Stability=0.9 lies between the two.
+    assert overall_zero > overall_unknown, (
+        f"stability=0 must give lineage more relative weight than "
+        f"stability=None; zero={overall_zero:.3f} unknown={overall_unknown:.3f}"
+    )
+    assert overall_unknown <= overall_high <= overall_zero or (
+        overall_unknown <= overall_zero
+    ), (
+        f"Monotonicity check: lower stability should pull toward lineage; "
+        f"zero={overall_zero:.3f} high={overall_high:.3f} unknown={overall_unknown:.3f}"
+    )
 
 
 # ── estimate_tumor_expression_ranges ──────────────────────────────

--- a/tests/test_tumor_expression.py
+++ b/tests/test_tumor_expression.py
@@ -9,6 +9,7 @@ from pirlygenes.tumor_purity import (
     TCGA_MEDIAN_PURITY,
     _combine_purity_estimates,
     _lineage_purity_estimates,
+    _select_tumor_specific_genes,
     _summarize_gene_level_purity,
     _summarize_lineage_support,
 )
@@ -104,6 +105,22 @@ def test_combine_purity_penalizes_signature_only_calls_with_infiltration():
     assert lower <= overall <= upper
 
 
+def test_combine_purity_deprioritizes_unstable_low_signature_when_lineage_exists():
+    overall, lower, upper = _combine_purity_estimates(
+        sig_purity=0.03,
+        sig_lower=0.005,
+        sig_upper=0.08,
+        estimate_purity=0.35,
+        lineage_purity=0.11,
+        lineage_lower=0.08,
+        lineage_upper=0.14,
+        sig_stability=0.2,
+    )
+    assert overall > 0.10
+    assert lower >= 0.08
+    assert upper >= overall
+
+
 def test_signature_summary_ignores_high_outlier():
     overall, lower, upper, stability = _summarize_gene_level_purity(
         [0.03, 0.04, 0.05, 0.06, 0.80],
@@ -113,6 +130,17 @@ def test_signature_summary_ignores_high_outlier():
     assert 0.03 <= lower <= overall
     assert upper < 0.30
     assert 0.1 < stability < 1.0
+
+
+def test_prad_signature_panel_excludes_rearranged_immune_genes():
+    panel = _select_tumor_specific_genes("PRAD", n=30)
+    assert panel
+    assert not any(
+        gene.startswith(("IGH", "IGK", "IGL", "TRA", "TRB", "TRG", "TRD"))
+        for gene in panel
+    )
+    assert "TRGV9" not in panel
+    assert "TRGC1" not in panel
 
 
 # ── estimate_tumor_expression_ranges ──────────────────────────────


### PR DESCRIPTION
## What changed

This tightens the purity estimator in the places that were causing unstable low-end calls and makes the reporting clearer when the evidence channels disagree.

- rebuilt tumor-signature panel selection around stricter expression/specificity gates and explicit exclusion of brittle rearranged / generic genes
- reused the same robust cancer-type signature panels in the plotting / signature-ranking paths, while still backfilling with legacy z-score genes so broader embedding behavior stays stable
- simplified evidence integration so a weak, unstable signature panel no longer acts as a hard lower anchor when the lineage signal is coherent
- surfaced that integration decision in the text reports and added the long/short transcript index to the sample quality section
- added regression coverage for signature-panel hygiene and for the lineage-over-signature integration case

## Why it changed

The root issue was that a fragile tumor-specific signature panel could undercall purity and then drag the combined estimate and interval downward even when lineage markers still supported the working cancer type. That was especially misleading in inflamed or biologically atypical samples where a few canonical markers were suppressed.

This change keeps the estimator configurable through the existing parameter blob, but reduces the number of places where brittle signature genes can dominate the result.

## Impact

- purity intervals should be less likely to collapse to implausibly low lower bounds just because the signature channel is noisy
- candidate ranking stays family-aware and exposes same-family alternatives more cleanly
- reports now say when the signature channel was explicitly downweighted instead of hiding that decision
- sample-quality reporting is more transparent for FFPE / degradation ambiguity because the long/short transcript index is shown directly

## Validation

- `pytest -q tests/test_tumor_expression.py tests/test_decomposition.py tests/test_plot_and_cli.py`
- local rs sample re-evaluation to confirm the PRAD call no longer bottoms out at the previous spurious lower tail
