### PR TITLE
fix(plot): make CTA "tumor-only" label unambiguous

### DIFF
--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -1876,10 +1876,18 @@ def plot_tumor_expression_ranges(
                             transform=ax_pct.get_yaxis_transform())
                 continue
             if isinstance(pct, float) and np.isinf(pct):
-                # TCGA has zero but sample has expression → tumor-specific
-                ax_pct.text(0.5, i, "tumor-only", fontsize=base_font - 2,
-                            color="#8b0000", fontweight="bold",
-                            ha="center", va="center",
+                # Sample expresses the gene but the TCGA cohort reference is
+                # zero — so this gene is absent from TCGA {cancer_code} but
+                # present in THIS sample. Draw a solid dark-red band across
+                # the row with white text inside so the reader can't mistake
+                # it for a tissue-decomposition claim or a general property
+                # of the cancer type.
+                ax_pct.axhspan(i - 0.35, i + 0.35, color="#6b0000",
+                               alpha=1.0, zorder=3, linewidth=0)
+                ax_pct.text(0.5, i, f"absent in TCGA {cancer_code}",
+                            fontsize=base_font - 2, color="white",
+                            fontweight="bold", ha="center", va="center",
+                            zorder=4,
                             transform=ax_pct.get_yaxis_transform())
                 continue
             bar_color = color if pct >= 0.5 else "#d4a017"

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.21.0"
+__version__ = "3.21.1"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary

The per-gene CTA plot's "vs <cancer_type> median" column used a floating dark-red "tumor-only" label whenever the TCGA cohort median was zero but the sample had expression. "tumor-only" is genuinely ambiguous — it reads as any of:

1. unique to this sample's tumor (the actual meaning)
2. a general property of the cancer type
3. a tissue-decomposition claim ("only in the tumor compartment")

In context (1) is correct: the gene is absent from the TCGA cohort reference but present in this sample.

This PR replaces the floating text with a full-width dark-red band across the row and bold white text inside reading **"absent in TCGA <cancer_code>"**. Reads at a glance, can't be mistaken for a decomposition claim.

## Before → After

Before: small dark-red italic-ish text "tumor-only" floating at x=0.5 in axes coordinates, on the otherwise-empty row.

After: solid `#6b0000` band spanning the full x-axis for that row (`axhspan(i-0.35, i+0.35)`, `zorder=3`); bold white text "absent in TCGA PRAD" centered on the band.

## Test plan

- [x] `tests/test_plot_and_cli.py` + `tests/test_tumor_expression.py` still pass (40/40)
- [x] Preview PNG rendered to confirm visual — see attached in PR discussion if needed