### PR TITLE
fix: move standalone decomposition PNGs to figures/, trim titles

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -288,6 +288,9 @@ def analyze(
 
     print("[analysis] Running broad-compartment decomposition...")
     decomp_png = None
+    composition_png = None
+    components_png = None
+    candidates_png = None
     candidate_codes = [row["code"] for row in analysis.get("candidate_trace", [])[:4]]
     candidate_tsv = "%s-cancer-candidates.tsv" % prefix if prefix else "cancer-candidates.tsv"
     import pandas as pd
@@ -623,6 +626,12 @@ def analyze(
     png_files = [
         summary_png,
         decomp_png,
+        # Standalone decomposition PNGs — composition / component breakdown
+        # / candidate bars. Historically missed the move-to-figures/ step
+        # because they weren't listed here.
+        composition_png,
+        components_png,
+        candidates_png,
         purity_png,
         "%s-immune.png" % prefix if prefix else "immune.png",
         "%s-tumor.png" % prefix if prefix else "tumor.png",

--- a/pirlygenes/decomposition/plot.py
+++ b/pirlygenes/decomposition/plot.py
@@ -251,11 +251,9 @@ def plot_decomposition_candidates(
     # segment labels — the title still sits above the legend.
     ax.legend(loc="lower center", bbox_to_anchor=(0.5, 1.02),
               ncol=3, frameon=False, fontsize=9)
-    ax.set_title(
-        "Sample decomposition candidates\n"
-        "(each bar = one candidate's estimated sample composition)",
-        fontweight="bold", pad=28,
-    )
+    # Title kept single-line — the per-bar segments + legend already
+    # explain that each row is one candidate's composition.
+    ax.set_title("Sample decomposition candidates", fontweight="bold", pad=28)
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
     fig.tight_layout()

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -2509,7 +2509,7 @@ def plot_purity_adjusted_targets(
     ax1.set_yticklabels(labels, fontsize=8)
     ax1.set_xlabel("Expression (TPM)")
     ax1.set_xscale("symlog", linthresh=1)
-    ax1.set_title(f"Purity-adjusted tumor expression\n({cancer_code}, purity={purity:.0%})")
+    ax1.set_title(f"Purity-adjusted tumor expression — {cancer_code} (purity={purity:.0%})")
     ax1.invert_yaxis()
     ax1.legend(fontsize=8, loc="lower right")
 
@@ -3888,11 +3888,8 @@ def plot_cancer_type_disjoint_genes(
     ax.set_yticks(y)
     ax.set_yticklabels(labels, fontsize=8)
     ax.set_xlabel("Signature similarity score", fontsize=10)
-    ax.set_title(
-        "Cancer type similarity score\n"
-        "(mean percentile rank of sample expression among signature genes)",
-        fontsize=11,
-    )
+    # Definition belongs on the axis label, not in a subtitle.
+    ax.set_title("Cancer type similarity score", fontsize=11)
     ax.invert_yaxis()
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
@@ -3962,7 +3959,7 @@ def plot_cohort_heatmap(
     ax.set_xticklabels(codes, fontsize=7, rotation=90)
     ax.set_yticks(range(len(present)))
     ax.set_yticklabels(present, fontsize=4)
-    ax.set_title(f"Curated cancer-type genes × TCGA cancer types\n({subtitle})", fontsize=11)
+    ax.set_title(f"Curated cancer-type genes × TCGA cancer types — {subtitle}", fontsize=11)
     fig.colorbar(im, ax=ax, label=cbar_label, shrink=0.6)
     fig.tight_layout()
 
@@ -3996,7 +3993,7 @@ def plot_cohort_disjoint_counts(
     ax.set_yticks(y)
     ax.set_yticklabels(labels, fontsize=7)
     ax.set_xlabel(f"Disjoint signature genes (of {n_genes} max)", fontsize=10)
-    ax.set_title("Cancer-type-specific disjoint gene counts\n(genes uniquely overexpressed vs all other types)", fontsize=11)
+    ax.set_title("Cancer-type-specific disjoint gene counts", fontsize=11)
     ax.invert_yaxis()
 
     for i, (code, count) in enumerate(stats):
@@ -4122,7 +4119,7 @@ def plot_cohort_therapy_targets(
     ax.set_xticklabels(codes, fontsize=7, rotation=90)
     ax.set_yticks(range(len(present)))
     ax.set_yticklabels(present, fontsize=6)
-    ax.set_title(f"Therapy targets × TCGA cancer types\n({subtitle})", fontsize=11)
+    ax.set_title(f"Therapy targets × TCGA cancer types — {subtitle}", fontsize=11)
     fig.colorbar(im, ax=ax, label=cbar_label, shrink=0.6)
     fig.tight_layout()
 
@@ -4194,7 +4191,7 @@ def _plot_geneset_by_cancer_heatmap(
     ax.set_xticklabels(codes, fontsize=7, rotation=90)
     ax.set_yticks(range(len(present)))
     ax.set_yticklabels(present, fontsize=5 if len(present) > 50 else 6)
-    ax.set_title(f"{title}\n({subtitle})", fontsize=11)
+    ax.set_title(f"{title} — {subtitle}", fontsize=11)
     fig.colorbar(im, ax=ax, label=cbar_label, shrink=0.6)
     fig.tight_layout()
 
@@ -4263,7 +4260,7 @@ def plot_cohort_ctas(
     ax.set_xticklabels(codes_clean, fontsize=7, rotation=90)
     ax.set_yticks(range(len(present)))
     ax.set_yticklabels(present, fontsize=6)
-    ax.set_title(f"Cancer-testis antigens × cancer types (top 50)\n({subtitle})", fontsize=11)
+    ax.set_title(f"Cancer-testis antigens × cancer types (top 50) — {subtitle}", fontsize=11)
     fig.colorbar(im, ax=ax, label=cbar_label, shrink=0.6)
     fig.tight_layout()
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.22.2"
+__version__ = "3.22.3"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary

Two cleanups spotted while reviewing `rs/pirlygenes-output/`:

### 1. Decomposition standalone PNGs weren't moving into `figures/`

After a sample analysis you get this layout:

\`\`\`
pirlygenes-output/
├── figures/
│   ├── sample-decomposition.png     ← composite 4-panel (in figures/)
│   ├── sample-purity.png
│   └── ...
├── sample-decomposition-candidates.png   ← orphaned, should be in figures/
├── sample-decomposition-components.png   ← same
├── sample-decomposition-composition.png  ← same
└── sample-analysis.md
\`\`\`

The three standalone decomposition PNGs (added in #40 / the earlier v3.18.0 work) were created by the CLI but never added to the `png_files` list at `cli.py:623` that drives the \"move into figures/\" step. So they ended up in the output root instead.

Fix: initialize the three variables to `None` at the same spot as `decomp_png`, and include them in the move list.

### 2. Multi-line titles trimmed where the second line was obvious

The candidate-bars plot title was \`\"Sample decomposition candidates\\n(each bar = one candidate's estimated sample composition)\"\`. The second line is redundant — the segmented bars + legend already show that. Same pattern across several other plots.

Dropped entirely:
- `Sample decomposition candidates` (was + \"each bar = one candidate's estimated sample composition\")
- `Cancer type similarity score` (was + \"mean percentile rank of sample expression among signature genes\" — definition belongs on axis label, not title)
- `Cancer-type-specific disjoint gene counts` (was + \"genes uniquely overexpressed vs all other types\")

Merged `\\n({subtitle})` footers into single-line \`\" — {subtitle}\"\` for cancer-type / therapy / CTA heatmaps and purity-adjusted tumor expression.

Kept the second line where it carries non-obvious info (therapy-target safety tissue list, purity-adjustment caveat).

## Test plan

- [x] 158/158 tests pass
- [ ] Manual: verify output layout on re-run — orphan PNGs now land under `figures/`