### PR TITLE
feat: TPM-space TME subtraction + TME-explainable flag

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1485,16 +1485,36 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                  "These can be targeted by antibody-drug conjugates, CAR-T, "
                  "or bispecific T-cell engagers.\n")
     if len(surface_targets):
-        lines.append(f"| Gene | {value_label} | Range | Observed | vs TCGA | TCGA %ile | Therapies |")
-        lines.append("|------|-----------|-------|----------|---------|-----------|-----------|")
+        lines.append(
+            f"| Gene | {value_label} | Range | Observed | vs TCGA | TCGA %ile | TME | Therapies |"
+        )
+        lines.append(
+            "|------|-----------|-------|----------|---------|-----------|-----|-----------|"
+        )
         for _, row in surface_targets.head(20).iterrows():
             bold = "**" if row["therapies"] else ""
             vs_tcga = row["pct_cancer_median"]
+            # TME warning: "⚠" when a healthy reference tissue alone
+            # could explain ≥50% of the sample signal, so the reported
+            # tumor-cell attribution is unreliable (tracked via the
+            # `tme_explainable` flag computed in estimate_tumor_
+            # expression_ranges; see issue #45).
+            tme_warn = "⚠" if row.get("tme_explainable") else ""
             lines.append(
                 f"| {bold}{row['symbol']}{bold} | {row['median_est']:.1f} | "
                 f"{row['est_1']:.1f}\u2013{row['est_9']:.1f} | {row['observed_tpm']:.1f} | "
                 f"{'%.1fx' % vs_tcga if pd.notna(vs_tcga) else '—'} | {row['tcga_percentile']:.0%} | "
-                f"{row['therapies']} |"
+                f"{tme_warn} | {row['therapies']} |"
+            )
+        if (
+            "tme_explainable" in surface_targets.columns
+            and surface_targets.head(20)["tme_explainable"].any()
+        ):
+            lines.append(
+                "\n⚠ = sample signal could be entirely explained by a single healthy "
+                "tissue's expression (max across non-reproductive tissues ≥ 50% of "
+                "observed TPM). The tumor-cell attribution for these genes is "
+                "unreliable — consider stromal / immune origin."
             )
     else:
         lines.append("No surface targets above threshold.\n")

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -2127,6 +2127,68 @@ def estimate_tumor_expression_ranges(
             if bg:
                 decomp_backgrounds.append(bg)
 
+    # Per-gene max across healthy tissues (precomputed vector; used to
+    # flag rows where sample signal could be entirely TME-explained).
+    # Vectorized once here to avoid a per-gene `.loc[].max()` inside the
+    # main loop — that was a measured ~30x slowdown on full panels.
+    if ntpm_nonrepro:
+        _max_healthy = ref_dedup[ntpm_nonrepro].astype(float).max(axis=1)
+        max_healthy_tpm_by_symbol = _max_healthy.to_dict()
+    else:
+        max_healthy_tpm_by_symbol = {}
+
+    # --- Full-coverage TPM-space TME background (fixes issue #45) --------
+    #
+    # The decomposition's `tme_background_hk` dict only covers genes that
+    # were in the decomposition's signature panel. For target-list genes
+    # like FN1 / COL1A1 / IGKC that AREN'T signature genes but ARE clearly
+    # stromal/immune expressed, `tme_background_hk.get(sym, 0.0)` returns 0
+    # → no TME subtraction → `tumor_tpm ≈ sample_tpm / purity` which
+    # inflates the "Tumor TPM" reported in the target table.
+    #
+    # Fix: when we have a decomposition result with a `fractions` dict,
+    # build a full-gene signature matrix using the same cell-type /
+    # bulk-tissue references the decomposition engine uses, and compute:
+    #
+    #   tme_bg_tpm[g] = Σ_{c ≠ tumor} fractions[c] × ref_tpm[g, c]
+    #
+    # This gives a per-gene TPM-scale TME background for every gene in
+    # the reference, not just signature genes. The formula in the loop
+    # prefers this TPM-space path when available and falls back to the
+    # HK-fold path when it isn't.
+    tme_bg_tpm_by_symbol = None
+    if decomposition_results:
+        top_fractions = (
+            getattr(decomposition_results[0], "fractions", None) or {}
+        )
+        non_tumor_components = [
+            c for c, f in top_fractions.items() if c != "tumor" and f > 0
+        ]
+        if non_tumor_components:
+            from .decomposition.signature import build_signature_matrix
+            try:
+                _genes, sym_list, matrix, _cols = build_signature_matrix(
+                    non_tumor_components,
+                    gene_subset=None,
+                    sample_by_eid=None,
+                )
+                non_tumor_fracs = np.array(
+                    [float(top_fractions[c]) for c in non_tumor_components],
+                    dtype=float,
+                )
+                # Per-gene expected non-tumor contribution to sample TPM:
+                # Σ_c fractions[c] × ref_tpm[g, c]. `fractions[c]` is
+                # already scaled by (1 − tumor_fraction), so summing
+                # directly gives absolute non-tumor TPM — no extra
+                # (1 − p) multiplier needed at the formula site.
+                tme_tpm_vec = matrix @ non_tumor_fracs
+                tme_bg_tpm_by_symbol = {
+                    str(sym): float(val)
+                    for sym, val in zip(sym_list, tme_tpm_vec)
+                }
+            except Exception:
+                tme_bg_tpm_by_symbol = None
+
     # --- Purity-adjusted TCGA (HK-normalized, then deconvolved) ---
     # For each FPKM cancer-type column, compute:
     #   tcga_hk = FPKM / FPKM_HK_median
@@ -2196,13 +2258,28 @@ def estimate_tumor_expression_ranges(
         tme_fold_med = float(np.median(tme_folds))
         tme_fold_hi = float(np.percentile(tme_folds, 75))
 
-        # 3×3 grid in HK-fold space, then convert back to TPM
+        # 9-point estimate grid. TPM-space path (preferred) uses the
+        # decomposition's per-gene expected TME contribution directly.
+        # HK-fold path is the fallback when no decomposition is available
+        # or the gene is absent from the reference.
         estimates = []
-        for bg in [tme_fold_lo, tme_fold_med, tme_fold_hi]:
-            for p in [p_lo, p_med, p_hi]:
-                tumor_fold = max(0.0, (sample_fold - (1 - p) * bg) / p)
-                tumor_tpm = tumor_fold * sample_hk_median
-                estimates.append(tumor_tpm)
+        if tme_bg_tpm_by_symbol is not None and symbol in tme_bg_tpm_by_symbol:
+            bg_tpm_mid = tme_bg_tpm_by_symbol[symbol]
+            # Uncertainty on the TME estimate itself: ±50%. This captures
+            # the fact that bulk HPA / cell-type references may under- or
+            # over-estimate the actual infiltrate composition in the
+            # specific sample (e.g. reactive tumor stroma expresses FN1
+            # higher than resting fibroblasts).
+            for bg_tpm in [bg_tpm_mid * 0.5, bg_tpm_mid, bg_tpm_mid * 1.5]:
+                for p in [p_lo, p_med, p_hi]:
+                    tumor_tpm = max(0.0, (observed - bg_tpm)) / p
+                    estimates.append(tumor_tpm)
+        else:
+            for bg in [tme_fold_lo, tme_fold_med, tme_fold_hi]:
+                for p in [p_lo, p_med, p_hi]:
+                    tumor_fold = max(0.0, (sample_fold - (1 - p) * bg) / p)
+                    tumor_tpm = tumor_fold * sample_hk_median
+                    estimates.append(tumor_tpm)
         estimates.sort()
         median_est = float(np.median(estimates))
 
@@ -2232,6 +2309,13 @@ def estimate_tumor_expression_ranges(
         else:
             vs_tcga = None
 
+        # TME-explainability flag: the max TPM this gene reaches in ANY
+        # single healthy reference tissue. If the sample value is below
+        # that ceiling, the signal could in principle come entirely from
+        # non-tumor cells — the reported Tumor TPM is then unreliable.
+        max_healthy_tpm = float(max_healthy_tpm_by_symbol.get(symbol, 0.0))
+        tme_explainable = max_healthy_tpm >= observed * 0.5
+
         # Categorize
         is_cta = symbol in cta_symbols
         is_surface = symbol in surf_symbols
@@ -2256,6 +2340,8 @@ def estimate_tumor_expression_ranges(
             "tme_fold_lo": round(tme_fold_lo, 4),
             "tme_fold_med": round(tme_fold_med, 4),
             "tme_fold_hi": round(tme_fold_hi, 4),
+            "max_healthy_tpm": round(max_healthy_tpm, 2),
+            "tme_explainable": bool(tme_explainable),
             **{f"est_{i+1}": round(estimates[i], 2) for i in range(9)},
             "median_est": round(median_est, 2),
             "pct_cancer_median": round(vs_tcga, 2) if vs_tcga is not None else None,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.22.4"
+__version__ = "3.23.0"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary

Addresses #45. Two changes:

### 1. Full-coverage TPM-space TME background

`tme_background_hk` on each decomposition result only covers signature genes. Target-table genes like FN1 / COL1A1 / IGKC aren't signature genes, so they got `tme_background = 0` and passed through the purity formula as if entirely tumor-derived.

When we have a decomposition result with a `fractions` dict, we now build a **full-gene** signature matrix using the same cell-type / bulk-tissue references the engine already uses:

```
tme_bg_tpm[g] = Σ_{c ≠ tumor} fractions[c] × ref_tpm[g, c]
```

Applied directly: `tumor_tpm = max(0, sample_tpm − tme_bg_tpm) / purity`. Falls back to the HK-fold tissue-panel path for genes not in the reference.

### 2. `tme_explainable` flag + ⚠ annotation

Per gene: max TPM across healthy non-reproductive reference tissues. If that ceiling ≥ 50% of the sample value, a single healthy tissue alone could plausibly explain the signal — tumor-cell attribution is unreliable.

The surface-target table in the sample report now adds a `TME` column; rows with the flag get a ⚠ symbol and a footnote (\"sample signal could be entirely explained by a single healthy tissue's expression ... consider stromal / immune origin\").

## Known limit (not fixed here)

The `1/purity` division in the formula structurally inflates every gene's estimate at low purity. For genes like FN1 where *reactive tumor stroma* expresses them higher than any healthy reference, the reference-based subtraction can't fully compensate. The ⚠ flag surfaces this to the reader rather than burying it in a misleading \"Tumor TPM\" number.

Proper fix requires cancer-specific reactive-stroma reference profiles (TCGA-derived) — worth a separate design effort if we want quantitative tumor-cell TPM for stromal-origin genes.

## Performance

Max-across-healthy-tissues is vectorized once outside the per-gene loop (was a per-gene `.loc[].max()` inside — first naive version took 36m on the full suite; now back to ~27s).

## Test plan

- [x] 158/158 tests pass
- [x] Existing `test_generate_target_report_is_mode_aware` still passes (guarded the new column access since tests construct hand-rolled ranges_df)

## Output schema additions

- `max_healthy_tpm` — max TPM across healthy non-reproductive nTPM tissues
- `tme_explainable` — bool, true when `max_healthy_tpm ≥ 0.5 × observed_tpm`