### PR TITLE
fix: CTA shrinkage floor; investigate matched-normal component

### DIFF
--- a/pirlygenes/decomposition/signature.py
+++ b/pirlygenes/decomposition/signature.py
@@ -195,6 +195,25 @@ def build_signature_matrix(components, gene_subset=None, sample_by_eid=None):
 
     cols = []
     for comp in components:
+        # Priority 0: explicit matched-normal-epithelium convention,
+        # `matched_normal_<tissue>` — used by `get_template_components`
+        # for solid_primary + cancer_type to admit admixed normal-tissue
+        # glands as a non-tumor compartment. Directly resolves to the
+        # bulk nTPM tissue column.
+        if comp.startswith("matched_normal_"):
+            tissue = comp[len("matched_normal_"):]
+            tissue_col = f"nTPM_{tissue}"
+            if tissue_col in bulk.columns:
+                vals = (
+                    bulk[tissue_col]
+                    .astype(float)
+                    .reindex(genes)
+                    .fillna(0.0)
+                    .values
+                )
+                cols.append(vals)
+                continue
+
         # Priority 1: composite tissue category (best-match selection)
         category = COMPONENT_TO_CATEGORY.get(comp)
         if category is not None:

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -2304,6 +2304,13 @@ def estimate_tumor_expression_ranges(
         if tme_explainable:
             k_shrinkage = 0.40
 
+        # Shrinkage floor: when the cohort prior is near-zero (e.g.
+        # CTAs — activated in a minority of samples, so median = 0),
+        # the prior mean is uninformative. Empirical-Bayes shrinkage
+        # toward 0 would wrongly pull real sample-specific signal
+        # down. Skip shrinkage in that regime and trust the sample.
+        skip_shrinkage = cohort_prior_tpm < 1.0
+
         # 9-point estimate grid. TPM-space path (preferred) uses the
         # decomposition's per-gene expected TME contribution directly.
         # HK-fold path is the fallback when no decomposition is
@@ -2313,8 +2320,14 @@ def estimate_tumor_expression_ranges(
         # contribute more than the observed signal if a single healthy
         # tissue could explain it alone).
         def _apply_priors(raw_tumor_tpm, purity_used):
-            w_sample = float(purity_used) / (float(purity_used) + k_shrinkage)
-            shrunk = w_sample * raw_tumor_tpm + (1.0 - w_sample) * cohort_prior_tpm
+            if skip_shrinkage:
+                shrunk = raw_tumor_tpm
+            else:
+                w_sample = float(purity_used) / (float(purity_used) + k_shrinkage)
+                shrunk = (
+                    w_sample * raw_tumor_tpm
+                    + (1.0 - w_sample) * cohort_prior_tpm
+                )
             if tme_explainable:
                 shrunk = min(shrunk, observed)
             return max(0.0, shrunk)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.24.0"
+__version__ = "3.24.1"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_tumor_expression.py
+++ b/tests/test_tumor_expression.py
@@ -312,6 +312,54 @@ def test_ranges_tme_explainable_clamps_at_observed():
     )
 
 
+def test_ranges_skips_shrinkage_when_cohort_prior_is_near_zero():
+    """CTAs with cohort median ≈ 0 (activated in a minority of samples)
+    must NOT be shrunk toward zero by empirical-Bayes — the cohort
+    median is uninformative for sparsely-expressed genes.
+    """
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    from pirlygenes.gene_sets_cancer import CTA_gene_id_to_name, pan_cancer_expression
+    import pandas as pd
+
+    # Pick 3 CTAs with cohort_prior near zero in PRAD.
+    ref = pan_cancer_expression().drop_duplicates(subset="Symbol").set_index("Symbol")
+    cta_map = CTA_gene_id_to_name()
+    zero_cohort_ctas = []
+    for gid, sym in cta_map.items():
+        if sym in ref.index and float(ref.loc[sym, "FPKM_PRAD"]) < 0.1:
+            zero_cohort_ctas.append((gid, sym))
+        if len(zero_cohort_ctas) >= 3:
+            break
+    assert zero_cohort_ctas, "Should find at least one near-zero CTA in PRAD"
+
+    rows = [{"gene_id": gid, "gene_name": sym, "TPM": 50.0}
+            for gid, sym in zero_cohort_ctas]
+    rows.extend([
+        {"gene_id": "ENSG00000075624", "gene_name": "ACTB",   "TPM": 150.0},
+        {"gene_id": "ENSG00000156508", "gene_name": "EEF1A1", "TPM": 300.0},
+        {"gene_id": "ENSG00000111640", "gene_name": "GAPDH",  "TPM": 100.0},
+    ])
+    df = pd.DataFrame(rows)
+    purity = {"overall_lower": 0.30, "overall_estimate": 0.35, "overall_upper": 0.40}
+    out = estimate_tumor_expression_ranges(df, "PRAD", purity)
+
+    # Near-zero cohort prior CTAs should land at roughly `observed/purity`,
+    # the raw deconvolution — NOT shrunk toward zero.
+    cta_symbols = {sym for _, sym in zero_cohort_ctas}
+    ctas = out[out["symbol"].isin(cta_symbols)]
+    assert len(ctas) > 0
+    for _, row in ctas.iterrows():
+        # observed=50, purity~0.35 → raw ≈ 143. Allow some flexibility
+        # for the 3x3 TME/purity grid's median.
+        assert row["cohort_prior_tpm"] < 1.0, (
+            f"{row['symbol']} cohort prior {row['cohort_prior_tpm']} not near zero"
+        )
+        assert row["median_est"] > 100, (
+            f"{row['symbol']} median_est {row['median_est']} was shrunk toward zero "
+            f"despite near-zero cohort prior (should be ~143)"
+        )
+
+
 def test_ranges_low_purity_shrinks_toward_cohort_prior():
     """At very low purity, the sample-based estimator has high variance
     (1/purity inflates). Shrinkage should pull estimates toward the


### PR DESCRIPTION
## Summary

Follow-up on #45 addressing two user-reported concerns:

### 1. CTAs shrunk toward zero (fixed)

The v3.24.0 empirical-Bayes shrinkage pulled estimates toward \`cohort_prior_tpm\`, which for CTAs is typically 0 (activated in a minority of TCGA samples, so the cohort median reads 0 by definition — not because typical tumors express 0). DAZ3 / NUTM1 / CAGE1 / PAGE1 etc. got dragged to ~0.64 × raw_estimate when they should have been at raw_estimate.

**Fix**: when \`cohort_prior_tpm < 1.0\` TPM the prior is uninformative; skip shrinkage and trust the sample. \`tme_explainable\` clamp still applies.

Before (v3.24.0): \`observed=50, purity=0.35, cohort_prior=0 → median_est ≈ 91\` (shrunk)
After (v3.24.1): \`observed=50, purity=0.35, cohort_prior=0 → median_est ≈ 143\` (raw 50/0.35, no shrinkage)

### 2. Matched-normal epithelium subtraction (investigated, not shipped)

Explored adding \`matched_normal_<tissue>\` as a dynamic component to \`solid_primary\` so admixed normal glands (KLK3 in prostate, SFTPB in lung, ALB in liver, ...) get their own compartment rather than being attributed to tumor. Verified via reference data that CTAs are safe: 97-99% of CTAs have nTPM < 5 in matched normal across PRAD/BRCA/LUAD/SKCM, so NNLS wouldn't \"steal\" CTA signal.

**Two clinical tests regressed** when I added the component: PRAD+smooth_muscle mix flipped solid_primary → met_soft_tissue, and bg002179 flipped COAD → READ. That's not test brittleness — adding a component genuinely shifts NNLS template selection, and rebalancing template scoring without a principled calibration would risk further regressions.

**Conservative outcome**: kept the \`matched_normal_<tissue>\` prefix handling in \`signature.build_signature_matrix\` (harmless — only triggers when that prefix is used, which no template currently emits) so the plumbing is in place for a future calibrated rollout. No decomposition template changes shipped.

The existing \`tme_explainable\` flag + clamp already handles the KLK3 case adequately: observed=500, max_healthy_prostate=7700 → tme_explainable=True → median_est clamped at 500. The report shows \`vs_TCGA=0.05x\` (sample way below typical PRAD) and the ⚠ flag surfaces the ambiguity.

## Test plan

- [x] 161/161 tests pass (+1 new)
- [x] \`test_ranges_skips_shrinkage_when_cohort_prior_is_near_zero\` — real CTA IDs with cohort_prior < 0.1 in PRAD must produce median_est ≈ observed/purity