### PR TITLE
fix(load): defensive copy in get_data cache (v3.26.0, closes #29)

### DIFF
--- a/pirlygenes/load_dataset.py
+++ b/pirlygenes/load_dataset.py
@@ -56,5 +56,7 @@ def get_data(name, _dataframes_dict=None):
         candidates.append(candidate + ".csv")
     for candidate in candidates:
         if candidate in _dataframes_dict:
-            return _dataframes_dict[candidate]
+            # Return a copy so callers that mutate in place (e.g. df["c"]=...,
+            # df.fillna(0, inplace=True)) can't corrupt the shared cache.
+            return _dataframes_dict[candidate].copy()
     raise ValueError(f"Dataset {name} not found")

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.25.0"
+__version__ = "3.26.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -18,6 +18,17 @@ def test_get_data_missing_raises():
         ld.get_data("does-not-exist", _dataframes_dict={})
 
 
+def test_get_data_returns_copy_not_cached_reference():
+    # Mutating the returned DataFrame must not corrupt the cached copy that
+    # subsequent callers will get (issue #29).
+    first = ld.get_data("ADC-trials")
+    first["_should_not_persist"] = 1
+    first.drop(first.index, inplace=True)
+    second = ld.get_data("ADC-trials")
+    assert "_should_not_persist" not in second.columns
+    assert len(second) > 0
+
+
 def test_get_all_csv_paths_contains_core_dataset():
     paths = ld.get_all_csv_paths()
     assert any(Path(p).name == "ADC-trials.csv" for p in paths)


### PR DESCRIPTION
## Summary

- Return a copy from `get_data()` so callers that mutate in place cannot corrupt the shared module-level cache introduced in PR #24
- Adds regression test: mutate + drop all rows on a returned frame, re-fetch, assert cache is intact
- Bumps version to 3.26.0

## Context

The cache gave a ~4× test speedup by skipping repeated disk reads, but returned cached DataFrames by reference. All current callers happen to use functional methods (no in-place mutation), so this was a latent hazard rather than an active bug — fixing it eliminates an easy foot-gun.

Deep copy is milliseconds on our 20K-row reference frames, negligible next to the 6s disk read the cache amortizes.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 175 passed, 1 skipped (was 174)
- [x] New `test_get_data_returns_copy_not_cached_reference` covers the mutation hazard

Closes #29.