### PR TITLE
fix(cli): clean stale prefix outputs before writing (v3.26.1, closes #30)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -12,6 +12,7 @@
 
 from argh import named, dispatch_commands
 import json
+from pathlib import Path
 from typing import Optional, Set
 
 from .version import print_name_and_version
@@ -137,6 +138,42 @@ def _parse_csv_tokens(arg_value: Optional[str]):
     return tokens or None
 
 
+def _clean_prefix_outputs(out_dir: Path, prefix_path: str) -> int:
+    """Delete stale files from a prior run sharing the same output prefix.
+
+    Removes files in ``out_dir`` (and the ``figures/`` subdir) whose name
+    starts with ``{prefix_basename}-``, so a partial rerun cannot leave
+    misleading artifacts from an earlier successful run. Only touches
+    files matching our prefix — anything else the user placed in the
+    directory is preserved (issue #30).
+
+    Also removes ``{prefix_basename}-vs-cancer`` scatter subdirectories.
+    Returns the number of files deleted.
+    """
+    base = Path(prefix_path).name
+    if not base:
+        return 0
+    stale_prefix = f"{base}-"
+    removed = 0
+    for directory in (out_dir, out_dir / "figures"):
+        if not directory.is_dir():
+            continue
+        for path in directory.iterdir():
+            if path.is_file() and path.name.startswith(stale_prefix):
+                path.unlink()
+                removed += 1
+            elif path.is_dir() and path.name.startswith(stale_prefix):
+                for child in path.iterdir():
+                    if child.is_file():
+                        child.unlink()
+                        removed += 1
+                try:
+                    path.rmdir()
+                except OSError:
+                    pass
+    return removed
+
+
 @named("analyze")
 def analyze(
     input_path: str,
@@ -170,6 +207,10 @@ def analyze(
         prefix = str(out_dir / output_image_prefix)
     else:
         prefix = str(out_dir / "sample")
+
+    stale_removed = _clean_prefix_outputs(out_dir, prefix)
+    if stale_removed:
+        print(f"[output] Removed {stale_removed} stale files from prior run")
 
     df_expr = load_expression_data(
         input_path,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.26.0"
+__version__ = "3.26.1"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_cli_output_cleanup.py
+++ b/tests/test_cli_output_cleanup.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from pirlygenes.cli import _clean_prefix_outputs
+
+
+def _touch(p: Path, text: str = "") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return p
+
+
+def test_clean_prefix_removes_prefixed_files_only(tmp_path):
+    # Prior-run files matching prefix base
+    _touch(tmp_path / "sample-summary.md", "old")
+    _touch(tmp_path / "sample-decomposition.png", "old")
+    _touch(tmp_path / "figures" / "sample-targets.png", "old")
+    # Files that must NOT be deleted
+    _touch(tmp_path / "README.md", "keep")
+    _touch(tmp_path / "other-user-file.txt", "keep")
+    _touch(tmp_path / "figures" / "not-ours.png", "keep")
+
+    prefix = str(tmp_path / "sample")
+    removed = _clean_prefix_outputs(tmp_path, prefix)
+
+    assert removed == 3
+    assert not (tmp_path / "sample-summary.md").exists()
+    assert not (tmp_path / "sample-decomposition.png").exists()
+    assert not (tmp_path / "figures" / "sample-targets.png").exists()
+    assert (tmp_path / "README.md").exists()
+    assert (tmp_path / "other-user-file.txt").exists()
+    assert (tmp_path / "figures" / "not-ours.png").exists()
+
+
+def test_clean_prefix_removes_scatter_subdir(tmp_path):
+    scatter = tmp_path / "sample-vs-cancer"
+    _touch(scatter / "PRAD.png", "old")
+    _touch(scatter / "LUAD.png", "old")
+    _touch(tmp_path / "sample-summary.md", "old")
+
+    removed = _clean_prefix_outputs(tmp_path, str(tmp_path / "sample"))
+
+    assert removed == 3
+    assert not scatter.exists()
+    assert not (tmp_path / "sample-summary.md").exists()
+
+
+def test_clean_prefix_custom_image_prefix(tmp_path):
+    # When user supplies output_image_prefix="bg002", only bg002-* should be cleaned
+    _touch(tmp_path / "bg002-summary.md", "old")
+    _touch(tmp_path / "sample-summary.md", "from-different-sample")
+
+    removed = _clean_prefix_outputs(tmp_path, str(tmp_path / "bg002"))
+    assert removed == 1
+    assert not (tmp_path / "bg002-summary.md").exists()
+    assert (tmp_path / "sample-summary.md").exists()
+
+
+def test_clean_prefix_empty_or_missing_dir(tmp_path):
+    # Calling on an empty / nonexistent dir should be a no-op
+    assert _clean_prefix_outputs(tmp_path, str(tmp_path / "sample")) == 0
+    assert _clean_prefix_outputs(tmp_path / "doesnotexist", str(tmp_path / "doesnotexist" / "sample")) == 0


### PR DESCRIPTION
## Summary

- New `_clean_prefix_outputs(out_dir, prefix_path)` helper deletes files in `out_dir` and `out_dir/figures/` whose name starts with `{prefix_basename}-`, plus any prefix-matching scatter subdirectory
- Called right after `out_dir.mkdir(...)` in `analyze` so partial reruns can't leave misleading artifacts from earlier runs
- Only touches files matching our prefix — preserves `README.md` and any user-placed files
- Bumps version to 3.26.1

## Why

Previously, run #1 would write the full output set; if run #2 failed mid-pipeline, the earlier `sample-decomposition.png` stayed in the directory under the same filename, and the user had no obvious signal that it was stale.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 179 passed, 1 skipped (was 175; +4 new)
- [x] `tests/test_cli_output_cleanup.py` covers: prefix-only deletion, figures/ subdir, scatter subdir, custom `output_image_prefix`, empty/missing-dir no-op

Closes #30.