### PR TITLE
fix(decomposition): exclude MHC-II + ribosomal from auto-picked markers (v3.26.2, closes #31)

### DIFF
--- a/pirlygenes/decomposition/engine.py
+++ b/pirlygenes/decomposition/engine.py
@@ -29,6 +29,43 @@ from .templates import (
 from ..gene_sets_cancer import housekeeping_gene_ids, pan_cancer_expression
 from ..tumor_purity import rank_cancer_type_candidates, _score_host_tissues
 
+
+# Marker symbols that must never be auto-selected by the specificity-based
+# rule, even when their HPA nTPM in a target component is high (issue #31).
+#
+# MHC-II / shared APC genes are expressed on B cells *and* macrophages,
+# dendritic cells, monocytes, and activated T cells. Auto-selecting them
+# as "B_cell markers" lets the NNLS re-route MHC-II signal into T_cell
+# and myeloid columns, distorting per-compartment fractions. The curated
+# ``COMPONENT_MARKERS`` in signature.py remains the source of truth for
+# B-cell-specific markers (MS4A1, CD79A, CD79B, CD19, BANK1).
+_AUTO_MARKER_EXCLUDED_SYMBOLS = frozenset({
+    "CD74",
+    "HLA-DRA", "HLA-DRB1", "HLA-DRB5",
+    "HLA-DPA1", "HLA-DPB1",
+    "HLA-DQA1", "HLA-DQB1",
+    "HLA-DMA", "HLA-DMB",
+    "HLA-DOA", "HLA-DOB",
+})
+
+
+def _is_ribosomal_protein_symbol(symbol: str) -> bool:
+    """RPL* / RPS* ribosomal proteins are broadly expressed and leak
+    into every compartment when auto-picked (issue #31, RPL18A showed up
+    as a B_cell marker).
+    """
+    if not isinstance(symbol, str):
+        return False
+    return symbol.startswith("RPL") or symbol.startswith("RPS")
+
+
+def _is_excluded_auto_marker(symbol: str) -> bool:
+    return (
+        symbol in _AUTO_MARKER_EXCLUDED_SYMBOLS
+        or _is_ribosomal_protein_symbol(symbol)
+    )
+
+
 DECOMPOSITION_PARAMETERS = {
     # ── Sample mode routing ──────────────────────────────────────────────
     # Controls which template set is evaluated.
@@ -402,6 +439,11 @@ def _select_marker_rows(
             if not keep[idx]:
                 continue
             if idx in chosen:
+                continue
+            # Block shared-APC (MHC-II) and ribosomal-protein leakage (#31).
+            # Curated markers above already ran, so genuine B/T/myeloid
+            # specifics are in; this only blocks the auto-pick residue.
+            if _is_excluded_auto_marker(str(symbols[idx])):
                 continue
             chosen.append(int(idx))
             if len(chosen) >= top_n_per_component:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.26.1"
+__version__ = "3.26.2"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -678,6 +678,53 @@ def test_plot_decomposition_candidates_empty_results_returns_none():
     assert plot_decomposition_candidates([]) is None
 
 
+def test_auto_marker_selection_excludes_mhc_ii_and_ribosomal(monkeypatch):
+    """#31: CD74 / HLA-D* / RPL* / RPS* must not be auto-picked as
+    component-specific markers, even when their reference nTPM is high
+    in the target component. Curated ``COMPONENT_MARKERS`` from
+    signature.py remains the source of truth.
+    """
+    import numpy as np
+    from pirlygenes.decomposition.engine import (
+        _AUTO_MARKER_EXCLUDED_SYMBOLS,
+        _select_marker_rows,
+    )
+
+    # Build a 3-component (T_cell, B_cell, myeloid) synthetic matrix where
+    # the first few "genes" are exactly the excluded symbols and happen to
+    # be high only in B_cell — so the specificity rule would otherwise
+    # auto-pick them.
+    tainted = ["CD74", "HLA-DPB1", "HLA-DQB1", "RPL18A", "RPS6"]
+    clean_b = ["BANK1", "MS4A1", "CD79A"]  # genuine B-cell markers
+    genes = tainted + clean_b + [f"OTHER{i}" for i in range(50)]
+    symbols = list(genes)  # symbol==gene_id for this toy case
+
+    n = len(genes)
+    mat = np.full((n, 3), 0.1)  # baseline in T_cell / B_cell / myeloid
+    # tainted genes: very high in B_cell only
+    for i in range(len(tainted)):
+        mat[i, 1] = 200.0
+    # clean b-cell markers: also high in B_cell
+    for i in range(len(tainted), len(tainted) + len(clean_b)):
+        mat[i, 1] = 150.0
+
+    fit_rows, _weights, marker_df = _select_marker_rows(
+        genes=genes,
+        symbols=symbols,
+        sig_matrix_hk=mat,
+        comp_names=["T_cell", "B_cell", "myeloid"],
+    )
+
+    auto_b_cell = marker_df[marker_df["component"] == "B_cell"]["symbol"].tolist()
+    for bad in tainted:
+        assert bad not in auto_b_cell, f"Auto-picked excluded marker {bad} for B_cell"
+
+    # The exclusion table itself must cover the MHC-II shared-APC genes
+    # that motivated issue #31 (guard against accidental deletion).
+    for required in ["CD74", "HLA-DPB1", "HLA-DQB1"]:
+        assert required in _AUTO_MARKER_EXCLUDED_SYMBOLS
+
+
 def test_candidate_composition_segments_sum_to_one():
     """(tumor, template_specific, shared_host) must sum to 1."""
     from types import SimpleNamespace


### PR DESCRIPTION
## Summary

- Auto-pick marker selection (``_select_marker_rows``) now skips MHC-II shared-APC genes (CD74, HLA-DRA/B, HLA-DPA1/B1, HLA-DQA1/B1, HLA-DMA/B, HLA-DOA/B) and all RPL*/RPS* ribosomal-protein symbols
- Curated ``COMPONENT_MARKERS`` remain the source of truth for component-specific markers; this only blocks the auto-pick residue
- New test asserts the excluded symbols cannot enter the auto-selected set even when their reference nTPM is artificially boosted in a target component
- Bumps version to 3.26.2

## Why

On an 89%-TME PRAD sample, the auto-selected B_cell markers were CD74, HLA-DPB1, HLA-DQB1, RPL18A — genes broadly expressed on myeloid and activated T cells. The NNLS re-routed MHC-II signal into T_cell and myeloid columns, under-crediting B_cell and over-crediting T_cell. Upstream curated markers (MS4A1, CD79A, CD79B, CD19, BANK1) weren't the problem; the issue was letting specificity-based auto-pick fall back to pan-APC genes.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 180 passed, 1 skipped (+1 new targeted test)

Closes #31.