### PR TITLE
feat(v4.0.0): sample-context as stage-1 attribution base layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,25 @@ pirlygenes data
 pirlygenes plot-cancer-cohorts sample1.tsv sample2.tsv sample3.tsv --cancer-type PRAD
 ```
 
+## Attribution flow: "make it make sense"
+
+`pirlygenes` treats every TPM in a bulk tumor sample as a claim that must be *attributed* to some source — and then explains away as much of it as possible before crediting the tumor. The goal is a conservative, defensible core of tumor-specific expression, not a lift of raw TPM straight into therapeutic target recommendations.
+
+The flow runs in five stages:
+
+1. **Sample context** (runs *first*, before any cancer-type inference). A `SampleContext` is inferred from the expression table alone — what **library prep** produced the data (poly-A capture, ribo-depletion, total RNA, or exome capture) and what **preservation / degradation** state the RNA is in (fresh-frozen, FFPE, partial degradation). This becomes a **base layer of expression expectations**: which genes are expected to be over- or under-represented for *artifactual* reasons, independent of biology. The context is propagated forward and every downstream stage reads from it.
+2. **Coarse healthy-tissue decomposition.** Broad non-tumor compartments (T cell, B cell, myeloid, fibroblast, endothelial, plus site-specific host tissue for met samples) are fit by weighted NNLS against curated marker panels, anchored to an externally-estimated tumor purity.
+3. **Fine TME-subtype / activation-state dissection** (in progress: CAF vs healthy fibroblast, TAM polarisation, exhausted T, tumor endothelium, etc.). Activated-state references refine the coarse compartment call into biologically actionable subsets.
+4. **Tumor-value adjustment.** Per gene, the TME and matched-normal contributions are subtracted from the observed TPM before dividing by purity. Genes whose observed signal is dominantly explained by non-tumor compartments are flagged `tme_explainable` rather than credited to the tumor.
+5. **Conservative tumor-specific core.** What remains after stages 1–4 is reported as a bounded per-gene tumor-expression range (9-point across low/median/high TME and low/median/high purity), with a low-purity caveat for samples below 20% purity where TME residuals would otherwise be amplified ≥5×.
+
+Each stage *adds* to the attribution chain; none replaces earlier stages. The `analyze` report (summary.md, analysis.md, targets.md) surfaces the chain so a reader can see *why* a number is what it is, not just the final value.
+
 ## The `analyze` command
 
 The main entry point for single-sample analysis. Takes a gene expression file (CSV, TSV, or Excel with a TPM column) and produces a comprehensive output directory with:
 
+- **Sample context inference** — library prep (poly-A / ribo-depleted / total RNA / exome capture) and preservation (fresh / FFPE / degraded) detected from the expression table; propagated to every downstream step as the base layer of expression expectations
 - **Sample quality assessment** — RNA degradation / FFPE detection (transcript-length gene pairs + tissue-matched MT/RP baselines) and cell line / cell culture detection
 - **Cancer type identification** — auto-detected or specified, scored against 33 TCGA types
 - **Tumor purity estimation** — three methods combined: cancer-type signature genes, ESTIMATE stromal/immune enrichment, and lineage gene calibration
@@ -158,6 +173,7 @@ Every `analyze` run produces a directory with these files (prefixed by the input
 
 | File | Description |
 |---|---|
+| `*-sample-context.png` | Stage 1 diagnostic: library prep + preservation inference with thresholds used for the call |
 | `*-sample-summary.png` | Overview: cancer type, purity, background signatures |
 | `*-decomposition.png` | 4-panel: ranked hypotheses, best-fit composition, component support, marker logic |
 | `*-purity.png` | Tumor purity estimation detail |

--- a/pirlygenes/__init__.py
+++ b/pirlygenes/__init__.py
@@ -35,6 +35,7 @@ from .gene_sets_cancer import (
     tme_markers_df,
 )
 from .load_dataset import load_all_dataframes, load_all_dataframes_dict, get_data
+from .sample_context import SampleContext, infer_sample_context, plot_sample_context
 from .plot import (
     plot_ctas_vs_cancer_type_detail,
     plot_gene_expression,
@@ -83,4 +84,8 @@ __all__ = [
     "cancer_family_panels_df",
     "cancer_family_panel",
     "cancer_family_panels",
+    # Sample context (stage 1 of unified attribution flow)
+    "SampleContext",
+    "infer_sample_context",
+    "plot_sample_context",
 ]

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -63,6 +63,7 @@ from .decomposition import (
     plot_decomposition_component_breakdown,
     plot_decomposition_composition,
 )
+from .sample_context import infer_sample_context, plot_sample_context
 from .sample_quality import assess_sample_quality
 
 _DATASET_SOURCES = {
@@ -223,6 +224,23 @@ def analyze(
     forced_labels = _parse_always_label_genes(label_genes)
     template_overrides = _parse_csv_tokens(decomposition_templates)
 
+    # Stage 1 of the unified attribution flow: infer SampleContext BEFORE
+    # cancer-type inference. Downstream stages (purity CIs, decomposition,
+    # tumor-value adjustment, reporting) read from it as the base layer
+    # of expression expectations.
+    print("[context] Inferring sample context (library prep + preservation)...")
+    sample_context = infer_sample_context(df_expr)
+    print(f"[context] {sample_context.summary_line()}")
+    for flag in sample_context.flags:
+        print(f"[context] {flag}")
+
+    context_png = "%s-sample-context.png" % prefix if prefix else "sample-context.png"
+    try:
+        plot_sample_context(sample_context, save_to_filename=context_png, save_dpi=output_dpi)
+        print(f"[plot] Saved sample-context diagnostic to {context_png}")
+    except Exception as exc:  # noqa: BLE001 — plotting must not break analyze
+        print(f"[plot] sample-context plot failed: {exc}")
+
     # Strip plots: split into focused panels for readability
     # Immune microenvironment
     immune_sets = {k: default_gene_sets[k] for k in
@@ -276,6 +294,23 @@ def analyze(
     # Sample composition analysis
     print("[analysis] Running sample composition analysis...")
     analysis = analyze_sample(df_expr, cancer_type=cancer_type)
+    analysis["sample_context"] = sample_context
+
+    # Stage 1 propagation: widen purity confidence intervals under
+    # detected degradation (#26). A noisier sample has a noisier purity
+    # estimate; we don't re-estimate, just scale the reported band.
+    ci_factor = sample_context.purity_ci_widening_factor()
+    if ci_factor > 1.0 and "purity" in analysis:
+        purity_block = analysis["purity"]
+        est = purity_block.get("overall_estimate")
+        lo = purity_block.get("overall_lower")
+        hi = purity_block.get("overall_upper")
+        if est is not None and lo is not None and hi is not None:
+            half_lo = max(0.0, est - lo) * ci_factor
+            half_hi = max(0.0, hi - est) * ci_factor
+            purity_block["overall_lower"] = round(max(0.0, est - half_lo), 4)
+            purity_block["overall_upper"] = round(min(1.0, est + half_hi), 4)
+            purity_block["ci_widening_factor"] = round(ci_factor, 3)
     analysis["sample_mode"] = infer_sample_mode(
         candidate_rows=analysis.get("candidate_trace"),
         cancer_types=[analysis["cancer_type"]] if analysis.get("cancer_type") else ([cancer_type] if cancer_type else None),
@@ -291,8 +326,22 @@ def analyze(
     cancer_code = analysis["cancer_type"]
     purity = analysis["purity"]
     fit_quality = analysis.get("fit_quality", {})
-    print(f"[analysis] Cancer type: {analysis['cancer_name']} ({cancer_code}), "
-          f"score={analysis['cancer_score']:.3f}")
+    candidate_trace_for_print = analysis.get("candidate_trace", [])
+    top_row = candidate_trace_for_print[0] if candidate_trace_for_print else None
+    if top_row:
+        parts = [
+            f"signature={top_row.get('signature_score', 0.0):.2f}",
+            f"geomean={top_row.get('support_geomean', 0.0):.2f}",
+            f"normalized={top_row.get('support_norm', 0.0):.2f}",
+        ]
+        if len(candidate_trace_for_print) > 1:
+            runner = candidate_trace_for_print[1]
+            parts.append(
+                f"(runner-up {runner['code']} {runner.get('support_norm', 0.0):.2f})"
+            )
+        print(f"[analysis] Cancer type: {analysis['cancer_name']} ({cancer_code}), " + ", ".join(parts))
+    else:
+        print(f"[analysis] Cancer type: {analysis['cancer_name']} ({cancer_code})")
     if fit_quality.get("label"):
         print(f"[analysis] Fit quality: {fit_quality['label']} — {fit_quality.get('message', '')}")
     print(f"[analysis] Sample mode: {_sample_mode_display(analysis['sample_mode'])}")
@@ -354,6 +403,7 @@ def analyze(
                 "family_factor": row.get("family_factor"),
                 "signature_stability": row.get("signature_stability"),
                 "support_score": row["support_score"],
+                "support_geomean": row.get("support_geomean"),
                 "support_norm": row["support_norm"],
             }
             for idx, row in enumerate(analysis.get("candidate_trace", []))
@@ -1136,6 +1186,21 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
         )
     summary += ambiguity_clause
 
+    # Sample context (stage 1 of unified attribution flow) lands as the
+    # first framing line after the cancer-type summary, so readers see
+    # how library-prep + preservation shape all downstream claims.
+    sample_context = analysis.get("sample_context")
+    if sample_context is not None:
+        context_line = f"\n\n**Sample context**: {sample_context.summary_line()}."
+        if sample_context.missing_mt:
+            context_line += " ⚠ MT genes missing from quant table — degradation signal is unreliable."
+        if sample_context.purity_ci_widening_factor() > 1.0:
+            context_line += (
+                f" Purity CIs widened ×{sample_context.purity_ci_widening_factor():.2f} "
+                "to reflect degradation-driven noise."
+            )
+        summary += context_line
+
     # Quality flags in summary
     quality = analysis.get("quality")
     if quality and quality.get("has_issues"):
@@ -1215,31 +1280,55 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
                 "- **Requested decomposition templates**: "
                 + ", ".join(constraints["decomposition_templates"])
             )
-    top_cancers = analysis.get("top_cancers", [(cancer_code, analysis["cancer_score"])])
-    for code, score in top_cancers[:5]:
-        name = CANCER_TYPE_NAMES.get(code, code)
-        lines.append(f"- **{code}** ({name}): {score:.3f}")
+    if candidate_trace:
+        lines.append("- **Top candidates** (geomean · normalized):")
+        for row in candidate_trace[:5]:
+            name = CANCER_TYPE_NAMES.get(row["code"], row["code"])
+            lines.append(
+                f"  - **{row['code']}** ({name}): "
+                f"{row.get('support_geomean', 0.0):.2f} · {row.get('support_norm', 0.0):.2f}"
+            )
+    else:
+        top_cancers = analysis.get("top_cancers", [(cancer_code, analysis["cancer_score"])])
+        for code, score in top_cancers[:5]:
+            name = CANCER_TYPE_NAMES.get(code, code)
+            lines.append(f"- **{code}** ({name}): {score:.3f}")
     lines.append("")
 
     if candidate_trace:
         lines.append("### Cancer Type Inference — Candidate Ranking\n")
         lines.append(
             "Each row is a TCGA cancer-type hypothesis considered by the classifier. "
-            "**Support** is the combined score used for ranking (higher = better). "
-            "**Signature** measures z-scored expression of cancer-type-enriched genes, "
-            "**Purity** is the overall purity estimate for that hypothesis, **Lineage** "
-            "is an orthogonal per-lineage-gene purity, and **Concordance** is how well "
-            "the sample's lineage-gene pattern matches the expected pattern for that "
-            "cancer type. Top row is the working call.\n"
+            "Three scores summarize the match; the top row is the working call.\n\n"
+            "- **Signature** (0–1): raw match quality between the sample's expression and "
+            "this cancer type's TCGA-derived signature genes, computed from z-scored "
+            "expression of cancer-type-enriched genes. Interpretable on its own — higher "
+            "means the lineage pattern is strongly present. Does not account for purity "
+            "or lineage concordance.\n"
+            "- **Geomean** (0–1): the geometric mean of the five factors that feed the "
+            "ranking (signature × purity × lineage support × signature stability × family "
+            "factor). Stays bounded on [0, 1] so it's comparable across samples, unlike "
+            "the raw product which collapses toward zero.\n"
+            "- **Normalized** (0–1, top = 1.0): each candidate's composite support score "
+            "divided by the top candidate's. Use this to judge separation — if the runner-up "
+            "is ≪ 1.0, the top call is well-isolated; values near 1.0 mean the call is "
+            "ambiguous between rows.\n\n"
+            "Supporting columns: **Purity** is the overall tumor-purity estimate under "
+            "this hypothesis; **Lineage** is an orthogonal per-lineage-gene purity; "
+            "**Concordance** is how well the sample's lineage-gene pattern matches the "
+            "expected pattern for that cancer type.\n"
         )
-        lines.append("| Cancer | Family | Support | Signature | Purity | Lineage | Concordance |")
-        lines.append("|--------|--------|---------|-----------|--------|---------|-------------|")
+        lines.append("| Cancer | Family | Signature | Geomean | Normalized | Purity | Lineage | Concordance |")
+        lines.append("|--------|--------|-----------|---------|------------|--------|---------|-------------|")
         for row in candidate_trace[:8]:
             lineage = row.get("lineage_purity")
             concordance = row.get("lineage_concordance")
             lines.append(
-                f"| {row['code']} | {row.get('family_label') or '—'} | {row['support_score']:.3f} | {row['signature_score']:.3f} | "
-                f"{row['purity_estimate']:.3f} | "
+                f"| {row['code']} | {row.get('family_label') or '—'} | "
+                f"{row.get('signature_score', 0.0):.3f} | "
+                f"{row.get('support_geomean', 0.0):.3f} | "
+                f"{row.get('support_norm', 0.0):.3f} | "
+                f"{row.get('purity_estimate', 0.0):.3f} | "
                 f"{'%.3f' % lineage if lineage is not None else '—'} | "
                 f"{'%.3f' % concordance if concordance is not None else '—'} |"
             )
@@ -1500,6 +1589,43 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
 
     lines = [f"# Therapeutic Target Analysis — {cancer_code} ({cancer_name})\n"]
     lines.append(_target_report_mode_intro(sample_mode, cancer_code, p_lo, p_mid, p_hi))
+
+    # Low-purity TME-inflation caveat (#35). Below 20% purity, every
+    # residual TPM is amplified ≥5× by the tumor-value division.
+    # Combined with incomplete TME subtraction, this can rank classic
+    # stromal / ECM genes (FN1, COL1A1/2, DCN) as high-expressing tumor
+    # markers. Users must read the caveat before interpreting the CAR-T
+    # / ADC / radioligand target tables.
+    if p_mid is not None and p_mid < 0.20:
+        lines.append(
+            f"> **⚠ Low-purity caveat**: estimated purity is "
+            f"**{p_mid:.0%}**, so residual TPM is divided by a small "
+            "number and amplified ≥5×. Genes heavily expressed in "
+            "fibroblast / endothelial / immune compartments (FN1, "
+            "COL1A1/2, DCN, etc.) can appear as high tumor-expressed "
+            "even when most of the signal is stromal. Treat the "
+            "`tme_explainable=true` column in the TSV as the primary "
+            "filter for therapy-target safety; cross-check any "
+            "`median_est` > 30 TPM against `tme_fold_med` before acting.\n"
+        )
+
+    # Sample-context caveat (stage 1 propagation): when the sample was
+    # flagged as degraded / FFPE, every marker-selection step down the
+    # pipeline is noisier and the target medians are correspondingly
+    # less reliable.
+    sample_context = analysis.get("sample_context")
+    if sample_context is not None and sample_context.is_degraded:
+        index_str = (
+            f" (length-pair index {sample_context.degradation_index:.2f})"
+            if sample_context.degradation_index is not None else ""
+        )
+        lines.append(
+            f"> **⚠ Degradation caveat**: sample flagged as "
+            f"`{sample_context.degradation_severity}` degradation"
+            f"{index_str}. Long-transcript TPMs are under-represented; "
+            "tumor-expression estimates for long-gene targets carry "
+            "higher uncertainty than the reported CIs suggest.\n"
+        )
     if sample_mode == "pure":
         lines.append(
             "Each gene is reported as a bounded expression estimate around the observed sample value, "

--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -1,0 +1,658 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample-context inference — library prep, preservation, degradation.
+
+First stage of the unified attribution flow (see README "Attribution
+flow"). Runs before cancer-type inference and produces a ``SampleContext``
+that every downstream step consumes as a **base-layer of expression
+expectations**: which genes are expected to be over- or under-represented
+for artifactual reasons, and how to compensate.
+
+The detection uses signals that are tissue-independent, so this module
+can run on a raw expression table without knowing what cancer or normal
+tissue the sample is from:
+
+- **Library prep** — replication-dependent histone fraction and MT
+  ribosomal-RNA presence. Histone mRNAs and MT rRNAs are *not*
+  polyadenylated and therefore disappear under poly-A capture but
+  survive in total-RNA / ribosomal-depletion libraries.
+- **Preservation (FFPE vs fresh)** — long/short matched-gene-pair ratio
+  (from ``data/degradation-gene-pairs.csv``). Long transcripts degrade
+  faster than short ones in FFPE.
+- **Missing-MT** — complete absence of mitochondrial genes is an
+  artifact (pipeline filter, or exome-capture) rather than biology;
+  degrades confidence in all MT-based signals.
+
+What downstream steps use the context for:
+
+- Marker selection: downweight long-transcript markers under FFPE; skip
+  the extended-housekeeping exclusion universe from tumor-specific
+  marker computations.
+- Purity estimator: widen confidence intervals proportional to
+  degradation severity.
+- Decomposition: adjust fit weights for sample_context-biased genes.
+- Tumor-value adjustment: subtract TME-explainable expression from
+  therapy-target columns (prevents FN1/COL1A1 low-purity inflation).
+- Reporting: show the context chain so users see *why* a number was
+  adjusted, not just the result.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ── Reference gene patterns ──────────────────────────────────────────────
+#
+# Replication-dependent histones (H1-*, H2AC*, H2BC*, H3C*, H4C*) are the
+# canonical family of non-polyadenylated mRNAs. Their fraction collapses
+# under poly-A selection and remains meaningful under total-RNA /
+# ribo-depletion, making them the primary library-prep indicator when
+# combined with MT rRNAs.
+#
+# We match by symbol prefix to cover both HGNC 2020+ names (H2AC1,
+# H2BC1, H3C1, H4C1) and the older HIST* synonyms that some annotations
+# still emit (HIST1H2BC, etc.). A sample's histone signal is then
+# ``sum(TPM for histone symbols) / sum(TPM for all expressed symbols)``.
+_HISTONE_SYMBOL_PREFIXES: tuple[str, ...] = (
+    "H1-", "H2AC", "H2BC", "H3C", "H4C",
+    "HIST1H", "HIST2H", "HIST3H", "HIST4H",
+)
+
+# MT ribosomal RNAs — non-polyadenylated. Present in total / ribo-dep,
+# absent in poly-A and typically in exome capture. Combined with the
+# histone fraction, this disambiguates all four common libraries.
+_MT_RRNA_SYMBOLS: frozenset[str] = frozenset({"MT-RNR1", "MT-RNR2"})
+
+# MT protein-coding mRNAs — polyadenylated. Present in every library
+# that retains mitochondrial transcripts (total, ribo-dep, poly-A).
+# Absence alongside absence of MT rRNAs indicates either exome capture
+# (no MT coverage) or an upstream filter that stripped MT contigs.
+_MT_MRNA_SYMBOLS: frozenset[str] = frozenset({
+    "MT-CO1", "MT-CO2", "MT-CO3",
+    "MT-ND1", "MT-ND2", "MT-ND3", "MT-ND4", "MT-ND4L", "MT-ND5", "MT-ND6",
+    "MT-CYB", "MT-ATP6", "MT-ATP8",
+})
+
+
+# ── Thresholds ────────────────────────────────────────────────────────────
+# Calibrated from ENCODE total-RNA vs poly-A replicates and a TCGA
+# poly-A-capture snapshot. Values are conservative — the inference
+# returns ``unknown`` rather than guess when signals conflict.
+
+_THRESHOLDS = {
+    # Fraction of total expressed TPM that is replication-dependent
+    # histone mRNA.  Poly-A libraries: <<0.1%. Total/ribo-dep: 0.3–2%.
+    "histone_fraction_polyA_ceiling": 0.002,   # below: likely poly-A
+    "histone_fraction_total_floor":   0.005,   # above: likely total / ribo-dep
+
+    # MT rRNA fraction — fraction of all MT TPM attributed to MT-RNR1/2.
+    # Total RNA: MT rRNAs dominate MT signal (>70% of MT TPM).
+    # Ribo-depleted: rRNAs removed; MT rRNAs usually <10% of MT TPM.
+    # Poly-A: rRNAs absent.
+    "mt_rrna_fraction_of_mt_depleted_ceiling": 0.10,
+    "mt_rrna_fraction_of_mt_total_floor":      0.40,
+
+    # Overall MT expression — expressed as fraction of all sample TPM.
+    # <0.1% flagged as "MT missing" (either filtered or exome capture).
+    "mt_fraction_suspicious_floor": 0.001,
+
+    # Gene-length degradation index (long/short observed/expected
+    # median ratio). Calibrated in sample_quality.QUALITY_THRESHOLDS;
+    # kept consistent here.
+    "degradation_pair_moderate": 0.30,
+    "degradation_pair_severe":   0.20,
+}
+
+
+# ── Data class ────────────────────────────────────────────────────────────
+
+@dataclass
+class SampleContext:
+    """Base-layer of expression expectations for a sample.
+
+    Every downstream step reads this to know which genes will be over-
+    or under-represented for *artifactual* reasons, independent of
+    biology.  The attribution flow is:
+
+        raw TPM  →  [SampleContext inference]  →  sample_context +
+                    expression_priors  →  coarse TME decomposition  →
+                    fine TME subtype dissection  →  tumor-value
+                    adjustment  →  conservative tumor-specific core
+
+    Fields are all additive: none replace or override existing
+    functionality; they *inform* it.  A ``None`` or ``unknown`` field is
+    a signal that the context was inconclusive and downstream should
+    behave as if the sample has default expectations.
+    """
+
+    # Library preparation method inferred from histone + MT rRNA signals.
+    # One of: "poly_a", "ribo_depleted", "total_rna", "exome_capture",
+    # "unknown". ``poly_a`` is the most common for RNA-seq of clinical
+    # samples; ``total_rna`` and ``ribo_depleted`` together cover most
+    # research cohorts and recent ribo-depleted clinical protocols.
+    library_prep: str = "unknown"
+    library_prep_confidence: float = 0.0  # 0.0 (guess) to 1.0 (strong)
+
+    # Preservation / degradation status. ``fresh_frozen`` is the default
+    # expectation for a non-degraded sample; ``ffpe`` flags formalin-
+    # fixed paraffin-embedded RNA; ``degraded`` catches partial
+    # degradation from slow processing or thaw cycles.
+    preservation: str = "unknown"          # "fresh_frozen" | "ffpe" | "degraded" | "unknown"
+    preservation_confidence: float = 0.0
+
+    # Severity of degradation from the gene-length pair index.
+    degradation_severity: str = "none"     # "none" | "mild" | "moderate" | "severe"
+    degradation_index: Optional[float] = None  # long/short observed/expected median
+
+    # Whether mitochondrial genes are missing from the quant table.
+    # If True, degradation signal cannot be assessed from MT fold and
+    # is unreliable.
+    missing_mt: bool = False
+
+    # Diagnostic signals used by the inference, retained so the report
+    # can explain *why* a call was made. Do not rely on these keys from
+    # external code; they are reporting-only.
+    signals: dict = field(default_factory=dict)
+
+    # User-readable context flags for console output / summary.md.
+    flags: list[str] = field(default_factory=list)
+
+    # ── Computed downstream adjustments ──────────────────────────────
+
+    @property
+    def is_ffpe(self) -> bool:
+        return self.preservation == "ffpe"
+
+    @property
+    def is_degraded(self) -> bool:
+        return self.degradation_severity in ("moderate", "severe")
+
+    def long_transcript_weight_factor(self) -> float:
+        """Multiplier applied to long-transcript marker weights (#25).
+
+        FFPE samples systematically under-represent long transcripts,
+        which biases any decomposition marker with long-transcript-
+        dominant reference signal.  Returns 1.0 when no degradation is
+        detected and halves progressively as severity rises.
+        """
+        return {
+            "severe":   0.3,
+            "moderate": 0.5,
+            "mild":     0.75,
+            "none":     1.0,
+        }.get(self.degradation_severity, 1.0)
+
+    def purity_ci_widening_factor(self) -> float:
+        """Multiplicative widening of purity confidence intervals (#26).
+
+        A degraded sample yields noisier purity estimates because the
+        upstream gene-expression measurements are noisier.  Returns a
+        factor ≥ 1 that downstream CI construction multiplies into its
+        half-width.
+        """
+        return {
+            "severe":   1.6,
+            "moderate": 1.3,
+            "mild":     1.1,
+            "none":     1.0,
+        }.get(self.degradation_severity, 1.0)
+
+    def summary_line(self) -> str:
+        """One-line human summary for reports and stdout."""
+        prep = {
+            "poly_a":         "poly-A capture",
+            "ribo_depleted":  "ribosomal-depleted",
+            "total_rna":      "total RNA",
+            "exome_capture":  "exome capture",
+            "unknown":        "unknown library prep",
+        }.get(self.library_prep, self.library_prep)
+        pres = {
+            "fresh_frozen": "fresh / frozen",
+            "ffpe":         "FFPE",
+            "degraded":     "partially degraded",
+            "unknown":      "unknown preservation",
+        }.get(self.preservation, self.preservation)
+        deg = "" if self.degradation_severity == "none" else f", {self.degradation_severity} degradation"
+        return f"{prep}, {pres}{deg}"
+
+
+# ── Inference ─────────────────────────────────────────────────────────────
+
+
+def _sum_tpm_for_symbols(tpm_by_symbol, symbol_set) -> float:
+    total = 0.0
+    for sym in symbol_set:
+        v = tpm_by_symbol.get(sym)
+        if v is not None and not (isinstance(v, float) and math.isnan(v)) and v > 0:
+            total += float(v)
+    return total
+
+
+def _sum_tpm_for_prefixes(tpm_by_symbol, prefixes) -> float:
+    total = 0.0
+    for sym, v in tpm_by_symbol.items():
+        if not isinstance(sym, str):
+            continue
+        if v is None or (isinstance(v, float) and math.isnan(v)) or v <= 0:
+            continue
+        if sym.startswith(prefixes):
+            total += float(v)
+    return total
+
+
+def _infer_library_prep(tpm_by_symbol, signals):
+    """Infer library prep from histone + MT rRNA signals. Records
+    evidence into ``signals`` and returns ``(library_prep, confidence)``.
+    """
+    total_tpm = sum(
+        v for v in tpm_by_symbol.values()
+        if v is not None and not (isinstance(v, float) and math.isnan(v)) and v > 0
+    )
+    if total_tpm <= 0:
+        return "unknown", 0.0
+
+    histone_tpm = _sum_tpm_for_prefixes(tpm_by_symbol, _HISTONE_SYMBOL_PREFIXES)
+    histone_frac = histone_tpm / total_tpm
+
+    mt_rrna_tpm = _sum_tpm_for_symbols(tpm_by_symbol, _MT_RRNA_SYMBOLS)
+    mt_mrna_tpm = _sum_tpm_for_symbols(tpm_by_symbol, _MT_MRNA_SYMBOLS)
+    mt_total_tpm = mt_rrna_tpm + mt_mrna_tpm
+    mt_fraction = mt_total_tpm / total_tpm
+    mt_rrna_fraction_of_mt = (
+        mt_rrna_tpm / mt_total_tpm if mt_total_tpm > 0 else None
+    )
+
+    signals["histone_fraction"] = round(histone_frac, 5)
+    signals["mt_fraction"] = round(mt_fraction, 5)
+    signals["mt_rrna_fraction_of_mt"] = (
+        round(mt_rrna_fraction_of_mt, 4) if mt_rrna_fraction_of_mt is not None else None
+    )
+
+    # Exome capture: MT absent AND histones absent (exome panels don't
+    # cover MT contigs and only pick up sparse histone exons).
+    if (
+        mt_fraction < _THRESHOLDS["mt_fraction_suspicious_floor"]
+        and histone_frac < _THRESHOLDS["histone_fraction_polyA_ceiling"]
+    ):
+        return "exome_capture", 0.6
+
+    # Total RNA: histones high AND MT rRNAs dominate MT signal
+    if (
+        histone_frac >= _THRESHOLDS["histone_fraction_total_floor"]
+        and mt_rrna_fraction_of_mt is not None
+        and mt_rrna_fraction_of_mt >= _THRESHOLDS["mt_rrna_fraction_of_mt_total_floor"]
+    ):
+        return "total_rna", 0.9
+
+    # Ribo-depleted: histones high AND MT rRNAs depleted
+    if (
+        histone_frac >= _THRESHOLDS["histone_fraction_total_floor"]
+        and mt_rrna_fraction_of_mt is not None
+        and mt_rrna_fraction_of_mt <= _THRESHOLDS["mt_rrna_fraction_of_mt_depleted_ceiling"]
+    ):
+        return "ribo_depleted", 0.85
+
+    # Poly-A: histones absent AND MT rRNAs absent
+    if (
+        histone_frac <= _THRESHOLDS["histone_fraction_polyA_ceiling"]
+        and (mt_rrna_fraction_of_mt is None or mt_rrna_fraction_of_mt <= _THRESHOLDS["mt_rrna_fraction_of_mt_depleted_ceiling"])
+        and mt_fraction >= _THRESHOLDS["mt_fraction_suspicious_floor"]
+    ):
+        return "poly_a", 0.8
+
+    # Ambiguous: histones low, MT signal mixed. Most clinical cohorts
+    # are poly-A so default there at low confidence.
+    if histone_frac <= _THRESHOLDS["histone_fraction_polyA_ceiling"]:
+        return "poly_a", 0.5
+
+    return "unknown", 0.2
+
+
+def _infer_preservation_and_degradation(tpm_by_symbol, signals):
+    """Infer preservation + degradation severity using the gene-length
+    pair index from ``data/degradation-gene-pairs.csv``.
+
+    Returns ``(preservation, preservation_confidence, severity, index)``.
+    """
+    from .gene_sets_cancer import degradation_gene_pairs
+
+    ratios = []
+    n_short_expressed = 0
+    for short_gene, long_gene, expected in degradation_gene_pairs():
+        short_tpm = tpm_by_symbol.get(short_gene)
+        long_tpm = tpm_by_symbol.get(long_gene)
+        if short_tpm is None or (isinstance(short_tpm, float) and math.isnan(short_tpm)) or short_tpm <= 1:
+            continue
+        if long_tpm is None or (isinstance(long_tpm, float) and math.isnan(long_tpm)) or expected <= 0:
+            continue
+        n_short_expressed += 1
+        observed = float(long_tpm) / float(short_tpm)
+        ratios.append(observed / float(expected))
+
+    signals["n_degradation_pairs"] = n_short_expressed
+
+    if not ratios:
+        return "unknown", 0.0, "none", None
+
+    import numpy as np
+    index = float(np.median(ratios))
+    signals["degradation_index"] = round(index, 3)
+
+    if index < _THRESHOLDS["degradation_pair_severe"]:
+        return "ffpe", 0.85, "severe", index
+    if index < _THRESHOLDS["degradation_pair_moderate"]:
+        return "ffpe", 0.7, "moderate", index
+    if index < 0.55:
+        return "degraded", 0.6, "mild", index
+    return "fresh_frozen", 0.7, "none", index
+
+
+def _build_tpm_by_symbol(df_gene_expr):
+    """Return {symbol: max_TPM}, working whether the input frame has
+    a symbol column directly or only a gene_id column.
+
+    Prefers a direct symbol column (``gene_symbol``/``symbol``/``Symbol``)
+    so that synthetic test frames with just ``(gene_symbol, TPM)`` work
+    without requiring a gene-ID column. Falls back to
+    ``tumor_purity._build_sample_tpm_by_symbol`` (which maps gene IDs
+    through the HPA/pan-cancer reference) for frames without a symbol
+    column.
+    """
+    sym_col = next(
+        (c for c in ("gene_symbol", "Symbol", "symbol", "GeneName") if c in df_gene_expr.columns),
+        None,
+    )
+    tpm_col = "TPM" if "TPM" in df_gene_expr.columns else next(
+        (c for c in df_gene_expr.columns if c.lower() == "tpm"), None
+    )
+    if sym_col is not None and tpm_col is not None:
+        out = {}
+        for _, row in df_gene_expr.iterrows():
+            sym = row[sym_col]
+            if not isinstance(sym, str) or not sym:
+                continue
+            try:
+                tpm = float(row[tpm_col])
+            except (TypeError, ValueError):
+                continue
+            if math.isnan(tpm):
+                continue
+            if sym not in out or tpm > out[sym]:
+                out[sym] = tpm
+        return out
+    # Fall back to the gene-ID path.
+    from .tumor_purity import _build_sample_tpm_by_symbol
+    return _build_sample_tpm_by_symbol(df_gene_expr)
+
+
+def _summarise_expression_distribution(tpm_by_symbol, signals):
+    """Compute shape of the full expression distribution.
+
+    The whole range of TPM values carries library-prep and depth
+    information that is independent of the histone / MT / length-pair
+    probes above: detection breadth (how many genes are seen at all),
+    dynamic range, tail heaviness, and median expressed level.
+
+    Adds fields to ``signals``:
+
+    - ``genes_detected_above_0p5_tpm`` / ``above_1_tpm`` / ``above_10_tpm``
+    - ``log2_tpm_median`` (over expressed genes only) and IQR
+    - ``high_expression_tail_share`` — fraction of total TPM captured by
+      the top 1% of genes (platforms with aggressive poly-A capture and
+      shallow depth concentrate more mass in fewer genes)
+    """
+    import numpy as np
+
+    values = np.array(
+        [float(v) for v in tpm_by_symbol.values() if v > 0],
+        dtype=float,
+    )
+    n_genes = int(values.size)
+    signals["n_genes_with_any_expression"] = n_genes
+    if n_genes == 0:
+        return
+    signals["genes_detected_above_0p5_tpm"] = int((values > 0.5).sum())
+    signals["genes_detected_above_1_tpm"] = int((values > 1.0).sum())
+    signals["genes_detected_above_10_tpm"] = int((values > 10.0).sum())
+
+    expressed = values[values > 1.0]
+    if expressed.size:
+        log2_expr = np.log2(expressed + 1.0)
+        signals["log2_tpm_median"] = round(float(np.median(log2_expr)), 3)
+        signals["log2_tpm_iqr"] = round(
+            float(np.subtract(*np.percentile(log2_expr, [75, 25]))), 3
+        )
+        signals["log2_tpm_p95"] = round(float(np.percentile(log2_expr, 95)), 3)
+
+    total = float(values.sum())
+    if total > 0:
+        top_n = max(1, int(round(0.01 * n_genes)))
+        top_sum = float(np.sort(values)[-top_n:].sum())
+        signals["top_1pct_share_of_total_tpm"] = round(top_sum / total, 4)
+
+
+def infer_sample_context(df_gene_expr) -> SampleContext:
+    """Infer a ``SampleContext`` from a TPM expression table.
+
+    This is the FIRST stage of the unified attribution flow — it runs
+    before cancer-type inference, decomposition, and any downstream
+    analysis that might be biased by FFPE / library-prep artifacts.
+
+    Parameters
+    ----------
+    df_gene_expr : pd.DataFrame
+        Expression frame with at minimum a ``gene_symbol`` (or
+        ``Symbol``/``symbol``) column and a ``TPM`` column. Accepts
+        the full pirlygenes expression format as well — any frame that
+        works with the existing purity pipeline works here.
+
+    Returns
+    -------
+    SampleContext
+        ``library_prep``, ``preservation``, ``degradation_severity``,
+        ``missing_mt``, diagnostic ``signals``, and human-readable
+        ``flags``.
+    """
+    try:
+        tpm_by_symbol = _build_tpm_by_symbol(df_gene_expr)
+    except (KeyError, ValueError, TypeError):
+        # Malformed / test-harness frames without gene-id or symbol
+        # columns cannot yield a context. Return a conservative unknown
+        # context so downstream code still has a valid object to read.
+        return SampleContext(
+            library_prep="unknown",
+            preservation="unknown",
+            degradation_severity="none",
+            missing_mt=True,
+            flags=["Sample context inference skipped — input frame has no gene column"],
+        )
+    # Drop NaN
+    tpm_by_symbol = {
+        s: v for s, v in tpm_by_symbol.items()
+        if v is not None and not (isinstance(v, float) and math.isnan(v))
+    }
+
+    signals = {}
+
+    _summarise_expression_distribution(tpm_by_symbol, signals)
+    library_prep, lp_conf = _infer_library_prep(tpm_by_symbol, signals)
+    preservation, pr_conf, severity, index = _infer_preservation_and_degradation(
+        tpm_by_symbol, signals
+    )
+
+    # Missing-MT detection (#61). We check the count of MT symbols that
+    # map to any TPM > 0 in the sample. ``missing_mt`` is a distinct
+    # signal from preservation — it's about the quant table, not the RNA.
+    mt_found = sum(
+        1 for s in (_MT_RRNA_SYMBOLS | _MT_MRNA_SYMBOLS)
+        if s in tpm_by_symbol and tpm_by_symbol[s] > 0
+    )
+    signals["mt_genes_detected"] = mt_found
+    signals["mt_genes_total"] = len(_MT_RRNA_SYMBOLS) + len(_MT_MRNA_SYMBOLS)
+    missing_mt = mt_found <= 1
+
+    flags = []
+    if missing_mt:
+        flags.append(
+            "Mitochondrial genes missing from quant table — degradation "
+            "signal from MT fraction is unreliable; FFPE detection falls "
+            "back to gene-length pair index only"
+        )
+    if library_prep == "unknown":
+        flags.append("Library prep inconclusive — histone + MT-rRNA signals did not match any profile")
+    else:
+        flags.append(
+            f"Library prep: {library_prep.replace('_', ' ')} "
+            f"(confidence {lp_conf:.0%})"
+        )
+    if preservation == "ffpe":
+        flags.append(
+            f"Preservation: FFPE / heavily degraded "
+            f"(length-pair index {index:.2f})"
+        )
+    elif preservation == "degraded":
+        flags.append(f"Preservation: partial degradation (length-pair index {index:.2f})")
+    elif preservation == "fresh_frozen":
+        flags.append(f"Preservation: fresh / frozen (length-pair index {index:.2f})")
+
+    return SampleContext(
+        library_prep=library_prep,
+        library_prep_confidence=lp_conf,
+        preservation=preservation,
+        preservation_confidence=pr_conf,
+        degradation_severity=severity,
+        degradation_index=index,
+        missing_mt=missing_mt,
+        signals=signals,
+        flags=flags,
+    )
+
+
+# ── Plotting ──────────────────────────────────────────────────────────────
+
+
+def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
+                        save_dpi: int = 150) -> Optional[str]:
+    """Standalone PNG summarising ``sample_context`` as the first panel
+    a user sees in an analyze report.
+
+    Two-row layout (single PNG — plot-crowding preference):
+
+    - **Top**: text block with library prep, preservation, degradation
+      severity, missing-MT flag, and confidence.
+    - **Bottom**: three horizontal bars showing the diagnostic fractions
+      (histone mRNA fraction of total; MT rRNA fraction of MT; overall
+      MT fraction of total) with the thresholds used for the call.
+    """
+    import matplotlib.pyplot as plt
+
+    fig, (ax_text, ax_bars) = plt.subplots(
+        nrows=2, ncols=1, figsize=(10, 5.5),
+        gridspec_kw={"height_ratios": [1, 1.5]},
+    )
+    ax_text.axis("off")
+
+    prep_label = {
+        "poly_a": "Poly-A capture",
+        "ribo_depleted": "Ribosomal depletion",
+        "total_rna": "Total RNA",
+        "exome_capture": "Exome capture",
+        "unknown": "Unknown",
+    }.get(sample_context.library_prep, sample_context.library_prep)
+
+    pres_label = {
+        "fresh_frozen": "Fresh / frozen",
+        "ffpe": "FFPE",
+        "degraded": "Partial degradation",
+        "unknown": "Unknown",
+    }.get(sample_context.preservation, sample_context.preservation)
+
+    severity_color = {
+        "none": "#2e8b57",
+        "mild": "#daa520",
+        "moderate": "#d2691e",
+        "severe": "#b22222",
+    }.get(sample_context.degradation_severity, "#666666")
+
+    header_lines = [
+        f"Library prep:  {prep_label}   "
+        f"(confidence {sample_context.library_prep_confidence:.0%})",
+        f"Preservation:  {pres_label}",
+        (
+            f"Degradation:   {sample_context.degradation_severity}"
+            + (f"  (length-pair index {sample_context.degradation_index:.2f})"
+               if sample_context.degradation_index is not None else "")
+        ),
+    ]
+    if sample_context.missing_mt:
+        header_lines.append("⚠ MT genes missing from quant table")
+
+    ax_text.text(
+        0.02, 0.95, "Sample context",
+        fontsize=14, fontweight="bold", va="top",
+    )
+    for i, line in enumerate(header_lines):
+        ax_text.text(
+            0.02, 0.70 - 0.22 * i, line,
+            fontsize=11, va="top", family="monospace",
+            color=severity_color if i == 2 else "black",
+        )
+
+    # Bottom panel: diagnostic bars
+    signals = sample_context.signals
+    hist_frac = signals.get("histone_fraction", 0.0) or 0.0
+    mt_frac = signals.get("mt_fraction", 0.0) or 0.0
+    mt_rrna_frac = signals.get("mt_rrna_fraction_of_mt") or 0.0
+
+    bars = [
+        ("Histone fraction\n(replication-dependent mRNAs)",
+         hist_frac, _THRESHOLDS["histone_fraction_total_floor"],
+         "Total/ribo-dep floor"),
+        ("MT fraction\n(of total sample TPM)",
+         mt_frac, _THRESHOLDS["mt_fraction_suspicious_floor"],
+         "Suspicious-floor"),
+        ("MT-rRNA / MT-total",
+         mt_rrna_frac, _THRESHOLDS["mt_rrna_fraction_of_mt_total_floor"],
+         "Total-RNA floor"),
+    ]
+    y = [i for i in range(len(bars))]
+    values = [b[1] for b in bars]
+    labels = [b[0] for b in bars]
+    thresholds = [(b[2], b[3]) for b in bars]
+
+    ax_bars.barh(y, values, color="#4682b4", alpha=0.8)
+    ax_bars.set_yticks(y)
+    ax_bars.set_yticklabels(labels, fontsize=9)
+    ax_bars.invert_yaxis()
+    ax_bars.set_xlim(0, max(max(values) * 1.2, 1.0))
+    ax_bars.set_xlabel("Fraction", fontsize=10)
+    for yi, (thr, thr_name) in zip(y, thresholds):
+        ax_bars.axvline(thr, color="#888888", linestyle="--", linewidth=0.8)
+        ax_bars.text(
+            thr, yi - 0.4, thr_name,
+            fontsize=7, color="#666666", ha="left",
+        )
+    for yi, val in zip(y, values):
+        ax_bars.text(val, yi, f"  {val:.3f}", va="center", fontsize=9)
+
+    ax_bars.spines["top"].set_visible(False)
+    ax_bars.spines["right"].set_visible(False)
+    ax_bars.set_title("Library-prep diagnostic signals", fontsize=10, loc="left")
+
+    fig.tight_layout()
+    fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+    plt.close(fig)
+    return save_to_filename

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -1647,13 +1647,17 @@ def rank_cancer_type_candidates(
                 )
         else:
             family_factor = 1.0
-        support_score = (
-            signature_score
-            * max(purity_estimate, family_params["support_norm_floor"])
-            * lineage_support_factor
-            * max(signature_stability, family_params["signature_stability_floor"])
-            * max(family_factor, family_params["min_factor"])
+        support_factors = (
+            signature_score,
+            max(purity_estimate, family_params["support_norm_floor"]),
+            lineage_support_factor,
+            max(signature_stability, family_params["signature_stability_floor"]),
+            max(family_factor, family_params["min_factor"]),
         )
+        support_score = float(np.prod(support_factors))
+        # Geomean across the 5 factors — same ordering as support_score but
+        # stays bounded on [0, 1] instead of collapsing toward zero.
+        support_geomean = float(support_score ** (1.0 / len(support_factors))) if support_score > 0 else 0.0
         rows.append(
             {
                 "code": code,
@@ -1670,6 +1674,7 @@ def rank_cancer_type_candidates(
                 "family_specificity": family_specificity,
                 "family_factor": family_factor,
                 "support_score": support_score,
+                "support_geomean": support_geomean,
                 "purity_result": purity_result,
             }
         )

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.26.2"
+__version__ = "4.0.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_sample_context.py
+++ b/tests/test_sample_context.py
@@ -1,0 +1,233 @@
+import pandas as pd
+
+from pirlygenes.gene_sets_cancer import pan_cancer_expression, degradation_gene_pairs
+from pirlygenes.sample_context import (
+    SampleContext,
+    infer_sample_context,
+    _HISTONE_SYMBOL_PREFIXES,
+    _MT_MRNA_SYMBOLS,
+    _MT_RRNA_SYMBOLS,
+)
+
+
+def _frame_from_pairs(pairs):
+    """Build a minimal (gene_symbol, TPM) expression frame from [(sym, tpm)]."""
+    return pd.DataFrame([{"gene_symbol": s, "TPM": float(t)} for s, t in pairs])
+
+
+def _pan_cancer_ntpm_sample(tissue):
+    """Synthetic sample equal to a reference normal tissue column."""
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    return pd.DataFrame(
+        {
+            "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+            "gene_symbol": ref["Symbol"],
+            "TPM": ref[f"nTPM_{tissue}"].astype(float),
+        }
+    )
+
+
+def _fresh_degradation_pair_expectations():
+    """Return list of (short, long, expected) pairs whose ``expected`` ratio
+    is used as the reference 'fresh' value."""
+    return list(degradation_gene_pairs())
+
+
+# ── Library-prep inference ────────────────────────────────────────────────
+
+
+def test_library_prep_polya_signature_is_detected():
+    """Histones absent, MT rRNAs absent, MT mRNAs present → poly-A."""
+    # Background expression to make histone + MT fractions small/large
+    # relative to total.
+    rows = [("ACTB", 500), ("GAPDH", 400), ("TUBB", 300)]
+    # MT mRNAs present (typical poly-A capture keeps them)
+    rows += [(sym, 50) for sym in _MT_MRNA_SYMBOLS]
+    # MT rRNAs absent. Histones absent.
+    frame = _frame_from_pairs(rows)
+
+    ctx = infer_sample_context(frame)
+    assert ctx.library_prep == "poly_a"
+    assert ctx.library_prep_confidence >= 0.5
+
+
+def test_library_prep_total_rna_signature_is_detected():
+    """Histones high, MT rRNAs dominant → total RNA."""
+    rows = [("ACTB", 500), ("GAPDH", 400), ("TUBB", 300)]
+    # High histone mass — use modern HGNC names so prefix detection
+    # catches H2AC* / H2BC* / H3C* / H4C*.
+    rows += [
+        ("H2BC1", 80), ("H2BC3", 70), ("H2BC4", 65), ("H2AC1", 60),
+        ("H3C1", 55), ("H4C1", 50),
+    ]
+    # MT rRNAs dominate MT signal (characteristic of total RNA libraries)
+    rows += [(sym, 200) for sym in _MT_RRNA_SYMBOLS]
+    rows += [(sym, 20) for sym in list(_MT_MRNA_SYMBOLS)[:5]]
+    frame = _frame_from_pairs(rows)
+
+    ctx = infer_sample_context(frame)
+    assert ctx.library_prep == "total_rna"
+    assert ctx.library_prep_confidence >= 0.7
+
+
+def test_library_prep_ribo_depleted_signature_is_detected():
+    """Histones present, MT rRNAs depleted → ribo-depleted."""
+    rows = [("ACTB", 500), ("GAPDH", 400), ("TUBB", 300)]
+    rows += [
+        ("H2BC1", 80), ("H2BC3", 70), ("H2AC1", 60), ("H3C1", 55), ("H4C1", 50),
+    ]
+    # MT rRNAs absent or very low; MT mRNAs present
+    rows += [(sym, 40) for sym in _MT_MRNA_SYMBOLS]
+    frame = _frame_from_pairs(rows)
+
+    ctx = infer_sample_context(frame)
+    assert ctx.library_prep == "ribo_depleted"
+
+
+def test_library_prep_exome_capture_signature_is_detected():
+    """MT absent AND histones absent → exome capture."""
+    rows = [("ACTB", 500), ("GAPDH", 400), ("TUBB", 300), ("TP53", 20), ("BRCA1", 10)]
+    # Nothing else — no MT, no histones.
+    frame = _frame_from_pairs(rows)
+    ctx = infer_sample_context(frame)
+    assert ctx.library_prep == "exome_capture"
+
+
+# ── Preservation + degradation ────────────────────────────────────────────
+
+
+def test_fresh_sample_not_flagged_as_degraded():
+    """A synthetic sample equal to a reference tissue column has
+    degradation-pair ratios equal to the expected values, so the
+    inference should land on fresh_frozen."""
+    df = _pan_cancer_ntpm_sample("liver")
+    ctx = infer_sample_context(df)
+    assert ctx.preservation == "fresh_frozen"
+    assert ctx.degradation_severity == "none"
+    assert ctx.degradation_index is not None
+    assert 0.7 < ctx.degradation_index < 1.5
+
+
+def test_ffpe_sample_triggers_ffpe_preservation():
+    """Construct a sample where long transcripts are systematically
+    depressed relative to their matched short transcripts — the
+    canonical FFPE signature.
+    """
+    import random
+    random.seed(0)
+    rows = []
+    # Background
+    rows += [("ACTB", 500), ("GAPDH", 400), ("TUBB", 300)]
+    # MT genes present (poly-A-like) for library_prep side signal
+    rows += [(sym, 30) for sym in _MT_MRNA_SYMBOLS]
+    # For each degradation pair, short gets normal TPM but long gets
+    # 10x lower than the fresh expected ratio would predict.
+    for short_sym, long_sym, expected in _fresh_degradation_pair_expectations()[:18]:
+        short_tpm = 50.0 + random.random() * 20
+        long_tpm = short_tpm * float(expected) * 0.10   # 10× depletion
+        rows.append((short_sym, short_tpm))
+        rows.append((long_sym, long_tpm))
+    frame = _frame_from_pairs(rows)
+
+    ctx = infer_sample_context(frame)
+    assert ctx.preservation == "ffpe"
+    assert ctx.degradation_severity in ("moderate", "severe")
+    assert ctx.degradation_index is not None and ctx.degradation_index < 0.3
+    assert ctx.long_transcript_weight_factor() < 1.0
+    assert ctx.purity_ci_widening_factor() > 1.0
+
+
+# ── Missing-MT ────────────────────────────────────────────────────────────
+
+
+def test_missing_mt_flag_set_when_mt_genes_absent():
+    """Expression frames without any MT gene should set missing_mt."""
+    rows = [("ACTB", 500), ("GAPDH", 400), ("TUBB", 300)]
+    frame = _frame_from_pairs(rows)
+    ctx = infer_sample_context(frame)
+    assert ctx.missing_mt is True
+    assert any("Mitochondrial genes missing" in f for f in ctx.flags)
+
+
+# ── Downstream adjustment factors ─────────────────────────────────────────
+
+
+def test_long_transcript_weight_factor_monotone_with_severity():
+    base = SampleContext(degradation_severity="none")
+    mild = SampleContext(degradation_severity="mild")
+    moderate = SampleContext(degradation_severity="moderate")
+    severe = SampleContext(degradation_severity="severe")
+    assert base.long_transcript_weight_factor() == 1.0
+    assert (
+        severe.long_transcript_weight_factor()
+        < moderate.long_transcript_weight_factor()
+        < mild.long_transcript_weight_factor()
+        <= 1.0
+    )
+
+
+def test_purity_ci_widening_factor_monotone_with_severity():
+    base = SampleContext(degradation_severity="none")
+    mild = SampleContext(degradation_severity="mild")
+    moderate = SampleContext(degradation_severity="moderate")
+    severe = SampleContext(degradation_severity="severe")
+    assert base.purity_ci_widening_factor() == 1.0
+    assert (
+        severe.purity_ci_widening_factor()
+        > moderate.purity_ci_widening_factor()
+        > mild.purity_ci_widening_factor()
+        > 1.0
+    )
+
+
+def test_summary_line_has_prep_and_preservation():
+    ctx = SampleContext(
+        library_prep="poly_a",
+        preservation="ffpe",
+        degradation_severity="severe",
+    )
+    line = ctx.summary_line()
+    assert "poly-A" in line
+    assert "FFPE" in line
+    assert "severe" in line
+
+
+def test_expression_distribution_signals_populated():
+    """The full-range expression summary should capture detection
+    breadth and dynamic range for every sample."""
+    df = _pan_cancer_ntpm_sample("liver")
+    ctx = infer_sample_context(df)
+    s = ctx.signals
+    for key in (
+        "n_genes_with_any_expression",
+        "genes_detected_above_0p5_tpm",
+        "genes_detected_above_1_tpm",
+        "genes_detected_above_10_tpm",
+        "log2_tpm_median",
+        "log2_tpm_iqr",
+        "log2_tpm_p95",
+        "top_1pct_share_of_total_tpm",
+    ):
+        assert key in s, f"{key} missing from signals"
+    assert s["n_genes_with_any_expression"] > 5000
+    assert 0 < s["top_1pct_share_of_total_tpm"] <= 1.0
+
+
+def test_plot_sample_context_writes_png(tmp_path):
+    from pirlygenes.sample_context import plot_sample_context
+
+    df = _pan_cancer_ntpm_sample("liver")
+    ctx = infer_sample_context(df)
+    out = tmp_path / "sample-context.png"
+    plot_sample_context(ctx, save_to_filename=str(out), save_dpi=80)
+    assert out.exists()
+    assert out.stat().st_size > 1000
+
+
+def test_histone_prefixes_include_both_hgnc_old_and_new():
+    # Guard against accidental deletion: we detect histones whether
+    # annotations use old HIST1H* names or modern HGNC H2AC*/H3C*/H4C*.
+    prefixes = _HISTONE_SYMBOL_PREFIXES
+    assert "H2BC" in prefixes
+    assert "H3C" in prefixes
+    assert "HIST1H" in prefixes


### PR DESCRIPTION
## Summary

Introduces a unified 5-stage attribution flow and lands its first stage: a `SampleContext` inferred from the expression table alone, **before** cancer-type inference, and propagated forward as the base layer of expression expectations that every downstream stage reads.

The five stages articulated in the new README section:

1. **Sample context** — library prep + preservation + degradation, runs first
2. **Coarse healthy-tissue decomposition** (existing)
3. **Fine TME subtype / activation dissection** (in progress — follow-up work)
4. **Tumor-value adjustment** — subtract explained-by-non-tumor before crediting tumor
5. **Conservative tumor-specific core** — bounded, with low-purity caveat

## What's in this PR

- New `pirlygenes/sample_context.py`:
  - `SampleContext` dataclass with library_prep / preservation / degradation_severity / missing_mt / signals / flags + computed downstream adjustment factors (`long_transcript_weight_factor`, `purity_ci_widening_factor`, `summary_line`).
  - `infer_sample_context(df_gene_expr)`: tissue-independent detection via replication-dependent histone fraction + MT rRNA presence (poly-A / ribo-depleted / total RNA / exome capture) + gene-length matched-pair index for FFPE / degradation. Includes expression-distribution signals (detection breadth, log2 TPM median + IQR, top-1% concentration) — covers the preliminary-summary themes of #68.
  - `plot_sample_context(ctx, ...)`: standalone PNG per the plot-crowding preference — header text block + three diagnostic fraction bars with thresholds.
- Propagation into `analyze`:
  - Runs right after `load_expression_data`, before any strip plots or cancer-type inference.
  - Purity CIs widened multiplicatively by degradation severity (#26).
  - summary.md gains a sample-context line; targets.md gains a low-purity (<20%) caveat for #35 and a degradation caveat when the sample is FFPE / moderately-or-severely degraded.
- README: new "Attribution flow: make it make sense" section articulating the 5-stage chain.
- Stashed scoring-display changes folded in: `support_geomean` + `support_norm` shown alongside `signature_score` in cancer-type call output and candidate-ranking table, with defensive `.get(...)` defaults so mocked-analysis tests stay valid.

## Issues

Addressed directly or surfaced in the report:
- #26 widen purity CIs under degradation — direct widening factor
- #27 degradation index surfaced in the sample-context PNG
- #28 library-prep inference — subsumed by `infer_sample_context`
- #35 low-purity TME target inflation — explicit targets.md caveat
- #61 missing-MT genes detected + flagged
- #62 sample-context inference + propagation — this PR
- #68 expression-range / prep-signatures — signals collected here

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 193 passed, 1 skipped (was 180; +13 new tests in `tests/test_sample_context.py`, including all four library-prep signatures, FFPE detection, missing-MT, plot writer, and monotonicity of the downstream adjustment factors)
- [x] Existing tests unchanged

## Release

This is v4.0.0. Major bump because report shape changes (new summary.md and targets.md sections; new PNG file in output dir) and `SampleContext` is now a pervasive base layer — a reasonable break point to re-pin downstream consumers.