### PR TITLE
feat(v4.1.0): report clarity + --met-site (#13, #32, #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Key decomposition-related options:
 | `--sample-mode` | `auto` (default), `solid` (solid tumor biopsy), `heme` (hematologic malignancy), `pure` (cell line / sorted population) |
 | `--tumor-context` | `auto` (default), `primary` (restricts to primary-site templates), `met` (restricts to metastatic templates) |
 | `--site-hint` | Metastatic site (e.g. `liver`, `lung`, `brain`, `bone`) — selects the matching met template |
+| `--met-site` | Biopsy site for TME background augmentation (`primary`, `lymph_node`, `liver`, `brain`, `lung`, `bone`). Adds the host tissue to the TME reference so tumor-expression estimates aren't inflated by unsubtracted host signal (e.g. CD74 in a lymph-node met). |
 | `--decomposition-templates` | Comma-separated explicit template list (e.g. `solid_primary,met_liver`) |
 | `--label-genes` | Comma-separated genes to always label in plots |
 

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -193,11 +193,20 @@ def analyze(
     sample_mode: str = "auto",
     tumor_context: str = "auto",
     site_hint: Optional[str] = None,
+    met_site: Optional[str] = None,
     decomposition_templates: Optional[str] = None,
     therapy_target_top_k: int = 10,
     therapy_target_tpm_threshold: float = 30.0,
 ):
     from pathlib import Path
+
+    # Validate met_site up front, before any I/O, so bad values fail fast.
+    if met_site is not None:
+        from .plot import MET_SITE_TISSUE_AUGMENTATION as _MET_SITE_MAP
+        if met_site not in _MET_SITE_MAP:
+            raise ValueError(
+                f"--met-site must be one of {sorted(_MET_SITE_MAP.keys())}, got {met_site!r}"
+            )
 
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -295,6 +304,7 @@ def analyze(
     print("[analysis] Running sample composition analysis...")
     analysis = analyze_sample(df_expr, cancer_type=cancer_type)
     analysis["sample_context"] = sample_context
+    analysis["cancer_type_source"] = "user-specified" if cancer_type else "auto-detected"
 
     # Stage 1 propagation: widen purity confidence intervals under
     # detected degradation (#26). A noisier sample has a noisier purity
@@ -322,6 +332,7 @@ def analyze(
         tumor_context=tumor_context,
         site_hint=site_hint,
         decomposition_templates=template_overrides,
+        met_site=met_site,
     )
     cancer_code = analysis["cancer_type"]
     purity = analysis["purity"]
@@ -642,7 +653,11 @@ def analyze(
     # Generate text reports
     print("[report] Generating text reports...")
     _embedding_meta = get_embedding_feature_metadata(method="hierarchy")
-    _generate_text_reports(analysis, _embedding_meta, prefix, decomp_results=decomp_results)
+    _generate_text_reports(
+        analysis, _embedding_meta, prefix,
+        decomp_results=decomp_results,
+        input_path=input_path,
+    )
 
 
     # Cancer-type-specific gene set plot (only when --cancer-type specified)
@@ -680,6 +695,7 @@ def analyze(
             cancer_type=effective_cancer_type,
             purity_result=purity_dict,
             decomposition_results=decomp_results,
+            met_site=analysis.get("analysis_constraints", {}).get("met_site"),
         )
         ranges_tsv = "%s-tumor-expression-ranges.tsv" % prefix if prefix else "tumor-expression-ranges.tsv"
         ranges_df.to_csv(ranges_tsv, sep="\t", index=False)
@@ -1016,6 +1032,7 @@ def _analysis_constraints(
     tumor_context="auto",
     site_hint=None,
     decomposition_templates=None,
+    met_site=None,
 ):
     constraints = {}
     if cancer_type:
@@ -1028,6 +1045,8 @@ def _analysis_constraints(
         constraints["site_hint"] = site_hint
     if decomposition_templates:
         constraints["decomposition_templates"] = list(decomposition_templates)
+    if met_site:
+        constraints["met_site"] = met_site
     return constraints
 
 
@@ -1097,7 +1116,24 @@ def _summarize_sample_call(analysis, decomp_results, sample_mode):
     }
 
 
-def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None):
+def _next_best_support_gap(candidate_trace):
+    """Return (next_best_code, support_ratio) — ratio of top support_norm
+    over the second candidate's support_norm, or None when unavailable.
+    """
+    if not candidate_trace or len(candidate_trace) < 2:
+        return None, None
+    top = candidate_trace[0]
+    runner = candidate_trace[1]
+    top_n = float(top.get("support_norm", 0.0) or 0.0)
+    runner_n = float(runner.get("support_norm", 0.0) or 0.0)
+    if runner_n <= 0:
+        return runner.get("code"), None
+    return runner.get("code"), top_n / runner_n
+
+
+def _generate_text_reports(
+    analysis, embedding_meta, prefix, decomp_results=None, input_path=None,
+):
     """Write summary and detailed analysis markdown reports."""
     cancer_code = analysis["cancer_type"]
     cancer_name = analysis["cancer_name"]
@@ -1133,19 +1169,36 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
     subtype_clause = family_summary.get("subtype_clause")
     lead_candidate = candidate_trace[0]["code"] if candidate_trace else None
     constrained_cancer = constraints.get("cancer_type")
+
+    # Cancer-type call line. Qualitative, not raw composite-score (#32):
+    # show "top match, X× over next-best <CODE>" built from support_norm,
+    # and whether the call was auto-detected vs user-specified (#33).
+    source_label = {
+        "auto-detected": "auto-detected",
+        "user-specified": "user-specified",
+    }.get(analysis.get("cancer_type_source"), "")
+    source_suffix = f" ({source_label})" if source_label else ""
+    next_best_code, support_ratio = _next_best_support_gap(candidate_trace)
     if family_display:
         intro = f"The sample most closely matches **{family_display}**"
         if subtype_clause:
             if constrained_cancer and lead_candidate and constrained_cancer != lead_candidate:
-                intro += f", with **{cancer_code}** as the constrained working subtype"
+                intro += f", with **{cancer_code}** as the constrained working subtype{source_suffix}"
             else:
-                intro += f", with **{cancer_code}** as the current best subtype hypothesis"
-        intro += f" (score {analysis['cancer_score']:.3f}). "
+                intro += f", with **{cancer_code}** as the current best subtype hypothesis{source_suffix}"
+        intro += ". "
     else:
         intro = (
-            f"The sample most closely matches **{cancer_name} ({cancer_code})** "
-            f"(score {analysis['cancer_score']:.3f}). "
+            f"The sample most closely matches **{cancer_name} ({cancer_code})**"
+            f"{source_suffix}. "
         )
+    if next_best_code and support_ratio is not None and support_ratio > 1.0:
+        intro += (
+            f"Support is **{support_ratio:.1f}× over next-best {next_best_code}**. "
+        )
+    if fit_quality.get("label") and fit_quality.get("message"):
+        intro += f"Fit quality: *{fit_quality['label']}* — {fit_quality['message']} "
+
     summary = intro + _summary_mode_clause(sample_mode, purity, top_tissues) + (
         f"MHC-I expression is {mhc_level} "
         f"(HLA-A={hla_a:.0f}, HLA-B={hla_b:.0f}, B2M={b2m:.0f} TPM). "
@@ -1156,8 +1209,6 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
             " The tumor-specific signature panel was materially weaker and less stable than "
             "the lineage panel, so it was downweighted rather than used as a hard lower anchor."
         )
-    if fit_quality.get("message"):
-        summary += f" {fit_quality['message']}"
     if constraints:
         constraint_parts = []
         if constraints.get("cancer_type"):
@@ -1174,17 +1225,35 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
                 + ", ".join(constraints["decomposition_templates"])
                 + "**"
             )
+        if constraints.get("met_site"):
+            constraint_parts.append(
+                f"biopsy site **{constraints['met_site']}** (TME reference augmented)"
+            )
         if constraint_parts:
             summary += " Analysis constraints: " + "; ".join(constraint_parts) + "."
+    # Only surface the decomposition line when its call materially differs
+    # from the headline call (#33: the tumor fraction % is identical to the
+    # already-stated purity, so repeating it is noise).
     if call_summary.get("site_indeterminate"):
         summary += " Decomposition recovered broad admixture structure, but site/template assignment is indeterminate."
     elif best_decomp is not None:
-        summary += (
-            f" Best {_decomposition_section_title(sample_mode).lower()}: "
-            f"**{best_decomp.cancer_type} / {best_decomp.template}** "
-            f"with {_decomposition_fraction_label(sample_mode)} **{best_decomp.purity:.0%}**."
+        decomp_piece = (
+            f" Decomposition template: **{best_decomp.cancer_type} / {best_decomp.template}**"
         )
+        if (
+            getattr(best_decomp, "cancer_type", None)
+            and best_decomp.cancer_type != cancer_code
+        ):
+            decomp_piece += " (differs from headline call)"
+        summary += decomp_piece + "."
     summary += ambiguity_clause
+    # Tissue-score caveat (#33): readers were interpreting similarity
+    # scores as composition percentages. One short line clarifies.
+    if top_tissues:
+        summary += (
+            "\n\n*Note: background tissue scores are normalised similarity "
+            "to reference nTPM profiles, not composition percentages.*"
+        )
 
     # Sample context (stage 1 of unified attribution flow) lands as the
     # first framing line after the cancer-type summary, so readers see
@@ -1209,8 +1278,11 @@ def _generate_text_reports(analysis, embedding_meta, prefix, decomp_results=None
         summary += "\n\n**Quality note**: " + "; ".join(quality["flags"]) + "."
 
     summary_path = "%s-summary.md" % prefix if prefix else "summary.md"
+    header = "# Sample Analysis Summary\n"
+    if input_path:
+        header += f"\n*Input*: `{input_path}`\n"
     with open(summary_path, "w") as f:
-        f.write(f"# Sample Analysis Summary\n\n{summary}\n")
+        f.write(f"{header}\n{summary}\n")
     print(f"[report] Saved {summary_path}")
 
     # --- Detailed report ---

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -2036,6 +2036,7 @@ def estimate_tumor_expression_ranges(
     cancer_type,
     purity_result,
     decomposition_results=None,
+    met_site=None,
 ):
     """Estimate tumor-specific expression with uncertainty bounds.
 
@@ -2107,8 +2108,15 @@ def estimate_tumor_expression_ranges(
         if c.replace("nTPM_", "") not in _REPRODUCTIVE_TISSUES
     ]
 
-    # TME tissues (curated immune + stromal)
-    tme_cols = [c for c in ntpm_nonrepro if c.replace("nTPM_", "") in _TME_TISSUES]
+    # TME tissues (curated immune + stromal). Met-site aware: when the
+    # caller supplies ``met_site``, union in the host tissues for that
+    # biopsy site so the TME background reflects, e.g., lymph-node
+    # infiltrate for a nodal met (#13). Uniform median falls back to
+    # the default curated set.
+    effective_tme_tissues = set(_TME_TISSUES)
+    if met_site:
+        effective_tme_tissues |= MET_SITE_TISSUE_AUGMENTATION.get(met_site, set())
+    tme_cols = [c for c in ntpm_nonrepro if c.replace("nTPM_", "") in effective_tme_tissues]
 
     # --- HK-normalize reference columns ---
     # Each column (nTPM tissue or FPKM cancer type) gets its own HK median
@@ -3082,6 +3090,23 @@ _IMMUNE_TISSUES = {
 }
 
 _TME_TISSUES = _STROMAL_TISSUES | _IMMUNE_TISSUES
+
+# Met-site tissue augmentation (#13). When a biopsy was taken from a
+# specific metastatic site, its host-tissue contribution should be
+# represented in the TME background so tumor-expression estimates are
+# not inflated by unsubtracted host-tissue signal. Each entry lists
+# tissues to **add** to the TME reference; passing an empty set (for
+# `primary`) leaves the default set untouched.
+MET_SITE_TISSUE_AUGMENTATION = {
+    "primary":    set(),
+    "lymph_node": {"lymph_node", "spleen", "thymus", "tonsil"},
+    "liver":      {"liver"},
+    "brain":      {"cerebral_cortex", "cerebellum"},
+    "lung":       {"lung"},
+    "bone":       {"bone_marrow"},
+}
+
+MET_SITES = tuple(MET_SITE_TISSUE_AUGMENTATION.keys())
 
 # Clinically important genes with low TME background.  The data-driven
 # algorithm may miss these because their best z-score peaks in a sibling

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_report_clarity_and_met_site.py
+++ b/tests/test_report_clarity_and_met_site.py
@@ -1,0 +1,214 @@
+"""Tests for v4.1 report-clarity + met-site bundle (issues #13, #32, #33)."""
+
+import pandas as pd
+import pytest
+
+from pirlygenes.cli import _next_best_support_gap
+from pirlygenes.plot import MET_SITE_TISSUE_AUGMENTATION, estimate_tumor_expression_ranges
+from pirlygenes.gene_sets_cancer import pan_cancer_expression
+
+
+# ── #32: qualitative score language ────────────────────────────────────
+
+
+def test_next_best_support_gap_returns_ratio_for_two_candidates():
+    trace = [
+        {"code": "PRAD", "support_norm": 1.00},
+        {"code": "HNSC", "support_norm": 0.40},
+    ]
+    code, ratio = _next_best_support_gap(trace)
+    assert code == "HNSC"
+    assert ratio == pytest.approx(2.5, rel=1e-3)
+
+
+def test_next_best_support_gap_handles_edge_cases():
+    # One candidate — no gap to measure
+    assert _next_best_support_gap([{"code": "PRAD", "support_norm": 1.0}]) == (None, None)
+    # Empty
+    assert _next_best_support_gap([]) == (None, None)
+    # Runner-up has zero support — can't divide
+    code, ratio = _next_best_support_gap(
+        [
+            {"code": "PRAD", "support_norm": 1.0},
+            {"code": "HNSC", "support_norm": 0.0},
+        ]
+    )
+    assert code == "HNSC"
+    assert ratio is None
+
+
+# ── #13: met-site augmentation ─────────────────────────────────────────
+
+
+def test_met_site_augmentation_map_covers_all_sites_mentioned_in_issue():
+    """Issue #13 lists primary / lymph_node / liver / brain / lung / bone.
+    Any new met site exposed via CLI must live in the augmentation map
+    so downstream knows how to augment the TME reference."""
+    expected = {"primary", "lymph_node", "liver", "brain", "lung", "bone"}
+    assert expected.issubset(set(MET_SITE_TISSUE_AUGMENTATION.keys()))
+    # `primary` intentionally adds nothing — tumor is assumed in situ.
+    assert MET_SITE_TISSUE_AUGMENTATION["primary"] == set()
+
+
+def test_met_site_liver_includes_liver_tissue_in_tme_reference():
+    """Validates #13: a liver-met ``estimate_tumor_expression_ranges``
+    call should use a TME reference set that includes ``liver``, while
+    the default (met_site=None) does not."""
+    # Small synthetic sample drawn from the bundled reference so the
+    # function can actually run.
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    df = pd.DataFrame(
+        {
+            "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+            "gene_symbol": ref["Symbol"],
+            "TPM": ref["nTPM_liver"].astype(float),  # a liver-rich synthetic
+        }
+    )
+    purity = {
+        "overall_estimate": 0.6, "overall_lower": 0.4, "overall_upper": 0.8,
+        "components": {"stromal": {"enrichment": 1.0}, "immune": {"enrichment": 1.0}},
+    }
+
+    baseline = estimate_tumor_expression_ranges(
+        df_gene_expr=df, cancer_type="COAD", purity_result=purity,
+        met_site=None,
+    )
+    augmented = estimate_tumor_expression_ranges(
+        df_gene_expr=df, cancer_type="COAD", purity_result=purity,
+        met_site="liver",
+    )
+
+    # TME medians for liver-expressed genes (ALB, APOA1, HP) should be
+    # materially higher under the liver-augmented reference, since
+    # adding the liver column to the TME tissue set raises the
+    # percentile for liver-high genes.
+    def _tme_med(df_, symbol):
+        sub = df_[df_["symbol"] == symbol]
+        if sub.empty:
+            return None
+        # estimate_tumor_expression_ranges reports the TME background
+        # as a fold-over-HK median; a higher value means the reference
+        # TME set picks up more of this gene's signal.
+        return float(sub.iloc[0]["tme_fold_med"])
+
+    alb_baseline = _tme_med(baseline, "ALB")
+    alb_augmented = _tme_med(augmented, "ALB")
+    # Both runs should produce an ALB row (it's a reference gene).
+    assert alb_baseline is not None
+    assert alb_augmented is not None
+    # Augmented reference must have higher or equal TME contribution
+    # for the host-tissue gene.
+    assert alb_augmented >= alb_baseline
+    # And strictly higher when liver signal is the distinguishing
+    # factor (ALB is nearly liver-only).
+    assert alb_augmented > alb_baseline
+
+
+def test_met_site_rejects_unknown_value():
+    """Invalid met_site passed directly to the estimator is a no-op on
+    the set-union rather than a crash (the CLI layer validates before
+    reaching here). The function must not error on unknown strings."""
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    df = pd.DataFrame(
+        {
+            "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+            "gene_symbol": ref["Symbol"],
+            "TPM": ref["nTPM_liver"].astype(float),
+        }
+    )
+    purity = {
+        "overall_estimate": 0.6, "overall_lower": 0.4, "overall_upper": 0.8,
+        "components": {"stromal": {"enrichment": 1.0}, "immune": {"enrichment": 1.0}},
+    }
+    # Must not crash on unknown met_site (augmentation map .get default
+    # is an empty set). CLI validates up front in analyze().
+    ranges = estimate_tumor_expression_ranges(
+        df_gene_expr=df, cancer_type="COAD", purity_result=purity,
+        met_site="moon",
+    )
+    assert len(ranges) > 0
+
+
+def test_summary_md_structure_for_report_clarity(tmp_path):
+    """#33: summary.md should include the input filename, the source
+    attribution (auto vs user-specified), the tissue-score caveat, and
+    no raw ``score 0.019``-style composite number in the prose."""
+    from pirlygenes.cli import _generate_text_reports
+
+    analysis = {
+        "cancer_type": "PRAD",
+        "cancer_name": "Prostate Adenocarcinoma",
+        "cancer_score": 0.019,  # realistic low composite
+        "cancer_type_source": "auto-detected",
+        "top_cancers": [("PRAD", 0.019)],
+        "purity": {
+            "overall_estimate": 0.11,
+            "overall_lower": 0.01,
+            "overall_upper": 0.11,
+            "components": {
+                "stromal": {"enrichment": 4.3},
+                "immune": {"enrichment": 2.5},
+            },
+        },
+        "tissue_scores": [
+            ("prostate", 0.90, 20),
+            ("smooth_muscle", 0.72, 18),
+            ("rectum", 0.71, 17),
+        ],
+        "mhc1": {"HLA-A": 25, "HLA-B": 30, "HLA-C": 22, "B2M": 3000},
+        "mhc2": {},
+        "candidate_trace": [
+            {"code": "PRAD", "support_norm": 1.00, "signature_score": 0.67},
+            {"code": "HNSC", "support_norm": 0.40, "signature_score": 0.35},
+        ],
+        "family_summary": {},
+        "fit_quality": {"label": "strong_separation", "message": "Top match is clearly separated from alternatives."},
+        "sample_mode": "solid",
+        "analysis_constraints": {},
+    }
+
+    prefix = str(tmp_path / "sample")
+    # Minimal embedding_meta shape — summary.md is written first, before
+    # the more demanding analysis.md fields are consulted.
+    embedding_meta = {
+        "method": "hierarchy", "feature_kind": "hierarchical_scores",
+        "n_genes": 0, "n_features": 0, "n_types": 33, "families": [],
+    }
+    try:
+        _generate_text_reports(
+            analysis, embedding_meta, prefix,
+            decomp_results=[], input_path="/data/sample_BG002.tsv",
+        )
+    except KeyError:
+        # analysis.md generation may need more context than this fixture
+        # provides — we only assert on summary.md below.
+        pass
+
+    summary_md = (tmp_path / "sample-summary.md").read_text()
+    # Input filename header (#33)
+    assert "/data/sample_BG002.tsv" in summary_md
+    # Source attribution (#33)
+    assert "auto-detected" in summary_md
+    # Raw composite score 0.019 should NOT appear in prose (#32).
+    assert "0.019" not in summary_md, (
+        "Raw composite cancer_score must not be in summary prose (#32)."
+    )
+    # Qualitative ratio instead (#32) — top match is 2.5× HNSC.
+    assert "2.5" in summary_md and "HNSC" in summary_md
+    # Tissue score caveat (#33)
+    assert "similarity" in summary_md.lower()
+
+
+def test_cli_analyze_rejects_invalid_met_site(monkeypatch, tmp_path):
+    """CLI-level validation: analyze() should raise ValueError on
+    an unknown --met-site value rather than silently ignoring it."""
+    from pirlygenes import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "load_expression_data", lambda *a, **k: pd.DataFrame({"x": [1]}))
+    out_dir = str(tmp_path / "out")
+    with pytest.raises(ValueError):
+        cli_mod.analyze(
+            "input.csv",
+            output_dir=out_dir,
+            met_site="not_a_site",
+        )


### PR DESCRIPTION
## Summary

One coherent bundle covering the **report / presentation clarity** tier:

- **#33** — `summary.md` gains `*Input*:` filename header, auto-detected vs user-specified attribution, drops the duplicate tumor-fraction line, adds a tissue-score similarity caveat.
- **#32** — summary prose no longer shows the raw multiplicative composite (`score 0.019`). Replaced with qualitative "top match, X.X× over next-best `<CODE>`" plus the fit-quality label. Raw scores stay in the detailed `analysis.md` table for power users.
- **#13** — new `--met-site` CLI arg (`primary | lymph_node | liver | brain | lung | bone`). When set, the site's host tissues are unioned into `_TME_TISSUES` inside `estimate_tumor_expression_ranges`, so TME percentiles reflect the biopsy site and tumor-expression estimates aren't inflated by unsubtracted host signal (the CD74-in-lymph-node-PRAD case from the issue).
- **#34** — already shipped; closed separately as part of this bundle's intake.

## What changed

- `pirlygenes/plot.py`: new `MET_SITE_TISSUE_AUGMENTATION` map + `MET_SITES` tuple; `estimate_tumor_expression_ranges` takes a `met_site` parameter that unions augmentation tissues into the TME reference set.
- `pirlygenes/cli.py`: `analyze` grows a `met_site: Optional[str]` arg (validated up front); `_analysis_constraints` carries `met_site`; `_generate_text_reports` accepts `input_path=` and reformats the intro; new `_next_best_support_gap` helper computes the qualitative ratio; tissue-score caveat appended.
- `README.md`: documents `--met-site`.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 200 passed, 1 skipped (was 193; +7 new in `tests/test_report_clarity_and_met_site.py`)
- [x] End-to-end liver-met augmentation raises `tme_fold_med` for ALB (host-tissue gene) relative to the default TME set — confirms the augmentation actually flows into percentile computation.
- [x] `summary.md` contains input filename + auto-detected attribution + qualitative ratio over next-best + tissue-score caveat, and does NOT contain the raw composite score.
- [x] CLI `analyze()` raises `ValueError` on unknown `--met-site`.

Closes #13, #32, #33.