### PR TITLE
[codex] Fix transcript resolution and purity overconfidence

### DIFF
--- a/pirlygenes/aggregate_gene_expression.py
+++ b/pirlygenes/aggregate_gene_expression.py
@@ -22,6 +22,7 @@ from tqdm import tqdm
 
 from .common import find_column
 from .gene_ids import (
+    _build_indexes,
     find_gene_and_ensembl_release_by_name,
     find_gene_name_from_ensembl_transcript_id,
 )
@@ -101,6 +102,10 @@ def aggregate_gene_expression(
                 f"[aggregate] Resolving {len(unknown_unique)} unique transcripts via Ensembl lookup"
             )
 
+        # Build the Ensembl index *before* the progress bar starts so the
+        # user doesn't see a 0% bar stuck while the index loads.
+        _build_indexes()
+
         @lru_cache(maxsize=None)
         def _resolve_tx(t: str):
             g = find_gene_name_from_ensembl_transcript_id(t, verbose=False)
@@ -122,6 +127,9 @@ def aggregate_gene_expression(
 
     unknown_mask = gene_series.isna()
     unknown_genes_tpm = float(tpm[unknown_mask].sum())
+    unresolved_tx_count = int(unknown_mask.sum())
+    unresolved_unique_count = int(tx0[unknown_mask].nunique())
+    unresolved_high_tpm = []
 
     if verbose and unknown_mask.any():
         high_tpm_unknown = (
@@ -131,6 +139,10 @@ def aggregate_gene_expression(
             .sort_values("TPM", ascending=False)
         )
         high_tpm_unknown = high_tpm_unknown[high_tpm_unknown["TPM"] > 1]
+        unresolved_high_tpm = [
+            {"tx": str(row.tx), "TPM": float(row.TPM)}
+            for _, row in high_tpm_unknown.iterrows()
+        ]
         if len(high_tpm_unknown):
             print(
                 f"[aggregate] {len(high_tpm_unknown)} unresolved transcript IDs with TPM>1 (showing up to 20):"
@@ -182,5 +194,14 @@ def aggregate_gene_expression(
 
     if verbose:
         print(f"[aggregate] Completed aggregation with {len(df_gene_expr)} genes")
+    df_gene_expr.attrs["transcript_aggregation_stats"] = {
+        "known_tpm": known_genes_tpm,
+        "unknown_tpm": unknown_genes_tpm,
+        "known_fraction": float(pct_known / 100.0),
+        "unknown_fraction": float(unknown_genes_tpm / denom) if denom > 0 else 0.0,
+        "unresolved_row_count": unresolved_tx_count,
+        "unresolved_unique_count": unresolved_unique_count,
+        "unresolved_high_tpm": unresolved_high_tpm,
+    }
 
     return df_gene_expr

--- a/pirlygenes/decomposition/engine.py
+++ b/pirlygenes/decomposition/engine.py
@@ -140,6 +140,16 @@ DECOMPOSITION_PARAMETERS = {
         # selection finds too few rows and falls back to all expressed genes.
         "fallback_expression_floor": 0.05,
     },
+    # ── Matched-normal lineage override ────────────────────────────────
+    "lineage_override": {
+        # The matched-normal panel is allowed to correct an over-high
+        # signature purity downward (e.g. pure normal prostate run as
+        # PRAD), but large *upward* jumps are a red flag that the panel
+        # got contaminated by non-lineage genes. Reject those jumps.
+        "max_upward_delta": 0.25,
+        "max_upward_ratio": 2.0,
+        "ratio_floor": 0.05,
+    },
     # ── Template / hypothesis scoring ────────────────────────────────────
     # Final score = fit_score × (fit_score_base + fit_score_gain × cancer_support)
     #               × template_factor
@@ -624,6 +634,7 @@ def _fit_one_hypothesis(
     # purity flow.
     lineage_fraction_info = None
     purity_source = "signature"
+    warnings = []
     if (
         purity_override is None
         and matched_normal_name is not None
@@ -639,14 +650,34 @@ def _fit_one_hypothesis(
             and lineage_fraction_info["stability"] < 1.5
             and lineage_fraction_info["panel_genes_observed"] >= 10
         ):
-            tumor_fraction = float(lineage_fraction_info["estimate"])
-            purity_source = "lineage_panel"
-            purity_to_store = dict(purity_result or {})
-            purity_to_store["overall_estimate"] = tumor_fraction
-            purity_to_store["overall_lower"] = float(lineage_fraction_info["lower"])
-            purity_to_store["overall_upper"] = float(lineage_fraction_info["upper"])
-            purity_to_store["lineage_tumor_fraction"] = lineage_fraction_info
-            purity_to_store["purity_source"] = purity_source
+            candidate_purity = float(purity_result.get("overall_estimate") or 0.5)
+            lineage_estimate = float(lineage_fraction_info["estimate"])
+            override_params = DECOMPOSITION_PARAMETERS["lineage_override"]
+            upward_delta = lineage_estimate - candidate_purity
+            upward_ratio = (
+                lineage_estimate / max(candidate_purity, override_params["ratio_floor"])
+            )
+            if (
+                upward_delta > override_params["max_upward_delta"]
+                and upward_ratio > override_params["max_upward_ratio"]
+            ):
+                tumor_fraction = candidate_purity
+                purity_to_store = dict(purity_result or {})
+                purity_to_store["lineage_tumor_fraction"] = lineage_fraction_info
+                purity_to_store["purity_source"] = purity_source
+                warnings.append(
+                    "Lineage-panel purity conflicts with signature purity; "
+                    "kept the conservative signature prior"
+                )
+            else:
+                tumor_fraction = lineage_estimate
+                purity_source = "lineage_panel"
+                purity_to_store = dict(purity_result or {})
+                purity_to_store["overall_estimate"] = tumor_fraction
+                purity_to_store["overall_lower"] = float(lineage_fraction_info["lower"])
+                purity_to_store["overall_upper"] = float(lineage_fraction_info["upper"])
+                purity_to_store["lineage_tumor_fraction"] = lineage_fraction_info
+                purity_to_store["purity_source"] = purity_source
         else:
             tumor_fraction = float(purity_result.get("overall_estimate") or 0.5)
             purity_to_store = purity_result
@@ -662,8 +693,6 @@ def _fit_one_hypothesis(
             "purity_source": "override",
         }
         purity_source = "override"
-    warnings = []
-
     if not comp_names or tumor_fraction >= 0.999:
         return DecompositionResult(
             template=template_name,

--- a/pirlygenes/gene_ids.py
+++ b/pirlygenes/gene_ids.py
@@ -37,6 +37,8 @@ _installed_releases = " ".join([str(g.release) for g in genomes])
 _gene_id_to_name: dict = {}
 _transcript_id_to_gene_name: dict = {}
 _indexes_built = False
+_gene_id_miss_cache: set[str] = set()
+_transcript_id_miss_cache: set[str] = set()
 
 
 def _build_indexes():
@@ -64,11 +66,54 @@ def _build_indexes():
     _indexes_built = True
 
 
+def _lookup_gene_name_in_older_releases(gene_id: str) -> Optional[str]:
+    """Resolve a gene ID against older installed releases on demand.
+
+    The fast path indexes only the newest release. When a sample was
+    quantified against an older annotation, valid IDs can disappear from
+    that latest-only map; we need a correctness-preserving fallback
+    instead of silently treating them as unresolved.
+    """
+    gid = gene_id.split(".")[0]
+    if gid in _gene_id_miss_cache:
+        return None
+    for genome in genomes[1:]:
+        try:
+            gene = genome.gene_by_id(gid)
+        except Exception:
+            gene = None
+        if gene and gene.gene_name:
+            _gene_id_to_name[gid] = gene.gene_name
+            return gene.gene_name
+    _gene_id_miss_cache.add(gid)
+    return None
+
+
+def _lookup_transcript_name_in_older_releases(t_id: str) -> Optional[str]:
+    """Resolve a transcript ID against older installed releases on demand."""
+    tid = t_id.split(".")[0]
+    if tid in _transcript_id_miss_cache:
+        return None
+    for genome in genomes[1:]:
+        try:
+            transcript = genome.transcript_by_id(tid)
+        except Exception:
+            transcript = None
+        if transcript and transcript.gene_name:
+            _transcript_id_to_gene_name[tid] = transcript.gene_name
+            return transcript.gene_name
+    _transcript_id_miss_cache.add(tid)
+    return None
+
+
 def find_gene_name_from_ensembl_gene_id(
     gene_id: str, verbose: bool = False
 ) -> Optional[str]:
     _build_indexes()
-    name = _gene_id_to_name.get(gene_id.split(".")[0])
+    gid = gene_id.split(".")[0]
+    name = _gene_id_to_name.get(gid)
+    if name is None:
+        name = _lookup_gene_name_in_older_releases(gid)
     if name and verbose:
         print("Found %s -> %s" % (gene_id, name))
     return name
@@ -78,7 +123,10 @@ def find_gene_name_from_ensembl_transcript_id(
     t_id: str, verbose: bool = False
 ) -> Optional[str]:
     _build_indexes()
-    name = _transcript_id_to_gene_name.get(t_id.split(".")[0])
+    tid = t_id.split(".")[0]
+    name = _transcript_id_to_gene_name.get(tid)
+    if name is None:
+        name = _lookup_transcript_name_in_older_releases(tid)
     if name and verbose:
         print("Found %s -> %s" % (t_id, name))
     return name

--- a/pirlygenes/load_expression.py
+++ b/pirlygenes/load_expression.py
@@ -58,6 +58,8 @@ _RAW_FPKM_PATTERNS = [
     r"^mrna[_\s]?fpkm$",
 ]
 
+_MAX_UNRESOLVED_TRANSCRIPT_TPM_FRACTION = 0.05
+
 
 def _guess_col(columns, patterns):
     """Return the first column that matches any pattern, or None."""
@@ -259,6 +261,40 @@ def _first_non_empty(series):
         if pd.notna(val) and str(val).strip() != "":
             return val
     return series.iloc[0] if len(series) else None
+
+
+def _raise_if_transcript_aggregation_incomplete(df, input_path):
+    """Fail fast when transcript aggregation lost too much nonzero signal.
+
+    Downstream purity / ranking code interprets a missing symbol as 0 TPM
+    via ``dict.get(symbol, 0.0)``. If transcript->gene aggregation drops a
+    substantial chunk of TPM mass, continuing would produce overconfident
+    calls from a materially incomplete expression vector.
+    """
+    stats = df.attrs.get("transcript_aggregation_stats") or {}
+    unknown_fraction = float(stats.get("unknown_fraction") or 0.0)
+    if unknown_fraction <= _MAX_UNRESOLVED_TRANSCRIPT_TPM_FRACTION:
+        return
+
+    unknown_tpm = float(stats.get("unknown_tpm") or 0.0)
+    known_tpm = float(stats.get("known_tpm") or 0.0)
+    unresolved_unique = int(stats.get("unresolved_unique_count") or 0)
+    preview = stats.get("unresolved_high_tpm") or []
+    preview_text = ", ".join(
+        f"{row['tx']} ({row['TPM']:.1f} TPM)" for row in preview[:5]
+    )
+    if preview_text:
+        preview_text = f" Top unresolved transcripts: {preview_text}."
+    raise ValueError(
+        "Transcript-level aggregation left too much signal unresolved for "
+        f"{input_path}: {unknown_tpm:.1f} TPM ({unknown_fraction:.1%}) across "
+        f"{unresolved_unique} unique transcript IDs remained unmapped "
+        f"(known TPM={known_tpm:.1f}). This usually means the sample was "
+        "quantified against an older or mismatched Ensembl annotation. "
+        "Refusing to continue because downstream purity/classification code "
+        "would silently treat those genes as 0 TPM."
+        + preview_text
+    )
 
 
 def _apply_id_aliases_and_sum(df, verbose=True):
@@ -491,7 +527,10 @@ def _resolve_unknown_transcripts_to_genes(tx0_unique, verbose=False, progress=Tr
     ``tx2gene`` so the load path resolves the transcript set exactly
     once per file (#81).
     """
-    from .gene_ids import find_gene_name_from_ensembl_transcript_id
+    from .gene_ids import find_gene_name_from_ensembl_transcript_id, _build_indexes
+    # Build the Ensembl index *before* the progress bar starts so the
+    # user doesn't see a 0% bar stuck while the index loads.
+    _build_indexes()
     if verbose:
         print(f"[load] Resolving {len(tx0_unique)} unique transcripts via Ensembl")
     iterator = tqdm(
@@ -722,6 +761,7 @@ def load_expression_data(
             df, verbose=verbose, progress=progress,
             tx_to_gene_name=shared_tx_map,
         )
+        _raise_if_transcript_aggregation_incomplete(df, input_path)
 
         if save_aggregated_gene_expression:
             if aggregated_output_path:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.6.2"
+__version__ = "4.6.3"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_gene_ids_unit.py
+++ b/tests/test_gene_ids_unit.py
@@ -72,6 +72,8 @@ def test_lookup_functions_with_fake_genomes(monkeypatch):
     monkeypatch.setattr(gi, "_indexes_built", False)
     monkeypatch.setattr(gi, "_gene_id_to_name", {})
     monkeypatch.setattr(gi, "_transcript_id_to_gene_name", {})
+    monkeypatch.setattr(gi, "_gene_id_miss_cache", set())
+    monkeypatch.setattr(gi, "_transcript_id_miss_cache", set())
 
     assert gi.find_gene_name_from_ensembl_gene_id("ENSGA", verbose=False) == "GENEA"
     assert gi.find_gene_name_from_ensembl_transcript_id("ENST1", verbose=False) == "GENEA"
@@ -83,6 +85,28 @@ def test_lookup_functions_with_fake_genomes(monkeypatch):
     assert gi.find_gene_by_name_from_ensembl("CD276", verbose=False).id == "ENSGX"
     assert gi.find_gene_id_by_name_from_ensembl("CD276", verbose=False) == "ENSGX"
     assert gi.find_canonical_gene_id_and_name("CD276") == ("ENSGX", "CD276")
+
+
+def test_lookup_functions_fall_back_to_older_release_on_latest_miss(monkeypatch):
+    older_gene = FakeGene("ENSGOLD", "OLDER")
+    older_tx = SimpleNamespace(gene_name="OLDER")
+    genomes = [
+        FakeGenome(release=112),
+        FakeGenome(
+            release=111,
+            gene_by_id_map={"ENSGOLD": older_gene},
+            tx_by_id_map={"ENSTOLD": older_tx},
+        ),
+    ]
+    monkeypatch.setattr(gi, "genomes", genomes)
+    monkeypatch.setattr(gi, "_indexes_built", False)
+    monkeypatch.setattr(gi, "_gene_id_to_name", {})
+    monkeypatch.setattr(gi, "_transcript_id_to_gene_name", {})
+    monkeypatch.setattr(gi, "_gene_id_miss_cache", set())
+    monkeypatch.setattr(gi, "_transcript_id_miss_cache", set())
+
+    assert gi.find_gene_name_from_ensembl_gene_id("ENSGOLD", verbose=False) == "OLDER"
+    assert gi.find_gene_name_from_ensembl_transcript_id("ENSTOLD", verbose=False) == "OLDER"
 
 
 def test_find_canonical_gene_ids_and_names(monkeypatch):

--- a/tests/test_load_expression.py
+++ b/tests/test_load_expression.py
@@ -91,6 +91,39 @@ def test_load_expression_aggregate_and_save(tmp_path, monkeypatch):
     assert list(out["ensembl_gene_id"]) == ["ENSG1"]
 
 
+def test_load_expression_aggregate_raises_on_large_unresolved_fraction(tmp_path, monkeypatch):
+    p = tmp_path / "tx.csv"
+    pd.DataFrame({"transcript": ["tx1"], "tpm": [1.0]}).to_csv(p, index=False)
+
+    def _fake_tx2gene(*_args, **_kwargs):
+        out = pd.DataFrame(
+            {
+                "gene": ["GENE1"],
+                "TPM": [1.0],
+                "gene_id": ["ENSG1"],
+                "ensembl_release": [112],
+            }
+        )
+        out.attrs["transcript_aggregation_stats"] = {
+            "known_tpm": 910000.0,
+            "unknown_tpm": 90000.0,
+            "unknown_fraction": 0.09,
+            "unresolved_unique_count": 123,
+            "unresolved_high_tpm": [{"tx": "ENSTOLD1", "TPM": 1200.0}],
+        }
+        return out
+
+    monkeypatch.setattr(le, "tx2gene", _fake_tx2gene)
+
+    with pytest.raises(ValueError, match="silently treat those genes as 0 TPM"):
+        le.load_expression_data(
+            str(p),
+            aggregate_gene_expression=True,
+            verbose=False,
+            progress=False,
+        )
+
+
 def test_load_expression_with_gene_sidecar_skips_aggregation(tmp_path, monkeypatch):
     p = tmp_path / "sample.quant.sf.csv"
     sidecar = tmp_path / "Gene.csv"

--- a/tests/test_matched_normal.py
+++ b/tests/test_matched_normal.py
@@ -246,6 +246,53 @@ def test_estimate_ranges_non_epithelial_cancer_has_no_matched_normal_split():
     assert (ranges["matched_normal_tissue"].fillna("") == "").all()
 
 
+def test_lineage_override_rejects_large_upward_jump(monkeypatch):
+    """A matched-normal panel can correct an over-high signature purity
+    downward, but it must not jump a plausible low-purity call up to an
+    implausibly high value from a contaminated panel."""
+    from pirlygenes.decomposition import engine
+
+    monkeypatch.setattr(
+        engine,
+        "estimate_lineage_tumor_fraction",
+        lambda *_a, **_k: {
+            "estimate": 0.8,
+            "lower": 0.7,
+            "upper": 0.9,
+            "stability": 0.4,
+            "panel_size": 30,
+            "panel_genes_observed": 20,
+            "per_gene": [],
+        },
+    )
+
+    df = _tcga_sample("PRAD")
+    results = decompose_sample(
+        df,
+        cancer_types=["PRAD"],
+        candidate_rows=[
+            {
+                "code": "PRAD",
+                "signature_score": 0.7,
+                "purity_estimate": 0.2,
+                "support_norm": 1.0,
+                "purity_result": {
+                    "overall_estimate": 0.2,
+                    "overall_lower": 0.1,
+                    "overall_upper": 0.3,
+                },
+            }
+        ],
+        templates=["solid_primary"],
+        top_k=1,
+    )
+    assert len(results) == 1
+    result = results[0]
+    assert result.purity_source == "signature"
+    assert result.purity == pytest.approx(0.2)
+    assert any("Lineage-panel purity conflicts" in w for w in result.warnings)
+
+
 # ── vs_tcga label-routing fix (companion to issue #50 PR) ───────────────
 
 


### PR DESCRIPTION
## Summary

This fixes a misclassification / overconfidence path that showed up on the `~/data/rs` PRAD sample:

- older-but-valid Ensembl transcript IDs were no longer resolving during transcript-to-gene aggregation
- the loader then kept going with a materially incomplete expression vector
- downstream purity and cancer-type code treated unresolved genes as implicit `0 TPM`
- the matched-normal PRAD purity override could then jump far above the generic purity estimate from a contaminated panel

## Root Cause

A recent refactor changed transcript and gene ID resolution from "search all installed Ensembl releases" to "index only the newest installed release".

That broke samples quantified against older annotations. In the reported sample, high-TPM transcripts like older-release `HLA-DRA` isoforms and smooth-muscle `MYLK` isoforms stopped resolving, so substantial signal disappeared before ranking / purity / decomposition.

Separately, the matched-normal lineage override was allowed to replace a plausible low purity with a much higher panel estimate even when the two signals disagreed sharply. That made the run more confident than the evidence justified.

## What Changed

- restore correctness-preserving gene/transcript fallback lookup across older installed Ensembl releases when the latest-release index misses
- keep the latest-release index as the fast path, so common lookups stay cheap
- attach transcript-aggregation unresolved-signal stats and raise a hard loader error when too much TPM remains unmapped after aggregation
- reject large upward matched-normal purity overrides and keep the conservative signature prior instead
- bump the package version to `4.6.3`
- add regression tests for:
  - older-release ID fallback
  - fail-fast loader behavior on high unresolved transcript mass
  - rejecting large upward lineage-panel purity jumps

## Validation

- `pytest -n 0 tests/test_gene_ids_unit.py tests/test_load_expression.py tests/test_matched_normal.py`
- `pytest -n 0 tests/test_decomposition.py tests/test_plot_and_cli.py`
- direct repro on the reported sample after the fix:
  - `PRAD` ranks ahead of `HNSC` again
  - older-release `HLA-DRA` / `MYLK` transcript signal is restored
  - `PRAD / solid_primary` keeps the conservative purity prior instead of jumping to ~60%

## User Impact

This prevents confident but wrong calls when transcript annotations are mismatched, and it makes the matched-normal purity override behave conservatively when it conflicts with the primary purity evidence.
