### PR TITLE
[codex] Gate FN1 targeting on EDB transcripts

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -2609,6 +2609,19 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         landscape_cautions.append("some of the numerically highest surface rows are TME-dominant and should not be treated as tumor-cell targets")
     if matched_normal_summary:
         landscape_cautions.append("benign parent-tissue admixture is active")
+    if (
+        "therapy_supported" in ranges_df.columns
+        and "therapy_support_note" in ranges_df.columns
+    ):
+        fn1_blocked = ranges_df[
+            ranges_df["symbol"].eq("FN1")
+            & ~ranges_df["therapy_supported"].fillna(True).astype(bool)
+            & ranges_df["therapy_support_note"].fillna("").astype(str).str.len().gt(0)
+        ]
+        if len(fn1_blocked):
+            landscape_cautions.append(
+                fn1_blocked.sort_values("observed_tpm", ascending=False).iloc[0]["therapy_support_note"]
+            )
     if landscape_cautions:
         lines.append(f"- **Landscape cautions**: {'; '.join(landscape_cautions)}.")
     lines.append("")

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+from functools import lru_cache
 
 import seaborn as sns
 import matplotlib.pyplot as plt
@@ -18,6 +19,7 @@ import numpy as np
 
 from adjustText import adjust_text
 
+from .common import _guess_gene_cols  # re-exported; canonical home is common.py
 from .plot_data_helpers import prepare_gene_expr_df
 from .gene_ids import find_canonical_gene_ids_and_names
 from .gene_sets_cancer import (
@@ -40,33 +42,189 @@ def _load_gene_sets():
     return result
 
 
+_FN1_GENE_ID = "ENSG00000115414"
+_FN1_EDB_MIN_TPM = 5.0
+_FN1_EDB_MIN_FRACTION = 0.10
+_FN1_EDB_TRANSCRIPT_IDS = frozenset(
+    {
+        "ENST00000323926",  # FN1-201
+        "ENST00000354785",  # FN1-203
+        "ENST00000432072",  # FN1-209
+        "ENST00000456923",  # FN1-213
+    }
+)
+_FN1_EDB_TRANSCRIPT_NAMES = frozenset({"FN1-201", "FN1-203", "FN1-209", "FN1-213"})
+_FN1_EDB_EXON_IDS = frozenset({"ENSE00000965897", "ENSE00001744777"})
+_FN1_EDB_EXON_INTERVALS = frozenset(
+    {
+        (215392931, 215393203),
+        (215392931, 215393147),
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _fn1_edb_transcript_ids():
+    """Return versionless FN1 transcript IDs carrying the EDB cassette exon.
+
+    The curated FN1 ADC hook in this repo is PYX-201 / NCT05720117,
+    which is specific to EDB+ fibronectin rather than total FN1.
+    Resolve the EDB+ transcript set once from local Ensembl releases,
+    with a hardcoded fallback so the gate still works if pyensembl
+    metadata is unavailable at runtime.
+    """
+    ids = set(_FN1_EDB_TRANSCRIPT_IDS)
+    try:
+        from .gene_ids import genomes
+    except Exception:
+        return frozenset(ids)
+
+    for genome in genomes:
+        try:
+            genes = genome.genes_by_name("FN1")
+        except Exception:
+            continue
+        if not genes:
+            continue
+        gene = genes[0]
+        try:
+            transcript_ids = genome.transcript_ids_of_gene_id(gene.gene_id)
+        except Exception:
+            continue
+        for transcript_id in transcript_ids:
+            try:
+                transcript = genome.transcript_by_id(transcript_id)
+            except Exception:
+                continue
+            if getattr(transcript, "biotype", None) != "protein_coding":
+                continue
+            exons = list(getattr(transcript, "exons", []) or [])
+            exon_ids = {str(exon.exon_id) for exon in exons if getattr(exon, "exon_id", None)}
+            exon_intervals = {
+                (int(exon.start), int(exon.end))
+                for exon in exons
+                if getattr(exon, "start", None) is not None
+                and getattr(exon, "end", None) is not None
+            }
+            if (
+                getattr(transcript, "transcript_name", None) in _FN1_EDB_TRANSCRIPT_NAMES
+                or exon_ids & _FN1_EDB_EXON_IDS
+                or exon_intervals & _FN1_EDB_EXON_INTERVALS
+            ):
+                ids.add(str(transcript.transcript_id).split(".", 1)[0])
+    return frozenset(ids)
+
+
+def _summarize_fn1_edb_transcript_support(df_gene_expr):
+    """Summarize whether transcript-level input supports EDB+ FN1 targeting."""
+    import pandas as pd
+
+    prefix = (
+        "PYX-201 (NCT05720117) targets EDB+ FN1; bulk gene-level FN1 alone "
+        "is not sufficient evidence"
+    )
+    empty = {
+        "supported": False,
+        "note": f"{prefix} because transcript-level data is unavailable.",
+        "edb_tpm": None,
+        "edb_fraction": None,
+        "supporting_transcripts": "",
+    }
+
+    tx_df = getattr(df_gene_expr, "attrs", {}).get("transcript_expression")
+    if not isinstance(tx_df, pd.DataFrame) or tx_df.empty:
+        return empty
+    if "transcript_id" not in tx_df.columns or "TPM" not in tx_df.columns:
+        return empty
+
+    tx_ids = tx_df["transcript_id"].astype(str).str.split(".", n=1).str[0]
+    fn1_mask = pd.Series(False, index=tx_df.index, dtype=bool)
+    if "ensembl_gene_id" in tx_df.columns:
+        fn1_mask |= (
+            tx_df["ensembl_gene_id"].astype(str).str.split(".", n=1).str[0].eq(_FN1_GENE_ID)
+        )
+    if "gene_symbol" in tx_df.columns:
+        fn1_mask |= tx_df["gene_symbol"].fillna("").astype(str).str.upper().eq("FN1")
+    if not fn1_mask.any():
+        return {
+            **empty,
+            "note": f"{prefix} because no FN1 transcripts were retained in the transcript-level input.",
+        }
+
+    tx_tpm = pd.to_numeric(tx_df["TPM"], errors="coerce").fillna(0.0)
+    total_fn1_tpm = float(tx_tpm[fn1_mask].sum())
+    edb_mask = fn1_mask & tx_ids.isin(_fn1_edb_transcript_ids())
+    edb_tpm = float(tx_tpm[edb_mask].sum())
+    edb_fraction = (edb_tpm / total_fn1_tpm) if total_fn1_tpm > 0 else 0.0
+
+    support_by_tx = (
+        pd.DataFrame(
+            {
+                "transcript_id": tx_ids[edb_mask].values,
+                "TPM": tx_tpm[edb_mask].values,
+            }
+        )
+        .groupby("transcript_id", sort=False)["TPM"]
+        .sum()
+        .sort_values(ascending=False)
+    )
+    supporting_transcripts = ", ".join(
+        f"{transcript_id}:{value:.1f}"
+        for transcript_id, value in support_by_tx.head(4).items()
+    )
+
+    if edb_tpm <= 0:
+        note = f"{prefix} because no EDB+ FN1 transcripts were detected."
+        supported = False
+    elif edb_tpm >= _FN1_EDB_MIN_TPM and edb_fraction >= _FN1_EDB_MIN_FRACTION:
+        note = (
+            f"EDB+ FN1 transcript support present for PYX-201 / NCT05720117: "
+            f"{edb_tpm:.1f} TPM ({edb_fraction:.0%} of FN1 transcript signal)."
+        )
+        supported = True
+    else:
+        note = (
+            f"{prefix} because EDB+ FN1 transcripts reached only {edb_tpm:.1f} TPM "
+            f"({edb_fraction:.0%} of FN1 transcript signal), below the current gate."
+        )
+        supported = False
+
+    return {
+        "supported": supported,
+        "note": note,
+        "edb_tpm": edb_tpm,
+        "edb_fraction": edb_fraction,
+        "supporting_transcripts": supporting_transcripts,
+    }
+
+
+def _apply_therapy_support_gate(symbol, therapies, fn1_support):
+    """Return gated therapies plus structured support metadata."""
+    therapies = set(therapies or ())
+    if not therapies:
+        return therapies, None, "", None, None, ""
+    if symbol != "FN1":
+        return therapies, True, "", None, None, ""
+    if fn1_support.get("supported"):
+        return (
+            therapies,
+            True,
+            fn1_support.get("note", ""),
+            fn1_support.get("edb_tpm"),
+            fn1_support.get("edb_fraction"),
+            fn1_support.get("supporting_transcripts", ""),
+        )
+    return (
+        set(),
+        False,
+        fn1_support.get("note", ""),
+        fn1_support.get("edb_tpm"),
+        fn1_support.get("edb_fraction"),
+        fn1_support.get("supporting_transcripts", ""),
+    )
+
+
 # ------------------------ helpers ------------------------
-
-
-def _guess_gene_cols(df):
-    """Best-effort guess for gene ID and name columns in df_gene_expr."""
-    id_candidates = ["gene_id", "ensembl_gene_id", "canonical_gene_id", "GeneID"]
-    name_candidates = [
-        "gene_display_name",
-        "gene_name",
-        "canonical_gene_name",
-        "gene_symbol",
-        "symbol",
-        "GeneName",
-    ]
-    gene_id_col = next((c for c in id_candidates if c in df.columns), None)
-    gene_name_col = next((c for c in name_candidates if c in df.columns), None)
-    if gene_id_col is None:
-        raise KeyError(
-            "Could not find a gene ID column in df_gene_expr. "
-            "Tried: %s" % (id_candidates,)
-        )
-    if gene_name_col is None:
-        raise KeyError(
-            "Could not find a gene name column in df_gene_expr. "
-            "Tried: %s" % (name_candidates,)
-        )
-    return gene_id_col, gene_name_col
 
 
 def pick_genes_to_annotate(
@@ -1944,6 +2102,7 @@ def estimate_tumor_expression(
                 gene_therapies.setdefault(gname, set()).add(base)
         except Exception:
             pass
+    fn1_support = _summarize_fn1_edb_transcript_support(df_gene_expr)
 
     # Surface proteins
     try:
@@ -1994,7 +2153,11 @@ def estimate_tumor_expression(
         # Categorize
         is_cta = symbol in cta_symbols
         is_surface = symbol in surf_symbols
-        therapies = gene_therapies.get(symbol, set())
+        therapies, therapy_supported, therapy_support_note, therapy_support_tpm, therapy_support_fraction, therapy_supporting_transcripts = _apply_therapy_support_gate(
+            symbol,
+            gene_therapies.get(symbol, set()),
+            fn1_support,
+        )
         is_therapy = bool(therapies)
 
         # Filter: only include genes with meaningful tumor signal
@@ -2024,6 +2187,11 @@ def estimate_tumor_expression(
             "tcga_percentile": round(pctile, 3),
             "is_surface": is_surface,
             "is_cta": is_cta,
+            "therapy_supported": therapy_supported,
+            "therapy_support_note": therapy_support_note,
+            "therapy_support_tpm": round(therapy_support_tpm, 2) if therapy_support_tpm is not None else None,
+            "therapy_support_fraction": round(therapy_support_fraction, 3) if therapy_support_fraction is not None else None,
+            "therapy_supporting_transcripts": therapy_supporting_transcripts,
             "therapies": ", ".join(sorted(therapies)) if therapies else "",
         })
 
@@ -2271,6 +2439,7 @@ def estimate_tumor_expression_ranges(
                 gene_therapies.setdefault(gname, set()).add(base)
         except Exception:
             pass
+    fn1_support = _summarize_fn1_edb_transcript_support(df_gene_expr)
 
     try:
         surf_ids = surface_protein_gene_ids()
@@ -2440,7 +2609,11 @@ def estimate_tumor_expression_ranges(
         # Categorize
         is_cta = symbol in cta_symbols
         is_surface = symbol in surf_symbols
-        therapies = gene_therapies.get(symbol, set())
+        therapies, therapy_supported, therapy_support_note, therapy_support_tpm, therapy_support_fraction, therapy_supporting_transcripts = _apply_therapy_support_gate(
+            symbol,
+            gene_therapies.get(symbol, set()),
+            fn1_support,
+        )
 
         if is_cta:
             category = "CTA"
@@ -2523,6 +2696,11 @@ def estimate_tumor_expression_ranges(
             "is_surface": is_surface,
             "is_cta": is_cta,
             "excluded_from_ranking": excluded_from_ranking,
+            "therapy_supported": therapy_supported,
+            "therapy_support_note": therapy_support_note,
+            "therapy_support_tpm": round(therapy_support_tpm, 2) if therapy_support_tpm is not None else None,
+            "therapy_support_fraction": round(therapy_support_fraction, 3) if therapy_support_fraction is not None else None,
+            "therapy_supporting_transcripts": therapy_supporting_transcripts,
             "therapies": ", ".join(sorted(therapies)) if therapies else "",
         })
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.6.4"
+__version__ = "4.6.5"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_report_clarity_and_met_site.py
+++ b/tests/test_report_clarity_and_met_site.py
@@ -427,6 +427,67 @@ def test_recommended_targets_skips_tme_dominant_rows():
     assert "CD74" not in recs_block.split("**Best CTA targets**")[0]
 
 
+def test_target_report_explains_blocked_fn1_pyx201_call():
+    """FN1 should carry an explicit report caveat when the curated
+    PYX-201 hook is withheld for lack of EDB+ transcript support."""
+    from pirlygenes.cli import _generate_target_report
+
+    purity = {
+        "overall_estimate": 0.6, "overall_lower": 0.5, "overall_upper": 0.7,
+    }
+    analysis = {
+        "sample_mode": "solid", "cancer_type": "PRAD",
+        "mhc1": {"HLA-A": 100, "HLA-B": 200, "HLA-C": 80, "B2M": 300},
+    }
+    ranges_df = pd.DataFrame([
+        {
+            "symbol": "ADAM9", "median_est": 998, "observed_tpm": 825,
+            "est_1": 696, "est_9": 2179, "pct_cancer_median": 7.5,
+            "tcga_percentile": 1.0, "is_surface": True, "is_cta": False,
+            "tme_explainable": False, "tme_dominant": False,
+            "excluded_from_ranking": False, "therapies": "ADC",
+            "therapy_supported": True, "therapy_support_note": "",
+            "max_healthy_tpm": 300, "tme_fold_lo": 0.1, "tme_fold_med": 0.2,
+            "tme_fold_hi": 0.3, "cohort_prior_tpm": 100, "tme_only_tpm": 150,
+            "matched_normal_tpm": 0, "matched_normal_tissue": "",
+            "matched_normal_fraction": 0.0, "estimation_path": "tme_only",
+            "low_confidence_tumor": False, "category": "therapy_target",
+            **{f"est_{i+1}": 696 + i*150 for i in range(9)},
+        },
+        {
+            "symbol": "FN1", "median_est": 260, "observed_tpm": 180,
+            "est_1": 180, "est_9": 340, "pct_cancer_median": 0.9,
+            "tcga_percentile": 0.65, "is_surface": False, "is_cta": False,
+            "tme_explainable": False, "tme_dominant": False,
+            "excluded_from_ranking": False, "therapies": "",
+            "therapy_supported": False,
+            "therapy_support_note": (
+                "PYX-201 (NCT05720117) targets EDB+ FN1; bulk gene-level FN1 alone "
+                "is not sufficient evidence because transcript-level data is unavailable."
+            ),
+            "max_healthy_tpm": 500, "tme_fold_lo": 0.1, "tme_fold_med": 0.2,
+            "tme_fold_hi": 0.3, "cohort_prior_tpm": 120, "tme_only_tpm": 80,
+            "matched_normal_tpm": 0, "matched_normal_tissue": "",
+            "matched_normal_fraction": 0.0, "estimation_path": "tme_only",
+            "low_confidence_tumor": False, "category": "other",
+            **{f"est_{i+1}": 180 + i*20 for i in range(9)},
+        },
+    ])
+
+    tmp_prefix = "/tmp/target_test_fn1"
+    import os
+    if os.path.exists(f"{tmp_prefix}-targets.md"):
+        os.remove(f"{tmp_prefix}-targets.md")
+    _generate_target_report(
+        ranges_df, analysis, tmp_prefix, cancer_type="PRAD",
+        purity_result=purity,
+    )
+    targets = open(f"{tmp_prefix}-targets.md").read()
+
+    assert "PYX-201 (NCT05720117) targets EDB+ FN1" in targets
+    assert "Landscape cautions" in targets
+
+
 def test_ci_confidence_tier_buckets():
     from pirlygenes.cli import _ci_confidence_tier
 

--- a/tests/test_tumor_expression.py
+++ b/tests/test_tumor_expression.py
@@ -518,6 +518,86 @@ def test_ranges_pct_cancer_median_steap1_near_one():
         assert 0.5 < pct < 2.0, f"Expected ~1.0, got {pct}"
 
 
+def _fn1_target_test_frame():
+    import pandas as pd
+
+    return pd.DataFrame(
+        {
+            "ensembl_gene_id": [
+                "ENSG00000115414",  # FN1
+                "ENSG00000075624",  # ACTB
+                "ENSG00000156508",  # EEF1A1
+                "ENSG00000111640",  # GAPDH
+            ],
+            "gene_symbol": ["FN1", "ACTB", "EEF1A1", "GAPDH"],
+            "TPM": [180.0, 150.0, 300.0, 100.0],
+        }
+    )
+
+
+def test_ranges_fn1_therapy_requires_transcript_support():
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+
+    df = _fn1_target_test_frame()
+    purity = {"overall_lower": 0.45, "overall_estimate": 0.55, "overall_upper": 0.65}
+    out = estimate_tumor_expression_ranges(df, "PRAD", purity)
+    fn1 = out[out["symbol"] == "FN1"].iloc[0]
+
+    assert fn1["therapies"] == ""
+    assert fn1["category"] != "therapy_target"
+    assert bool(fn1["therapy_supported"]) is False
+    assert "EDB+ FN1" in fn1["therapy_support_note"]
+    assert "transcript-level data is unavailable" in fn1["therapy_support_note"]
+
+
+def test_ranges_fn1_therapy_stays_blocked_without_edb_transcripts():
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    import pandas as pd
+
+    df = _fn1_target_test_frame()
+    df.attrs["transcript_expression"] = pd.DataFrame(
+        {
+            "transcript_id": ["ENST00000443816", "ENST00000421182"],
+            "TPM": [70.0, 30.0],
+            "ensembl_gene_id": ["ENSG00000115414", "ENSG00000115414"],
+            "gene_symbol": ["FN1", "FN1"],
+        }
+    )
+    purity = {"overall_lower": 0.45, "overall_estimate": 0.55, "overall_upper": 0.65}
+    out = estimate_tumor_expression_ranges(df, "PRAD", purity)
+    fn1 = out[out["symbol"] == "FN1"].iloc[0]
+
+    assert fn1["therapies"] == ""
+    assert fn1["category"] != "therapy_target"
+    assert bool(fn1["therapy_supported"]) is False
+    assert "no EDB+ FN1 transcripts were detected" in fn1["therapy_support_note"]
+
+
+def test_ranges_fn1_therapy_requires_high_edb_transcripts():
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+    import pandas as pd
+
+    df = _fn1_target_test_frame()
+    df.attrs["transcript_expression"] = pd.DataFrame(
+        {
+            "transcript_id": ["ENST00000432072", "ENST00000443816"],
+            "TPM": [40.0, 20.0],
+            "ensembl_gene_id": ["ENSG00000115414", "ENSG00000115414"],
+            "gene_symbol": ["FN1", "FN1"],
+        }
+    )
+    purity = {"overall_lower": 0.45, "overall_estimate": 0.55, "overall_upper": 0.65}
+    out = estimate_tumor_expression_ranges(df, "PRAD", purity)
+    fn1 = out[out["symbol"] == "FN1"].iloc[0]
+
+    assert "ADC" in fn1["therapies"]
+    assert fn1["category"] == "therapy_target"
+    assert bool(fn1["therapy_supported"]) is True
+    assert fn1["therapy_support_tpm"] == 40.0
+    assert fn1["therapy_support_fraction"] == 0.667
+    assert "PYX-201 / NCT05720117" in fn1["therapy_support_note"]
+
+
 # ── _TME_TISSUES consistency ─────────────────────────────────────
 
 def test_tme_tissues_are_valid():


### PR DESCRIPTION
## Summary
- gate the curated FN1 therapy hook on transcript-level support for EDB-positive FN1 isoforms instead of bulk gene-level FN1 alone
- carry structured FN1 therapy-support metadata through tumor-expression ranking and surface the withheld-call rationale in the target markdown
- add regression tests for no-transcript, no-EDB, and EDB-supported FN1 cases

## Root Cause
`FN1` was being treated like a generic therapy-target gene because the ranking path only looked at curated gene-level therapy membership. That allowed PYX-201 / `NCT05720117` to be surfaced from total bulk `FN1` signal even though the trial hook is specific to EDB-positive fibronectin.

## Validation
- `pytest -n 0 tests/test_tumor_expression.py tests/test_report_clarity_and_met_site.py`
- `pytest -n 0 tests/test_plot_and_cli.py`

## Notes
- version bumped to `4.6.5`
- follow-up cleanup PR will carry the unrelated helper-extraction work currently left out of this branch
- fixes #91
