### PR TITLE
[codex] Extract shared TPM helper utilities

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -738,8 +738,8 @@ def _analyze_body(
     # report can explain *why* individual genes are high or low
     # (e.g. KLK3 ↓ + FOLH1 ↑ → AR-suppressed, consistent with ADT).
     try:
-        from .tumor_purity import _build_sample_tpm_by_symbol
-        sample_tpm_by_symbol = _build_sample_tpm_by_symbol(df_expr)
+        from .common import build_sample_tpm_by_symbol
+        sample_tpm_by_symbol = build_sample_tpm_by_symbol(df_expr)
         therapy_scores = score_therapy_signatures(sample_tpm_by_symbol, cancer_code)
     except (KeyError, ValueError, TypeError) as exc:
         print(f"[therapy-response] scoring skipped: {exc}")

--- a/pirlygenes/common.py
+++ b/pirlygenes/common.py
@@ -54,3 +54,77 @@ def without_dataframe_attrs(df: pd.DataFrame) -> Iterator[pd.DataFrame]:
     finally:
         if saved_attrs:
             df.attrs = saved_attrs
+
+
+# -------------------- gene-column helpers --------------------
+
+
+def guess_gene_cols(df):
+    """Best-effort guess for gene ID and name columns in df_gene_expr."""
+    id_candidates = ["gene_id", "ensembl_gene_id", "canonical_gene_id", "GeneID"]
+    name_candidates = [
+        "gene_display_name",
+        "gene_name",
+        "canonical_gene_name",
+        "gene_symbol",
+        "symbol",
+        "GeneName",
+    ]
+    gene_id_col = next((c for c in id_candidates if c in df.columns), None)
+    gene_name_col = next((c for c in name_candidates if c in df.columns), None)
+    if gene_id_col is None:
+        raise KeyError(
+            "Could not find a gene ID column in df_gene_expr. "
+            "Tried: %s" % (id_candidates,)
+        )
+    if gene_name_col is None:
+        raise KeyError(
+            "Could not find a gene name column in df_gene_expr. "
+            "Tried: %s" % (name_candidates,)
+        )
+    return gene_id_col, gene_name_col
+
+
+# Backward-compatible alias — internal callers historically imported
+# ``_guess_gene_cols`` from plot.py; the underscore form is kept so
+# those imports still resolve after plot.py re-exports it.
+_guess_gene_cols = guess_gene_cols
+
+
+# -------------------- TPM-by-symbol --------------------
+
+
+def build_sample_tpm_by_symbol(df_gene_expr):
+    """Return ``{symbol: max_TPM}`` from expression data (no normalization).
+
+    Maps Ensembl gene IDs to HGNC symbols via the bundled pan-cancer
+    reference, then groups by symbol keeping the maximum TPM per gene.
+    """
+    from .plot_data_helpers import _strip_ensembl_version
+    from .gene_sets_cancer import pan_cancer_expression
+
+    with without_dataframe_attrs(df_gene_expr):
+        gene_id_col, _gene_name_col = guess_gene_cols(df_gene_expr)
+        gene_ids = df_gene_expr[gene_id_col].astype(str).map(_strip_ensembl_version)
+
+        tpm_col = "TPM" if "TPM" in df_gene_expr.columns else next(
+            (c for c in df_gene_expr.columns if c.lower() == "tpm"), None
+        )
+        if tpm_col is None:
+            raise KeyError(f"No TPM column found. Columns: {list(df_gene_expr.columns)}")
+
+        ref = pan_cancer_expression()
+        id_to_sym = dict(zip(ref["Ensembl_Gene_ID"], ref["Symbol"]))
+
+        syms = gene_ids.map(id_to_sym)
+        tpms = pd.to_numeric(df_gene_expr[tpm_col], errors="coerce")
+        valid = syms.notna() & tpms.notna()
+        return dict(
+            pd.DataFrame({"sym": syms[valid], "tpm": tpms[valid]})
+            .groupby("sym")["tpm"]
+            .max()
+        )
+
+
+# Underscore alias for backward compatibility with internal callers.
+_build_sample_tpm_by_symbol = build_sample_tpm_by_symbol

--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -540,7 +540,7 @@ def _build_tpm_by_symbol(df_gene_expr):
     Prefers a direct symbol column (``gene_symbol``/``symbol``/``Symbol``)
     so that synthetic test frames with just ``(gene_symbol, TPM)`` work
     without requiring a gene-ID column. Falls back to
-    ``tumor_purity._build_sample_tpm_by_symbol`` (which maps gene IDs
+    ``common.build_sample_tpm_by_symbol`` (which maps gene IDs
     through the HPA/pan-cancer reference) for frames without a symbol
     column.
     """
@@ -562,9 +562,9 @@ def _build_tpm_by_symbol(df_gene_expr):
                 .groupby("sym")["tpm"]
                 .max()
             )
-    # Fall back to the gene-ID path.
-    from .tumor_purity import _build_sample_tpm_by_symbol
-    return _build_sample_tpm_by_symbol(df_gene_expr)
+    # Fall back to the gene-ID path (canonical home: common.py).
+    from .common import build_sample_tpm_by_symbol
+    return build_sample_tpm_by_symbol(df_gene_expr)
 
 
 def _summarise_expression_distribution(tpm_by_symbol, signals):

--- a/pirlygenes/sample_quality.py
+++ b/pirlygenes/sample_quality.py
@@ -181,9 +181,9 @@ def assess_sample_quality(df_gene_expr, tissue_scores=None):
         has_issues : bool
             True if any quality concern was detected.
     """
-    from .tumor_purity import _build_sample_tpm_by_symbol
+    from .common import build_sample_tpm_by_symbol
 
-    sample_tpm = _build_sample_tpm_by_symbol(df_gene_expr)
+    sample_tpm = build_sample_tpm_by_symbol(df_gene_expr)
 
     # Filter NaN values from the TPM dict (some reference genes have NaN
     # in TCGA cohorts where they were not measured, e.g. BCR/TCR loci).

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -30,10 +30,8 @@ from .gene_sets_cancer import (
     lineage_genes_by_cancer_type,
     pan_cancer_expression,
 )
-from .common import without_dataframe_attrs
+from .common import _build_sample_tpm_by_symbol as _common_build_sample_tpm
 from .load_dataset import get_data
-from .plot import _guess_gene_cols
-from .plot_data_helpers import _strip_ensembl_version
 
 
 # -------------------- cancer type → normal tissue mapping --------------------
@@ -348,28 +346,12 @@ _CANCER_NORMAL_TISSUES = {
 
 
 def _build_sample_tpm_by_symbol(df_gene_expr):
-    """Return {symbol: max_TPM} from expression data (no normalization)."""
-    with without_dataframe_attrs(df_gene_expr):
-        gene_id_col, _gene_name_col = _guess_gene_cols(df_gene_expr)
-        gene_ids = df_gene_expr[gene_id_col].astype(str).map(_strip_ensembl_version)
+    """Return {symbol: max_TPM} from expression data (no normalization).
 
-        tpm_col = "TPM" if "TPM" in df_gene_expr.columns else next(
-            (c for c in df_gene_expr.columns if c.lower() == "tpm"), None
-        )
-        if tpm_col is None:
-            raise KeyError(f"No TPM column found. Columns: {list(df_gene_expr.columns)}")
-
-        ref = pan_cancer_expression()
-        id_to_sym = dict(zip(ref["Ensembl_Gene_ID"], ref["Symbol"]))
-
-        syms = gene_ids.map(id_to_sym)
-        tpms = pd.to_numeric(df_gene_expr[tpm_col], errors="coerce")
-        valid = syms.notna() & tpms.notna()
-        return dict(
-            pd.DataFrame({"sym": syms[valid], "tpm": tpms[valid]})
-            .groupby("sym")["tpm"]
-            .max()
-        )
+    Canonical implementation lives in ``common.build_sample_tpm_by_symbol``;
+    this is a thin delegate kept for backward compatibility.
+    """
+    return _common_build_sample_tpm(df_gene_expr)
 
 
 def _geneset_hk_ratio(genes, hk_symbols, expr_by_symbol):

--- a/tests/test_sample_context.py
+++ b/tests/test_sample_context.py
@@ -110,7 +110,7 @@ def test_build_tpm_by_symbol_uses_gene_column_without_fallback(monkeypatch):
         raise AssertionError("tumor-purity fallback should not be used")
 
     monkeypatch.setattr(
-        "pirlygenes.tumor_purity._build_sample_tpm_by_symbol",
+        "pirlygenes.common.build_sample_tpm_by_symbol",
         _should_not_run,
     )
 

--- a/tests/test_tumor_purity_symbol_build.py
+++ b/tests/test_tumor_purity_symbol_build.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+from pirlygenes.common import build_sample_tpm_by_symbol
+# Backward-compat: the underscore alias is still importable from tumor_purity
 from pirlygenes.tumor_purity import _build_sample_tpm_by_symbol
 
 
@@ -24,7 +26,12 @@ def test_build_sample_tpm_by_symbol_does_not_deepcopy_attrs(monkeypatch):
             "Symbol": ["GENE1", "GENE2"],
         }
     )
-    monkeypatch.setattr("pirlygenes.tumor_purity.pan_cancer_expression", lambda: ref)
+    # Patch at the source module — common.py lazy-imports from gene_sets_cancer
+    monkeypatch.setattr("pirlygenes.gene_sets_cancer.pan_cancer_expression", lambda: ref)
 
-    out = _build_sample_tpm_by_symbol(df)
+    out = build_sample_tpm_by_symbol(df)
     assert out == {"GENE1": 1.0, "GENE2": 2.5}
+
+    # The tumor_purity delegate should produce the same result
+    out2 = _build_sample_tpm_by_symbol(df)
+    assert out2 == {"GENE1": 1.0, "GENE2": 2.5}


### PR DESCRIPTION
## Summary
- move generic gene-column and TPM-by-symbol helpers into `pirlygenes.common`
- update `tumor_purity`, `sample_context`, `sample_quality`, and the therapy-response caller to use the shared helper instead of duplicating logic or importing it from plotting code
- fix the attrs-safe regression test to patch the helper at its canonical import site

## Why
This is a cleanup follow-up to the FN1 work. It removes a brittle dependency chain (`tumor_purity` importing a helper from `plot.py`) and fixes the existing release-gate failure in `tests/test_tumor_purity_symbol_build.py` on clean `main`.

## Validation
- `source .venv/bin/activate && pytest tests/test_sample_context.py tests/test_sample_quality.py tests/test_tumor_purity_symbol_build.py`
- `source .venv/bin/activate && ./test.sh`
