### PR TITLE
fix: penalize decomposition candidates with purity below 2% floor (#98)

### DIFF
--- a/pirlygenes/decomposition/engine.py
+++ b/pirlygenes/decomposition/engine.py
@@ -196,6 +196,13 @@ DECOMPOSITION_PARAMETERS = {
         # Hard floor on the combined template factor to prevent a template
         # from being completely zeroed out by a poor tissue match.
         "min_template_factor": 0.05,
+        # Minimum tumor fraction below which the hypothesis score is
+        # heavily penalised.  A candidate at <2% purity is biologically
+        # nonsensical (no sample is 98% TME) and represents the NNLS
+        # solver routing almost all expression to host components.
+        # Penalty: score *= max(purity, floor) / floor  → smooth ramp
+        # that effectively zeroes out near-zero-purity candidates.
+        "min_tumor_fraction": 0.02,
     },
 }
 
@@ -876,6 +883,18 @@ def _fit_one_hypothesis(
     score = fit_score * (
         scoring["fit_score_base"] + scoring["fit_score_gain"] * cancer_support
     ) * template_factor
+
+    # Purity floor penalty (#98): candidates with biologically
+    # implausible purity (<2%) get their score collapsed so they
+    # don't clutter the candidate list as noise.
+    min_tf = scoring.get("min_tumor_fraction", 0.02)
+    if tumor_fraction < min_tf:
+        penalty = tumor_fraction / max(min_tf, 1e-6)
+        score *= penalty
+        warnings.append(
+            f"Purity {tumor_fraction:.1%} below {min_tf:.0%} floor "
+            f"(score penalised ×{penalty:.2f})"
+        )
 
     if not gene_attr.empty and gene_attr["overexplained_tpm"].gt(0).mean() > 0.2:
         warnings.append("Many genes are overexplained by the TME background")

--- a/tests/test_decomposition_internals.py
+++ b/tests/test_decomposition_internals.py
@@ -188,3 +188,35 @@ def test_lineage_override_upward_delta_is_positive():
     lo = DECOMPOSITION_PARAMETERS["lineage_override"]
     assert lo["max_upward_delta"] > 0
     assert lo["max_upward_ratio"] > 1.0
+
+
+def test_min_tumor_fraction_parameter_exists():
+    ts = DECOMPOSITION_PARAMETERS["template_scoring"]
+    assert "min_tumor_fraction" in ts
+    assert 0 < ts["min_tumor_fraction"] < 0.1
+
+
+def test_low_purity_candidate_is_penalised():
+    """A decomposition candidate with purity < min_tumor_fraction should
+    have a lower score than one at normal purity, all else equal."""
+    import pandas as pd
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression
+    from pirlygenes.decomposition import decompose_sample
+
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    # Build a PRAD sample — should score well for PRAD, poorly for unrelated types
+    df = pd.DataFrame({
+        "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+        "gene_symbol": ref["Symbol"],
+        "TPM": ref["FPKM_PRAD"].astype(float),
+    })
+    results = decompose_sample(
+        df, cancer_types=["PRAD", "HNSC"], templates=["solid_primary"], top_k=2,
+    )
+    assert len(results) == 2
+    prad_result = next(r for r in results if r.cancer_type == "PRAD")
+    hnsc_result = next(r for r in results if r.cancer_type == "HNSC")
+    # If HNSC has very low purity, it should have been penalised
+    if hnsc_result.purity < 0.02:
+        assert hnsc_result.score < prad_result.score * 0.5
+        assert any("floor" in w for w in hnsc_result.warnings)


### PR DESCRIPTION
## Summary

- Candidates with tumor fraction < 2% get score proportionally collapsed (score *= purity / 0.02)
- Adds `min_tumor_fraction` parameter to `DECOMPOSITION_PARAMETERS["template_scoring"]`
- Warning attached to affected candidates for debugging visibility

Fixes #98.

## Test plan

- [x] 327 passed, 1 skipped
- [x] New test verifies HNSC runner-up for PRAD sample is penalised when purity is near-zero
- [ ] CI green