### PR TITLE
Batch 1 fixes: purity CI widening (#101) + library-prep plot annotation (#102)

### DIFF
--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -945,7 +945,14 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
     ax_bars.set_yticks(y)
     ax_bars.set_yticklabels(labels, fontsize=9)
     ax_bars.invert_yaxis()
-    ax_bars.set_xlim(0, max(max(values) * 1.2, 1.0))
+    # #102: with exome-capture samples every value is ~0 and a raw axis
+    # (xlim = 1.0) produces a chart that looks empty. Give a minimum axis
+    # width tied to the thresholds so bars remain readable, and annotate
+    # the "all near zero" case with the plausible library-prep explanation.
+    max_value = max(values) if values else 0.0
+    max_threshold = max((b[2] for b in bars), default=0.0)
+    axis_floor = max(max_threshold * 4.0, 0.05)
+    ax_bars.set_xlim(0, max(max_value * 1.2, axis_floor))
     ax_bars.set_xlabel("Fraction", fontsize=10)
     for yi, (thr, thr_name) in zip(y, thresholds):
         ax_bars.axvline(thr, color="#888888", linestyle="--", linewidth=0.8)
@@ -955,6 +962,30 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
         )
     for yi, val in zip(y, values):
         ax_bars.text(val, yi, f"  {val:.3f}", va="center", fontsize=9)
+
+    if max_value < 0.01:
+        # Show the user what "all near zero" means rather than leaving a
+        # visually empty plot. Exome / hybrid-capture library prep strips
+        # non-polyadenylated RNAs (histones, mitochondrial), so near-zero
+        # values are the expected pattern — not a quality problem.
+        explanation = (
+            "All diagnostic signals are near zero — consistent with\n"
+            "exome / hybrid-capture library prep (non-polyadenylated\n"
+            "RNAs are filtered). Interpret MT / histone fractions\n"
+            "relative to the expected floor for this prep, not as\n"
+            "degradation evidence."
+        )
+        ax_bars.text(
+            0.98, 0.05, explanation,
+            transform=ax_bars.transAxes,
+            fontsize=8, color="#444444", ha="right", va="bottom",
+            bbox=dict(
+                boxstyle="round,pad=0.4",
+                facecolor="#f5f5dc",
+                edgecolor="#bbbbbb",
+                linewidth=0.6,
+            ),
+        )
 
     ax_bars.spines["top"].set_visible(False)
     ax_bars.spines["right"].set_visible(False)

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -895,6 +895,17 @@ def _combine_purity_estimates(
     overall_lower = float(np.clip(min(lower_candidates), 0.0, 1.0))
     overall_upper = float(np.clip(max(upper_candidates), 0.0, 1.0))
     overall = float(np.clip(overall, overall_lower, overall_upper))
+
+    # #101: lineage / signature upper quartiles are themselves depressed in
+    # low-purity samples, so `max(upper_candidates)` collapses onto the point
+    # estimate and the reported CI becomes one-sided low (e.g. 7–16 around 16).
+    # Mirror the lower half onto the upper half so the upper bound is at least
+    # as wide as the lower, reflecting the observed spread rather than the
+    # floor of the sample itself. The lower bound is left alone.
+    lower_span = overall - overall_lower
+    upper_span = overall_upper - overall
+    if upper_span < lower_span:
+        overall_upper = float(np.clip(overall + lower_span, 0.0, 1.0))
     return overall, overall_lower, overall_upper
 
 

--- a/tests/test_purity_internals.py
+++ b/tests/test_purity_internals.py
@@ -206,6 +206,28 @@ def test_combine_purity_conflict_deprioritizes_signature():
     assert overall > 0.40
 
 
+def test_combine_purity_ci_symmetric_when_upper_candidates_depressed():
+    """#101: low-purity samples had `max(upper_candidates) == overall` because
+    the upper quartiles were themselves low, producing a one-sided CI like
+    7–16% around 16%. The fix mirrors the wider half of the interval so the
+    upper bound reflects the observed spread, not the floor of the sample."""
+    overall, lo, hi = _combine_purity_estimates(
+        sig_purity=0.16, sig_lower=0.07, sig_upper=0.16,
+        estimate_purity=0.10,
+        lineage_purity=0.16, lineage_lower=0.08, lineage_upper=0.16,
+        sig_stability=0.5,
+    )
+    assert overall is not None
+    lower_span = overall - lo
+    upper_span = hi - overall
+    assert upper_span >= lower_span - 1e-9, (
+        f"upper span {upper_span:.4f} should not be smaller than lower span "
+        f"{lower_span:.4f} (got CI {lo:.3f}–{hi:.3f} around {overall:.3f})"
+    )
+    # Upper bound must meaningfully exceed the point estimate in this scenario
+    assert hi > overall + 0.01
+
+
 # ── _signature_conflicts_with_lineage ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Batch 1 of the v4.8 tackle-everything sweep. Narrow orthogonal fixes only.

### Implemented
- **#101** — \`_combine_purity_estimates\` in \`tumor_purity.py\`: mirror the lower half of the CI onto the upper half so the upper bound is at least as wide as the lower, fixing the one-sided-low CI that appeared on low-purity samples (e.g. 7–16% around 16%). Adds regression test.
- **#102** — \`plot_sample_context\` in \`sample_context.py\`: when every library-prep diagnostic fraction is below 0.01, overlay an annotation explaining that "all near zero" is the expected pattern for exome / hybrid-capture prep. Also gives the x-axis a minimum width tied to the thresholds so tiny bars remain readable.

### Closed as already fixed (no code change here — verified current main already addresses)
- **#83** scatter plots use \`effective_cancer_type\` (explicit #83 comment at cli.py:1039)
- **#84** \`plot_sample_summary\` accepts precomputed \`analysis\` (tumor_purity.py:1874; cli.py:765 passes it)
- **#86** \`plot_tumor_purity\` accepts precomputed \`purity_result\` (tumor_purity.py:1136; cli.py:1028 passes it)
- **#76** \`CTA_gene_names()\` already defaults to filtered+expressed (gene_sets_cancer.py:1022)

### Deferred
- **#1** add PAGE5 to CTA list — the CSV is generated by the upstream \`tsarina.evidence.CTA_evidence\` pipeline, so a manual row addition would miss the programmatic HPA filter columns. Left open; add via tsarina.

## Test plan
- [x] \`./test.sh\` — 342 passed, 1 skipped
- [x] New regression test \`test_combine_purity_ci_symmetric_when_upper_candidates_depressed\` covers the #101 bug scenario
- [x] Smoke-tested \`plot_sample_context\` with both exome-capture (all-zero signals) and total-RNA (nonzero) synthetic contexts