### PR TITLE
Batch 3: artifact expectations (#107) + confidence-tier infrastructure (#109) + report polish (#79)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -2322,8 +2322,32 @@ def _generate_text_reports(
 
     # Purity / composition
     lines.append(f"## {_purity_metric_label(sample_mode).title()}\n")
+    # #109: compute the sample-level confidence tier once and surface it
+    # inline so readers see a 19–100% CI render visibly different from a
+    # 58–70% CI (#79). The tier consumes purity CI width, point estimate,
+    # degradation severity, and sample-context flags.
+    from .confidence import compute_purity_confidence
+
+    sample_ctx_for_tier = analysis.get("sample_context")
+    deg_for_tier = (
+        getattr(sample_ctx_for_tier, "degradation_severity", "none")
+        if sample_ctx_for_tier else "none"
+    )
+    purity_tier = compute_purity_confidence(
+        purity,
+        sample_context=sample_ctx_for_tier,
+        degradation_severity=deg_for_tier,
+    )
+    analysis["purity_confidence"] = purity_tier
+    tier_suffix = (
+        f" — **{purity_tier.tier} confidence** "
+        f"({purity_tier.inline_note})"
+        if purity_tier.tier in {"low", "moderate"} and purity_tier.reasons
+        else ""
+    )
     lines.append(f"- **Overall estimate**: {purity['overall_estimate']:.0%} "
-                  f"({purity['overall_lower']:.0%}\u2013{purity['overall_upper']:.0%})")
+                  f"({purity['overall_lower']:.0%}\u2013{purity['overall_upper']:.0%})"
+                  f"{tier_suffix}")
     components = purity.get("components", {})
     for comp_name in ("stromal", "immune"):
         comp = components.get(comp_name, {})

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -1,0 +1,174 @@
+# Licensed under the Apache License, Version 2.0
+
+"""Confidence tiers for pirlygenes analyses (#109).
+
+A single source-of-truth for "how much should the reader trust this
+number" that every renderer consumes. The goal is structural: no
+quantity shows up in any report identically regardless of how shaky
+its underlying evidence is.
+
+The tier system has three levels:
+
+- ``"high"``: no caveats. CI tight, decomposition stable, no artefact
+  flags. Renderer shows the number bare.
+- ``"moderate"``: one signal is weaker than typical but the number is
+  still usable. Renderer shows the number with a short inline note.
+- ``"low"``: at least one core input is unreliable. Renderer shows the
+  number with a prominent low-confidence tag and, for summary-level
+  lists, excludes the row or requires the inline caveat.
+
+Two computed tiers:
+
+- ``compute_purity_confidence``: sample-level — purity CI width, point
+  estimate, degradation severity, prep-specific caveats.
+- ``compute_target_confidence``: per-target — rolls in the purity
+  tier, per-gene attribution (#108), TME flags, purity amplification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(frozen=True)
+class ConfidenceTier:
+    tier: str  # "high" | "moderate" | "low" | "unknown"
+    reasons: List[str] = field(default_factory=list)
+
+    @property
+    def badge(self) -> str:
+        return {"low": "⚠⚠", "moderate": "⚠", "high": "", "unknown": "?"}.get(
+            self.tier, ""
+        )
+
+    @property
+    def inline_note(self) -> str:
+        if not self.reasons:
+            return ""
+        return "; ".join(self.reasons)
+
+    def render(self) -> str:
+        if self.tier == "high":
+            return ""
+        note = self.inline_note
+        prefix = f"**{self.tier} confidence**"
+        return f"{prefix} ({note})" if note else prefix
+
+
+def compute_purity_confidence(
+    purity,
+    sample_context=None,
+    degradation_severity: str = "none",
+) -> ConfidenceTier:
+    """Tier the overall purity estimate.
+
+    ``purity`` is the dict produced by ``estimate_tumor_purity`` /
+    ``analyze_sample`` (keys ``overall_estimate``, ``overall_lower``,
+    ``overall_upper``).
+    """
+    reasons: List[str] = []
+    try:
+        overall = float(purity.get("overall_estimate") or 0.0)
+        lower = float(purity.get("overall_lower") or 0.0)
+        upper = float(purity.get("overall_upper") or 0.0)
+    except (TypeError, AttributeError, ValueError):
+        return ConfidenceTier(tier="unknown", reasons=["no purity estimate available"])
+
+    tier = "high"
+    span = upper - lower
+    if span >= 0.35:
+        tier = "low"
+        reasons.append(f"wide purity CI ({lower:.0%}–{upper:.0%})")
+    elif span >= 0.15:
+        tier = "moderate"
+        reasons.append(f"moderate purity CI span ({span * 100:.0f} pp)")
+
+    if overall < 0.15:
+        # Low-purity regime: even a tight CI is hard to act on because
+        # any non-tumor signal dominates after dividing by purity.
+        if tier != "low":
+            tier = "moderate" if tier == "high" else tier
+        reasons.append(f"low-purity regime ({overall:.0%})")
+        if overall < 0.08:
+            tier = "low"
+
+    sev = (degradation_severity or "none").lower()
+    if sev in ("moderate", "severe"):
+        # Severe RNA degradation biases long-transcript quantification;
+        # target TPMs downstream are less trustworthy.
+        if sev == "severe":
+            tier = "low"
+        elif tier == "high":
+            tier = "moderate"
+        reasons.append(f"{sev} RNA degradation")
+
+    if sample_context is not None:
+        flags = getattr(sample_context, "flags", None) or []
+        for flag in flags:
+            # targeted-panel inputs are handled elsewhere but worth
+            # flagging at the confidence layer so the tier stays honest.
+            if "targeted_panel" in str(flag).lower():
+                tier = "low"
+                reasons.append("likely targeted-panel input")
+                break
+
+    return ConfidenceTier(tier=tier, reasons=reasons)
+
+
+def compute_target_confidence(
+    row,
+    purity_tier: ConfidenceTier,
+    sample_context=None,
+) -> ConfidenceTier:
+    """Tier a single therapy-target row.
+
+    ``row`` is a dict- or Series-like with at least ``observed_tpm``,
+    optionally ``tme_dominant``, ``tme_explainable``,
+    ``attr_tumor_fraction``, and ``attribution`` (the new #108 columns).
+    """
+    reasons: List[str] = []
+    tier = purity_tier.tier if purity_tier.tier in {"low", "moderate", "high"} else "moderate"
+    if purity_tier.tier in {"low", "moderate"} and purity_tier.reasons:
+        # Fold in the sample-level reasons so target rows carry them
+        # when they're the dominant limit on confidence.
+        reasons.extend(purity_tier.reasons)
+
+    def _get(key, default=None):
+        try:
+            value = row.get(key) if hasattr(row, "get") else row[key]
+        except (KeyError, AttributeError):
+            return default
+        return value if value is not None else default
+
+    if _get("tme_dominant"):
+        tier = "low"
+        attribution = _get("attribution")
+        if isinstance(attribution, dict) and attribution:
+            top = max(attribution, key=lambda k: attribution[k])
+            reasons.append(
+                f"TME-dominant (tumor < 30% of observed; "
+                f"top non-tumor compartment: {top.replace('_', ' ')})"
+            )
+        else:
+            reasons.append("TME-dominant (≥70% of signal is non-tumor)")
+    elif _get("tme_explainable"):
+        if tier == "high":
+            tier = "moderate"
+        reasons.append("could be explained by a single healthy tissue's expression")
+
+    attr_fraction = _get("attr_tumor_fraction")
+    if isinstance(attr_fraction, (int, float)) and 0.3 <= float(attr_fraction) < 0.5:
+        if tier == "high":
+            tier = "moderate"
+        reasons.append(f"only {float(attr_fraction):.0%} of signal attributed to tumor core")
+
+    # Deduplicate reasons while preserving order.
+    seen = set()
+    deduped: List[str] = []
+    for r in reasons:
+        if r not in seen:
+            seen.add(r)
+            deduped.append(r)
+
+    return ConfidenceTier(tier=tier, reasons=deduped)

--- a/pirlygenes/data/artifact-expectations.csv
+++ b/pirlygenes/data/artifact-expectations.csv
@@ -1,0 +1,17 @@
+library_prep,preservation,gene_class,expected_lo,expected_hi,interpretation
+exome_capture,*,mitochondrial,0.000,0.005,Filtered by design — hybrid-capture kits do not select MT transcripts.
+exome_capture,*,rRNA,0.000,0.005,Filtered by design — rRNAs not targeted by exome probes.
+exome_capture,*,histone_cluster,0.000,0.010,Replication-dependent histone mRNAs lack poly-A tails and are not captured by exome probes.
+poly_a,fresh,mitochondrial,0.020,0.150,Expected MT band for poly-A capture in non-degraded RNA; tissue-dependent (heart/muscle skew higher).
+poly_a,ffpe,mitochondrial,0.005,0.080,FFPE depresses MT relative to fresh but some signal persists.
+poly_a,*,rRNA,0.000,0.005,Ribosomal RNAs are not polyadenylated and should be absent from poly-A libraries.
+poly_a,*,histone_cluster,0.000,0.005,Replication-dependent histones lack poly-A tails — absent from poly-A libraries.
+ribo_depleted,fresh,rRNA,0.001,0.020,Residual rRNA after ribosomal depletion (Ribo-Zero / NEBNext rRNA depletion).
+ribo_depleted,ffpe,rRNA,0.005,0.050,FFPE samples retain more rRNA residual because depletion is less efficient on fragmented RNA.
+ribo_depleted,fresh,mitochondrial,0.020,0.150,Mitochondrial rRNAs are typically NOT removed by nuclear-rRNA depletion; expected to be present.
+ribo_depleted,ffpe,mitochondrial,0.020,0.250,FFPE concentrates short MT transcripts; fraction rises with degradation.
+ribo_depleted,*,histone_cluster,0.005,0.030,Histone mRNAs are retained in ribo-depleted libraries (they have stem-loop tails).
+total_rna,fresh,rRNA,0.600,0.850,Ribosomal RNA dominates un-depleted total-RNA libraries.
+total_rna,ffpe,rRNA,0.500,0.900,FFPE total-RNA libraries remain rRNA-dominated with wider spread.
+total_rna,*,mitochondrial,0.020,0.200,MT transcripts present at typical tissue bands with wider spread in degraded samples.
+total_rna,*,histone_cluster,0.005,0.030,Histone cluster retained.

--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -852,6 +852,56 @@ def infer_sample_context(df_gene_expr) -> SampleContext:
 # ── Plotting ──────────────────────────────────────────────────────────────
 
 
+_GENE_CLASS_TO_SIGNAL = {
+    "histone_fraction": "histone_cluster",
+    "mt_fraction": "mitochondrial",
+    "mt_rrna_fraction_of_mt": "mitochondrial",  # same gene class
+}
+
+
+def _load_artifact_expectations():
+    """Return (library_prep, preservation, gene_class) -> (lo, hi, interp).
+
+    Loaded from ``data/artifact-expectations.csv`` (#107). ``preservation``
+    is either an explicit value or ``"*"``, which matches any preservation.
+    Returns an empty dict when the CSV is missing so downstream code
+    degrades gracefully.
+    """
+    try:
+        from .load_dataset import get_data
+
+        df = get_data("artifact-expectations")
+    except Exception:
+        return {}
+    out = {}
+    for _, row in df.iterrows():
+        key = (
+            str(row["library_prep"]).strip(),
+            str(row["preservation"]).strip(),
+            str(row["gene_class"]).strip(),
+        )
+        out[key] = (
+            float(row["expected_lo"]),
+            float(row["expected_hi"]),
+            str(row.get("interpretation", "")).strip(),
+        )
+    return out
+
+
+def _expectation_for(expectations, library_prep, preservation, gene_class):
+    """Look up the expected range for a (prep, preservation, class) combo.
+
+    Exact preservation match preferred; ``preservation="*"`` used as
+    the fallback. Returns ``None`` when no rule applies (unknown prep
+    or gene class).
+    """
+    for pres in (preservation, "*"):
+        key = (library_prep, pres, gene_class)
+        if key in expectations:
+            return expectations[key]
+    return None
+
+
 def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
                         save_dpi: int = 150) -> Optional[str]:
     """Standalone PNG summarising ``sample_context`` as the first panel
@@ -941,7 +991,45 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
     labels = [b[0] for b in bars]
     thresholds = [(b[2], b[3]) for b in bars]
 
-    ax_bars.barh(y, values, color="#4682b4", alpha=0.8)
+    # #107: expected-range bands for the inferred library prep +
+    # preservation. Shading a band behind each bar lets the reader see
+    # whether the observed value is inside the "normal for this prep"
+    # window instead of chasing an absolute threshold that doesn't
+    # apply to every prep.
+    expectations = _load_artifact_expectations()
+    signal_keys = ["histone_fraction", "mt_fraction", "mt_rrna_fraction_of_mt"]
+    bar_bands = []
+    in_band_count = 0
+    for yi, sig_key in zip(y, signal_keys):
+        gene_class = _GENE_CLASS_TO_SIGNAL.get(sig_key)
+        band = _expectation_for(
+            expectations,
+            sample_context.library_prep,
+            sample_context.preservation,
+            gene_class,
+        ) if gene_class else None
+        bar_bands.append(band)
+        if band is not None:
+            lo, hi, _ = band
+            ax_bars.axhspan(
+                yi - 0.35, yi + 0.35,
+                xmin=0.0, xmax=1.0,
+                facecolor="none", edgecolor="none",  # no-op placeholder
+            )
+            # Use axvspan-shape-per-row: draw a narrow patch via bar
+            # on a secondary layer to keep implementation simple.
+            ax_bars.barh(
+                [yi], [hi - lo], left=[lo],
+                color="#bbd8a3", alpha=0.4, edgecolor="none",
+                height=0.75, zorder=0,
+            )
+            val = values[signal_keys.index(sig_key)] if sig_key in (
+                "histone_fraction", "mt_fraction", "mt_rrna_fraction_of_mt"
+            ) else None
+            if val is not None and lo <= val <= hi:
+                in_band_count += 1
+
+    ax_bars.barh(y, values, color="#4682b4", alpha=0.85)
     ax_bars.set_yticks(y)
     ax_bars.set_yticklabels(labels, fontsize=9)
     ax_bars.invert_yaxis()
@@ -951,7 +1039,10 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
     # the "all near zero" case with the plausible library-prep explanation.
     max_value = max(values) if values else 0.0
     max_threshold = max((b[2] for b in bars), default=0.0)
-    axis_floor = max(max_threshold * 4.0, 0.05)
+    max_band_hi = max(
+        (band[1] for band in bar_bands if band is not None), default=0.0
+    )
+    axis_floor = max(max_threshold * 4.0, max_band_hi * 1.1, 0.05)
     ax_bars.set_xlim(0, max(max_value * 1.2, axis_floor))
     ax_bars.set_xlabel("Fraction", fontsize=10)
     for yi, (thr, thr_name) in zip(y, thresholds):
@@ -960,8 +1051,13 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
             thr, yi - 0.4, thr_name,
             fontsize=7, color="#666666", ha="left",
         )
-    for yi, val in zip(y, values):
-        ax_bars.text(val, yi, f"  {val:.3f}", va="center", fontsize=9)
+    for yi, val, band in zip(y, values, bar_bands):
+        if band is not None:
+            lo, hi, _ = band
+            status = "✓" if lo <= val <= hi else ("⚠" if val < lo * 0.5 or val > hi * 2 else "~")
+        else:
+            status = ""
+        ax_bars.text(val, yi, f"  {val:.3f} {status}", va="center", fontsize=9)
 
     if max_value < 0.01:
         # Show the user what "all near zero" means rather than leaving a

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,97 @@
+"""Tests for the confidence-tier module (#109)."""
+
+import pytest
+
+from pirlygenes.confidence import (
+    ConfidenceTier,
+    compute_purity_confidence,
+    compute_target_confidence,
+)
+
+
+def _purity(point, lo, hi):
+    return {
+        "overall_estimate": point,
+        "overall_lower": lo,
+        "overall_upper": hi,
+    }
+
+
+def test_tight_ci_high_tier():
+    tier = compute_purity_confidence(_purity(0.64, 0.58, 0.70))
+    assert tier.tier == "high"
+    assert tier.badge == ""
+
+
+def test_moderate_ci_span_moderate_tier():
+    tier = compute_purity_confidence(_purity(0.50, 0.35, 0.65))
+    assert tier.tier == "moderate"
+    assert "span" in tier.inline_note
+
+
+def test_wide_ci_low_tier():
+    tier = compute_purity_confidence(_purity(0.64, 0.19, 1.00))
+    assert tier.tier == "low"
+    assert "wide purity CI" in tier.inline_note
+    assert tier.badge == "⚠⚠"
+
+
+def test_low_purity_regime_bumps_tier():
+    # Tight CI but point estimate is in the low-purity regime — the
+    # tier should step down because dividing by a small number
+    # amplifies any non-tumor residual.
+    tier = compute_purity_confidence(_purity(0.10, 0.08, 0.14))
+    assert tier.tier in {"moderate", "low"}
+    assert any("low-purity regime" in r for r in tier.reasons)
+
+
+def test_severe_degradation_forces_low():
+    tier = compute_purity_confidence(
+        _purity(0.60, 0.55, 0.68),
+        degradation_severity="severe",
+    )
+    assert tier.tier == "low"
+    assert any("severe RNA degradation" in r for r in tier.reasons)
+
+
+def test_moderate_degradation_bumps_high_to_moderate():
+    tier = compute_purity_confidence(
+        _purity(0.60, 0.55, 0.68),
+        degradation_severity="moderate",
+    )
+    assert tier.tier == "moderate"
+
+
+def test_target_confidence_inherits_purity_tier():
+    purity_tier = ConfidenceTier(tier="moderate", reasons=["wide purity CI"])
+    target = {"observed_tpm": 150, "tme_dominant": False, "tme_explainable": False}
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "moderate"
+    assert "wide purity CI" in tier.reasons
+
+
+def test_target_confidence_tme_dominant_forces_low():
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    target = {
+        "observed_tpm": 1850,
+        "tme_dominant": True,
+        "attribution": {"T_cell": 1400, "myeloid": 300},
+        "attr_tumor_fraction": 0.15,
+    }
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "low"
+    assert any("TME-dominant" in r for r in tier.reasons)
+    assert any("T cell" in r for r in tier.reasons)
+
+
+def test_target_confidence_partial_tumor_fraction_moderate():
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    target = {
+        "observed_tpm": 200,
+        "tme_dominant": False,
+        "tme_explainable": False,
+        "attr_tumor_fraction": 0.40,
+    }
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "moderate"
+    assert any("40% of signal" in r for r in tier.reasons)


### PR DESCRIPTION
## Summary

Batch 3 of the v4.8 sweep — structural UX improvements. Builds on batch 2.

### #107 — artifact-expectations reference

- New \`data/artifact-expectations.csv\` encoding the expected fraction band per (\`library_prep\`, \`preservation\`, \`gene_class\`) for the three diagnostic signals. 16 rows covering \`exome_capture\`, \`poly_a\`, \`ribo_depleted\`, \`total_rna\` × \`fresh\`/\`ffpe\`.
- \`plot_sample_context\` overlays the expected band as a shaded patch behind each bar; each observation is tagged ✓ / ~ / ⚠ relative to that band rather than a fixed threshold.
- Axis width scales with the band upper bound so shading is always visible.
- Adding a new library prep now means editing the CSV, no code change.

### #109 — confidence-tier infrastructure

- New \`pirlygenes/confidence.py\` module:
  - \`ConfidenceTier\` dataclass (tier, reasons, badge, inline_note)
  - \`compute_purity_confidence(purity, sample_context, degradation_severity)\`
  - \`compute_target_confidence(row, purity_tier, sample_context)\`
- Attached to \`analysis["purity_confidence"]\`; analysis.md's \`Overall estimate\` line now renders visibly different for tight CIs vs wide CIs (addresses #79 case 2).
- Per-target tier reads #108 attribution (\`tme_dominant\`, \`attr_tumor_fraction\`, named top compartment) so target confidence is grounded in fitted compartments rather than independent heuristics.
- 9 new unit tests covering tight/moderate/wide CI, low-purity regime, degradation cascade, TME-dominant, partial tumor-fraction.

### #79 — structural fixes (overlap with #109)

The Recommended Targets Summary already excludes ⚠⚠ rows with an explicit caveat line; the #109 purity tier completes the CI-visibility half. Remaining #79 items (number-formatting drift across tables) deferred as cosmetic.

### #78 — verified already comprehensive

\`compose_disease_state_narrative\` already covers PRAD CRPC + NEPC, BRCA ER/HER2, EMT + hypoxia, active IFN. Adding LUAD EGFR/KRAS, HNSC HPV, COAD MSI, DLBC GCB/ABC requires expansion of \`therapy-response-signatures.csv\` — that curation belongs with #110's cancer-key-genes work.

## Tests

\`./test.sh\` — **355 passed, 1 skipped** (9 new confidence tests + existing passes).

## Not in this PR

- #110 cancer-type therapy landscape + curated key-genes panels (batch 4; requires clinician-relevant curation CSV).
- #106 sample-provenance page (batch 4).
- #111 brief + actionable markdowns (batch 4).