### PR TITLE
Batch 4 actionable: cancer-key-genes (#110) + brief/actionable (#111) + provenance (#106)

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -1,0 +1,482 @@
+# Licensed under the Apache License, Version 2.0
+
+"""Two-tier markdown handoff documents (#111).
+
+Audience distinction:
+
+- ``*-brief.md`` — one-page summary, ≤ 40 lines. For a clinician
+  skimming before a tumor board, or an LLM asked for a 3-sentence
+  referral-note paragraph. Strict structure; no internal jargon.
+- ``*-actionable.md`` — longer treatment-review document. For an
+  oncologist preparing a treatment discussion, reading carefully.
+
+Both consume:
+
+- ``analysis`` (the shared dict produced by ``analyze_sample`` and
+  enriched by the CLI pipeline), including ``purity_confidence`` from
+  :mod:`pirlygenes.confidence`.
+- ``ranges_df`` (per-gene tumor-expression + #108 attribution).
+- The disease-state narrative from ``compose_disease_state_narrative``.
+- The curated cancer-key-genes panels from ``gene_sets_cancer``.
+
+No JSON is produced — consumers read markdown. (See
+``feedback_markdown_not_json`` in the memory: the audience test for a
+new output is "who reads this and when?", not "is it machine-
+parseable?".)
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+
+def _phase_label(phase: str) -> str:
+    return {
+        "approved": "Approved",
+        "phase_3": "Phase 3",
+        "phase_2": "Phase 2",
+        "phase_1": "Phase 1",
+        "preclinical": "Preclinical",
+    }.get(phase, phase)
+
+
+def _format_therapy_bullet(target_row, expression_row) -> str:
+    """One standardized therapy bullet for the brief."""
+    sym = str(target_row.get("symbol") or "")
+    agent = str(target_row.get("agent") or "—")
+    phase = _phase_label(str(target_row.get("phase") or ""))
+    indication = str(target_row.get("indication") or "")
+    indication_clause = f", {indication}" if indication else ""
+    if expression_row is None:
+        return (
+            f"- **{sym}** — {agent} ({phase}{indication_clause}). "
+            f"Target **not measured** in this sample."
+        )
+    observed = float(expression_row.get("observed_tpm") or 0.0)
+    attr_tumor = float(expression_row.get("attr_tumor_tpm") or 0.0)
+    has_attribution = bool(expression_row.get("attribution"))
+    attr_fraction = float(expression_row.get("attr_tumor_fraction") or 0.0)
+    if observed < 1.0:
+        return (
+            f"- **{sym}** — {agent} ({phase}{indication_clause}). "
+            f"Observed {observed:.1f} TPM — **target absent** in this sample."
+        )
+    if has_attribution:
+        tumor_clause = f"tumor-attributed {attr_tumor:.0f} TPM"
+    else:
+        tumor_clause = f"observed {observed:.0f} TPM"
+    if attr_fraction >= 0.5:
+        conf = "high"
+    elif attr_fraction >= 0.3 or not has_attribution:
+        conf = "moderate"
+    else:
+        conf = "low (mostly non-tumor)"
+    return (
+        f"- **{sym}** — {agent} ({phase}{indication_clause}). "
+        f"{tumor_clause.capitalize()}. Confidence: {conf}."
+    )
+
+
+def _top_therapies(
+    targets_df,
+    ranges_df,
+    limit=3,
+):
+    """Pick the top therapies to show in the brief.
+
+    Priority: approved agents with present targets first, ranked by
+    tumor-attributed TPM; then trial phases. Non-measured / absent
+    targets are skipped from the brief (they still show in the full
+    landscape in ``actionable.md`` / ``targets.md``).
+    """
+    if targets_df is None or len(targets_df) == 0 or ranges_df is None:
+        return []
+    sym_to_row = {}
+    for _, rrow in ranges_df.iterrows():
+        sym_to_row[str(rrow["symbol"])] = rrow
+
+    phase_priority = {
+        "approved": 0, "phase_3": 1, "phase_2": 2, "phase_1": 3, "preclinical": 4,
+    }
+
+    scored = []
+    for _, t in targets_df.iterrows():
+        sym = str(t.get("symbol") or "")
+        expr = sym_to_row.get(sym)
+        if expr is None:
+            continue
+        observed = float(expr.get("observed_tpm") or 0.0)
+        if observed < 1.0:
+            # Target absent — the brief reports presence, not absence.
+            # The full landscape in targets.md has the absence noted.
+            continue
+        attr_tumor = float(expr.get("attr_tumor_tpm") or 0.0)
+        attr_fraction = float(expr.get("attr_tumor_fraction") or 1.0)
+        # Drop rows that are mostly non-tumor from the top-3 — they
+        # don't belong in the clinician handoff per #79 semantics.
+        if attr_fraction < 0.30:
+            continue
+        phase = str(t.get("phase") or "")
+        sort_key = (phase_priority.get(phase, 99), -attr_tumor, sym)
+        scored.append((sort_key, t, expr))
+
+    # Sort by key only — avoid pandas Series comparison in tie-break.
+    scored.sort(key=lambda item: item[0])
+
+    deduped = []
+    seen_symbols = set()
+    for sort_key, t, expr in scored:
+        sym = sort_key[2]
+        if sym in seen_symbols:
+            continue
+        seen_symbols.add(sym)
+        deduped.append((t, expr))
+        if len(deduped) >= limit:
+            break
+    return deduped
+
+
+def _caveats_from_purity_tier(purity_tier, sample_context) -> List[str]:
+    """User-facing caveat lines for the brief.
+
+    Converts the ``purity_tier.reasons`` (which are short internal
+    strings) into full sentences without internal jargon.
+    """
+    if purity_tier is None:
+        return []
+    reasons = getattr(purity_tier, "reasons", []) or []
+    out = []
+    for reason in reasons:
+        r = str(reason)
+        if "wide purity CI" in r:
+            out.append(
+                "Purity confidence interval is wide — target TPMs "
+                "could be over- or under-stated depending on the true "
+                "purity."
+            )
+        elif "low-purity regime" in r:
+            out.append(
+                "Sample is in a low-purity regime — raw target TPMs "
+                "tend to overstate tumor presence. Prefer the tumor-"
+                "attributed values."
+            )
+        elif "severe RNA degradation" in r:
+            out.append(
+                "RNA is severely degraded — long-transcript targets "
+                "are systematically under-counted; interpret "
+                "negative results cautiously."
+            )
+        elif "moderate RNA degradation" in r:
+            out.append(
+                "RNA is partially degraded — long-transcript targets "
+                "are under-counted to a moderate degree."
+            )
+        elif "targeted-panel" in r:
+            out.append(
+                "Input appears to be a targeted panel rather than "
+                "whole-transcriptome — relative expression estimates "
+                "should be interpreted within the panel only."
+            )
+    # Library prep / preservation note from sample_context.
+    if sample_context is not None:
+        prep = getattr(sample_context, "library_prep", None)
+        preservation = getattr(sample_context, "preservation", None)
+        prep_label = {
+            "exome_capture": "exome capture",
+            "poly_a": "poly-A capture",
+            "ribo_depleted": "ribosomal depletion",
+            "total_rna": "total RNA",
+        }.get(prep, None)
+        if prep_label and preservation == "ffpe":
+            out.append(
+                f"FFPE preservation with {prep_label} library prep — "
+                "short transcripts favored; some classes of targets "
+                "are artificially depressed."
+            )
+        elif prep_label == "exome capture":
+            out.append(
+                "Exome-capture library prep — mitochondrial and "
+                "non-coding RNAs are absent by design; don't interpret "
+                "their absence as sample quality issues."
+            )
+    return out
+
+
+def build_brief(
+    analysis,
+    ranges_df,
+    cancer_code: str,
+    disease_state: str,
+    sample_id: Optional[str] = None,
+) -> str:
+    """Return the one-page ``*-brief.md`` content (≤ 40 lines).
+
+    Audience: clinician skimming before a tumor board; LLM asked for a
+    short referral-note paragraph. Strict structure; no internal
+    jargon.
+    """
+    from .gene_sets_cancer import (
+        cancer_therapy_targets,
+        cancer_key_genes_cancer_types,
+    )
+
+    purity = analysis.get("purity") or {}
+    purity_tier = analysis.get("purity_confidence")
+    sample_context = analysis.get("sample_context")
+    cancer_name = analysis.get("cancer_name") or cancer_code
+
+    lines: List[str] = []
+    header_id = f": {sample_id}" if sample_id else ""
+    lines.append(f"# Brief{header_id}\n")
+    lines.append(
+        "<!-- Audience: clinician skimming before tumor board. "
+        "Intended length: ≤ 40 lines. -->"
+    )
+    lines.append("")
+
+    # Cancer call
+    lines.append(f"**Cancer call:** {cancer_code} ({cancer_name}).")
+
+    # Purity
+    overall = purity.get("overall_estimate")
+    lower = purity.get("overall_lower")
+    upper = purity.get("overall_upper")
+    if overall is not None and lower is not None and upper is not None:
+        tier_label = getattr(purity_tier, "tier", "unknown") if purity_tier else "unknown"
+        lines.append(
+            f"**Purity:** {overall:.0%} (CI {lower:.0%}–{upper:.0%}, "
+            f"{tier_label} confidence)."
+        )
+
+    # Disease state
+    if disease_state:
+        lines.append(f"**Disease state:** {disease_state}")
+
+    # Sample context
+    if sample_context is not None:
+        prep_label = str(getattr(sample_context, "library_prep", "unknown")).replace("_", " ")
+        pres_label = str(getattr(sample_context, "preservation", "unknown")).replace("_", " ")
+        lines.append(f"**Sample:** {prep_label} library, {pres_label} preservation.")
+
+    lines.append("")
+
+    # Top therapies — only if the cancer type is curated.
+    if cancer_code in cancer_key_genes_cancer_types():
+        targets_df = cancer_therapy_targets(cancer_code)
+        top = _top_therapies(targets_df, ranges_df, limit=3)
+        if top:
+            lines.append("## Top candidate therapies\n")
+            for target_row, expression_row in top:
+                lines.append(_format_therapy_bullet(target_row, expression_row))
+            lines.append("")
+        else:
+            lines.append(
+                "## Top candidate therapies\n"
+                "*No approved or trialed agents with a measured, "
+                "tumor-attributed target in this sample.*\n"
+            )
+    else:
+        lines.append(
+            f"## Top candidate therapies\n"
+            f"*Cancer type {cancer_code} is not yet in the curated "
+            "key-genes panel — see the full tables below for a raw "
+            "expression ranking.*\n"
+        )
+
+    # Caveats
+    caveats = _caveats_from_purity_tier(purity_tier, sample_context)
+    if caveats:
+        lines.append("## Caveats")
+        for c in caveats:
+            lines.append(f"- {c}")
+        lines.append("")
+
+    lines.append(
+        "*Full detail: see the accompanying `*-actionable.md`, "
+        "`*-summary.md`, `*-analysis.md`, and `*-targets.md`.*"
+    )
+
+    return "\n".join(lines)
+
+
+def build_actionable(
+    analysis,
+    ranges_df,
+    cancer_code: str,
+    disease_state: str,
+    sample_id: Optional[str] = None,
+) -> str:
+    """Return the longer ``*-actionable.md`` content (~2-3 pages).
+
+    Audience: oncologist preparing a treatment discussion, or LLM
+    asked to draft a clinical summary. Full structure with the
+    biomarker panel and therapy landscape inline; no pipeline-
+    internal jargon.
+    """
+    from .gene_sets_cancer import (
+        cancer_biomarker_genes,
+        cancer_therapy_targets,
+        cancer_key_genes_cancer_types,
+    )
+
+    purity = analysis.get("purity") or {}
+    purity_tier = analysis.get("purity_confidence")
+    sample_context = analysis.get("sample_context")
+    cancer_name = analysis.get("cancer_name") or cancer_code
+
+    lines: List[str] = []
+    header_id = f" — {sample_id}" if sample_id else ""
+    lines.append(f"# Actionable review{header_id}\n")
+    lines.append(
+        "<!-- Audience: oncologist preparing a treatment discussion; "
+        "molecular tumor board member reading carefully. -->"
+    )
+    lines.append("")
+
+    # Sample + confidence paragraph
+    lines.append("## Sample and confidence\n")
+    prep_label = str(
+        getattr(sample_context, "library_prep", "unknown")
+    ).replace("_", " ") if sample_context else "unknown"
+    pres_label = str(
+        getattr(sample_context, "preservation", "unknown")
+    ).replace("_", " ") if sample_context else "unknown"
+    if sample_context:
+        lines.append(
+            f"Input: **{prep_label}** library prep, **{pres_label}** "
+            "preservation. "
+            + _preservation_clinical_clause(sample_context)
+        )
+
+    overall = purity.get("overall_estimate")
+    lower = purity.get("overall_lower")
+    upper = purity.get("overall_upper")
+    tier_label = getattr(purity_tier, "tier", "unknown") if purity_tier else "unknown"
+    tier_reasons = getattr(purity_tier, "reasons", []) if purity_tier else []
+    if overall is not None:
+        confidence_clause = f"**{tier_label}** confidence"
+        if tier_reasons and tier_label in {"low", "moderate"}:
+            confidence_clause += " (" + "; ".join(tier_reasons) + ")"
+        lines.append(
+            f"\nPurity point estimate: **{overall:.0%}** "
+            f"(CI {lower:.0%}–{upper:.0%}). {confidence_clause.capitalize()}."
+        )
+
+    lines.append("")
+
+    # Cancer call + disease state
+    lines.append("## Cancer call and disease state\n")
+    lines.append(f"Working call: **{cancer_code}** ({cancer_name}).")
+    if disease_state:
+        lines.append(f"\n{disease_state}")
+    lines.append("")
+
+    # Therapy landscape
+    if cancer_code in cancer_key_genes_cancer_types():
+        targets_df = cancer_therapy_targets(cancer_code)
+        sym_to_row = {}
+        for _, rrow in ranges_df.iterrows():
+            sym_to_row[str(rrow["symbol"])] = rrow
+
+        if len(targets_df):
+            lines.append("## Therapy landscape\n")
+            lines.append(
+                "Agents with an approved or trialed indication for "
+                f"{cancer_code}, cross-referenced to this sample. "
+                "Approved agents listed first."
+            )
+            lines.append("")
+            lines.append(
+                "| Target | Agent | Class | Phase | Indication | "
+                "Observed | Tumor-attr. |"
+            )
+            lines.append(
+                "|--------|-------|-------|-------|------------|"
+                "----------|-------------|"
+            )
+            phase_order = {
+                "approved": 0, "phase_3": 1, "phase_2": 2,
+                "phase_1": 3, "preclinical": 4,
+            }
+            sorted_df = targets_df.assign(
+                _po=targets_df["phase"].map(
+                    lambda p: phase_order.get(str(p), 99)
+                )
+            ).sort_values(["_po", "symbol", "agent"])
+            for _, t in sorted_df.iterrows():
+                sym = str(t["symbol"])
+                expr = sym_to_row.get(sym)
+                if expr is None:
+                    obs_cell = "*not measured*"
+                    tumor_cell = "—"
+                else:
+                    obs_cell = f"{float(expr.get('observed_tpm') or 0):.1f}"
+                    attr_tumor = float(expr.get("attr_tumor_tpm") or 0)
+                    tumor_cell = (
+                        f"{attr_tumor:.0f}" if expr.get("attribution") else "—"
+                    )
+                phase = _phase_label(str(t.get("phase") or ""))
+                bold = "**" if phase == "Approved" else ""
+                lines.append(
+                    f"| {bold}{sym}{bold} | {t.get('agent', '—')} | "
+                    f"{t.get('agent_class', '—')} | {phase} | "
+                    f"{t.get('indication', '—')} | {obs_cell} | {tumor_cell} |"
+                )
+            lines.append("")
+
+        # Biomarker panel
+        biomarker_syms = cancer_biomarker_genes(cancer_code)
+        if biomarker_syms:
+            lines.append("## Biomarker panel\n")
+            lines.append(
+                "Lineage, diagnostic, and disease-state biomarkers for "
+                f"{cancer_code}. Status in this sample:"
+            )
+            lines.append("")
+            lines.append("| Gene | Observed TPM | Tumor-attributed |")
+            lines.append("|------|--------------|------------------|")
+            for sym in biomarker_syms:
+                row = sym_to_row.get(sym)
+                if row is None:
+                    lines.append(f"| {sym} | *not measured* | — |")
+                    continue
+                obs = float(row.get("observed_tpm") or 0)
+                attr = float(row.get("attr_tumor_tpm") or 0)
+                tumor_cell = f"{attr:.0f}" if row.get("attribution") else "—"
+                lines.append(f"| {sym} | {obs:.1f} | {tumor_cell} |")
+            lines.append("")
+
+    # Caveats
+    caveats = _caveats_from_purity_tier(purity_tier, sample_context)
+    if caveats:
+        lines.append("## Caveats\n")
+        for c in caveats:
+            lines.append(f"- {c}")
+        lines.append("")
+
+    lines.append(
+        "*See also: `*-summary.md` (free-form narrative), "
+        "`*-analysis.md` (full pipeline detail), `*-targets.md` "
+        "(complete target list), `*-provenance.md` (sample-content chain).*"
+    )
+    return "\n".join(lines)
+
+
+def _preservation_clinical_clause(sample_context) -> str:
+    """One-sentence clinician-facing framing of preservation."""
+    prep = getattr(sample_context, "library_prep", None)
+    preservation = getattr(sample_context, "preservation", None)
+    severity = getattr(sample_context, "degradation_severity", "none")
+    if preservation == "ffpe" and severity in ("moderate", "severe"):
+        return (
+            f"FFPE with {severity} degradation — long-transcript "
+            "quantification is biased; negative results for long genes "
+            "should be interpreted cautiously."
+        )
+    if prep == "exome_capture":
+        return (
+            "Exome-capture prep selectively targets coding exons; "
+            "mitochondrial and non-polyadenylated transcripts are "
+            "absent by design."
+        )
+    return ""

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1330,6 +1330,42 @@ def _analyze_body(
             cancer_type=effective_cancer_type,
             purity_result=purity_dict,
         )
+
+        # #111: two-tier markdown handoff. Emitted after the detailed
+        # reports so both can reference each other. The brief is the
+        # doc a clinician pastes into a note; the actionable is the
+        # one they read before a tumor board.
+        try:
+            from .brief import build_brief, build_actionable
+
+            disease_state_for_brief = compose_disease_state_narrative(analysis)
+            sample_id = prefix if prefix else None
+            brief_md = build_brief(
+                analysis,
+                ranges_df,
+                cancer_code=effective_cancer_type,
+                disease_state=disease_state_for_brief,
+                sample_id=sample_id,
+            )
+            actionable_md = build_actionable(
+                analysis,
+                ranges_df,
+                cancer_code=effective_cancer_type,
+                disease_state=disease_state_for_brief,
+                sample_id=sample_id,
+            )
+            brief_path = "%s-brief.md" % prefix if prefix else "brief.md"
+            actionable_path = (
+                "%s-actionable.md" % prefix if prefix else "actionable.md"
+            )
+            with open(brief_path, "w") as f:
+                f.write(brief_md)
+            with open(actionable_path, "w") as f:
+                f.write(actionable_md)
+            print(f"[report] Saved {brief_path}")
+            print(f"[report] Saved {actionable_path}")
+        except Exception as brief_err:
+            print(f"[warn] Brief / actionable rendering failed: {brief_err}")
     except Exception as e:
         print(f"[warn] Purity-adjusted analysis failed: {e}")
         import traceback

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1364,6 +1364,33 @@ def _analyze_body(
                 f.write(actionable_md)
             print(f"[report] Saved {brief_path}")
             print(f"[report] Saved {actionable_path}")
+
+            # #106: one-page provenance chain (library prep -> tumor
+            # core). Emits *-provenance.md alongside a simple stacked-
+            # bar figure showing the compartment composition.
+            from .provenance import build_provenance_md, plot_provenance_funnel
+
+            provenance_md = build_provenance_md(
+                analysis,
+                ranges_df,
+                decomp_results,
+                cancer_code=effective_cancer_type,
+                sample_id=sample_id,
+            )
+            prov_path = "%s-provenance.md" % prefix if prefix else "provenance.md"
+            with open(prov_path, "w") as f:
+                f.write(provenance_md)
+            print(f"[report] Saved {prov_path}")
+            prov_png = "%s-provenance.png" % prefix if prefix else "provenance.png"
+            fig_out = plot_provenance_funnel(
+                analysis,
+                ranges_df,
+                decomp_results,
+                save_to_filename=prov_png,
+                save_dpi=output_dpi,
+            )
+            if fig_out:
+                print(f"[plot] Saved {prov_png}")
         except Exception as brief_err:
             print(f"[warn] Brief / actionable rendering failed: {brief_err}")
     except Exception as e:

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -2656,6 +2656,121 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     matched_normal_summary = _matched_normal_split_summary(ranges_df)
     mhc_status_label, mhc_status_text = _mhc1_status_text(analysis.get("mhc1"))
 
+    # #110: cancer-type-scoped biomarker panel + therapy landscape.
+    # Emitted before the general surface/intracellular tables so a
+    # clinician reading top-down sees the curated, decision-relevant
+    # rows first. Silently omitted for cancer types that aren't yet
+    # curated in ``data/cancer-key-genes.csv`` — that's explicit, not
+    # a fallback to the general tables.
+    try:
+        from .gene_sets_cancer import (
+            cancer_biomarker_genes,
+            cancer_therapy_targets,
+            cancer_key_genes_cancer_types,
+        )
+
+        if cancer_code in cancer_key_genes_cancer_types():
+            # Build symbol → row lookup from ranges_df for biomarker
+            # expression levels.
+            sym_to_row = {}
+            for _, rrow in ranges_df.iterrows():
+                sym_to_row[str(rrow["symbol"])] = rrow
+
+            lines.append(f"## Biomarker Panel — {cancer_code}\n")
+            lines.append(
+                "Clinician-relevant biomarkers for this cancer type: "
+                "lineage confirmation, disease-state indicators, and "
+                "diagnostic markers. **Not therapy targets** — see the "
+                "Therapy Landscape below for druggable genes.\n"
+            )
+            biomarker_syms = cancer_biomarker_genes(cancer_code)
+            if biomarker_syms:
+                lines.append("| Gene | Observed TPM | Tumor-attributed | Attribution |")
+                lines.append("|------|--------------|------------------|-------------|")
+                for sym in biomarker_syms:
+                    row = sym_to_row.get(sym)
+                    if row is None:
+                        lines.append(f"| {sym} | *not measured* | — | — |")
+                        continue
+                    obs = float(row.get("observed_tpm") or 0.0)
+                    attr_tumor = float(row.get("attr_tumor_tpm") or 0.0)
+                    attribution_cell = _format_attribution_cell(row)
+                    tumor_cell = (
+                        f"{attr_tumor:.0f}" if row.get("attribution")
+                        else "—"
+                    )
+                    lines.append(
+                        f"| {sym} | {obs:.1f} | {tumor_cell} | {attribution_cell} |"
+                    )
+                lines.append("")
+            else:
+                lines.append("*No biomarker genes curated for this cancer type.*\n")
+
+            lines.append(f"## Therapy Target Landscape — {cancer_code}\n")
+            lines.append(
+                "Approved and trialed agents with an indication for this "
+                "cancer type, cross-referenced against sample expression. "
+                "Rows where the target is absent from the sample are "
+                "still shown to make that explicit.\n"
+            )
+            targets_df = cancer_therapy_targets(cancer_code)
+            if len(targets_df):
+                lines.append(
+                    "| Target | Agent | Class | Phase | Indication | "
+                    "Observed | Tumor-attr. | Attribution |"
+                )
+                lines.append(
+                    "|--------|-------|-------|-------|------------|"
+                    "----------|-------------|-------------|"
+                )
+                # Approved first, then phase_3, phase_2, phase_1,
+                # preclinical. Within phase, agent name for stability.
+                phase_order = {
+                    "approved": 0, "phase_3": 1, "phase_2": 2,
+                    "phase_1": 3, "preclinical": 4,
+                }
+                targets_sorted = targets_df.assign(
+                    _phase_key=targets_df["phase"].map(
+                        lambda p: phase_order.get(str(p), 99)
+                    )
+                ).sort_values(["_phase_key", "symbol", "agent"])
+                for _, trow in targets_sorted.iterrows():
+                    sym = str(trow["symbol"])
+                    expr = sym_to_row.get(sym)
+                    agent = str(trow.get("agent") or "—")
+                    agent_class = str(trow.get("agent_class") or "—")
+                    phase = str(trow.get("phase") or "—").replace("_", " ")
+                    indication = str(trow.get("indication") or "—")
+                    if expr is None:
+                        obs_cell = "*not measured*"
+                        tumor_cell = "—"
+                        attr_cell = "—"
+                    else:
+                        obs_cell = f"{float(expr.get('observed_tpm') or 0.0):.1f}"
+                        attr_tumor = float(expr.get("attr_tumor_tpm") or 0.0)
+                        tumor_cell = (
+                            f"{attr_tumor:.0f}" if expr.get("attribution")
+                            else "—"
+                        )
+                        attr_cell = _format_attribution_cell(expr)
+                    bold = "**" if phase == "approved" else ""
+                    lines.append(
+                        f"| {bold}{sym}{bold} | {agent} | {agent_class} | "
+                        f"{phase} | {indication} | {obs_cell} | "
+                        f"{tumor_cell} | {attr_cell} |"
+                    )
+                lines.append("")
+            else:
+                lines.append(
+                    "*No clinician-validated therapy targets curated for "
+                    "this cancer type yet. The general Surface / "
+                    "Intracellular tables below are ranked by raw "
+                    "expression, not by approved indication.*\n"
+                )
+    except Exception as _lm_err:
+        # Never fail the whole report on curation / loader issues.
+        print(f"[warn] Could not render cancer-key-genes panel: {_lm_err}")
+
     # Pre-sort the key target categories so the summary and the full
     # tables agree on what "top" means.
     ctas = (

--- a/pirlygenes/data/cancer-key-genes.csv
+++ b/pirlygenes/data/cancer-key-genes.csv
@@ -1,0 +1,150 @@
+cancer_code,subtype,symbol,role,agent,agent_class,phase,indication,rationale,source
+PRAD,,AR,biomarker,,,,,Androgen receptor — lineage confirmation; retained expression with collapsed transactivation targets indicates castrate-resistant disease,PMID:23332746
+PRAD,,KLK3,biomarker,,,,,PSA — transactivated target of AR; collapse with retained AR indicates CRPC,PMID:23332746
+PRAD,,KLK2,biomarker,,,,,Kallikrein 2 — AR-transactivated; parallels KLK3 in CRPC de-differentiation,PMID:23332746
+PRAD,,NKX3-1,biomarker,,,,,Prostate lineage transcription factor; lost in NEPC / de-differentiated disease,PMID:17538631
+PRAD,,HOXB13,biomarker,,,,,Prostate lineage; combined with NKX3-1 loss signals de-differentiation,PMID:28069311
+PRAD,,TMPRSS2,biomarker,,,,,AR-target gene; part of TMPRSS2-ERG fusion landscape,PMID:16254181
+PRAD,,ENO2,biomarker,,,,,Neuron-specific enolase — core NE-differentiation marker; elevation with AR-target collapse warrants NEPC workup,PMID:27322743
+PRAD,,CHGA,biomarker,,,,,Chromogranin A — NE differentiation marker,PMID:27322743
+PRAD,,SYP,biomarker,,,,,Synaptophysin — NE differentiation marker,PMID:27322743
+PRAD,,ASCL1,biomarker,,,,,NE lineage transcription factor; active in NEPC,PMID:31611234
+PRAD,,INSM1,biomarker,,,,,NE transcription factor; preferred marker over CHGA/SYP in some NEPC panels,PMID:31611234
+PRAD,,FOLH1,target,177Lu-PSMA-617,radioligand,approved,mCRPC,PSMA — lutetium radioligand approved for PSMA-PET positive mCRPC post-ARPI,PMID:34161051
+PRAD,,FOLH1,target,225Ac-PSMA-617,radioligand,phase_3,mCRPC,PSMA alpha-emitter in late-stage trials for PSMA-PET positive mCRPC,PMID:35930720
+PRAD,,STEAP1,target,AMG-509 (xaluritamig),TCE,phase_2,mCRPC,STEAP1×CD3 bispecific T-cell engager in mCRPC; encouraging phase 1 responses,PMID:37812792
+PRAD,,STEAP2,target,,ADC,preclinical,mCRPC,STEAP2 ADCs in discovery; coexpressed with STEAP1,
+PRAD,,DLL3,target,tarlatamab,TCE,phase_2,NEPC,DLL3×CD3 BiTE initially approved for SCLC; active trials in NEPC where DLL3 is retained,PMID:36417474
+PRAD,,KLK2,target,JNJ-69086420,bispecific,phase_1,mCRPC,KLK2-targeting bispecific in early-phase trials,PMID:38110199
+PRAD,,TACSTD2,target,sacituzumab govitecan,ADC,phase_2,mCRPC,Trop-2 ADC trials in CRPC following breast and urothelial approvals,
+PRAD,,AR,target,enzalutamide,small_molecule,approved,mCRPC,Second-generation AR antagonist; standard of care in CRPC,PMID:22894553
+PRAD,,AR,target,apalutamide,small_molecule,approved,nmCRPC,Approved for non-metastatic CRPC and mHSPC,PMID:29420164
+BRCA,,ESR1,biomarker,,,,,Estrogen receptor — drives endocrine therapy indication; loss / mutation marks endocrine resistance,PMID:27532823
+BRCA,,PGR,biomarker,,,,,Progesterone receptor — luminal marker; retained PR favors endocrine sensitivity,PMID:17438091
+BRCA,,ERBB2,biomarker,,,,,HER2 — gating biomarker for HER2-targeted agents; IHC/ISH 3+ or FISH-amplified eligible,PMID:17544441
+BRCA,,MKI67,biomarker,,,,,Ki-67 proliferation index; prognostic and guides chemo decisions in ER+ disease,PMID:21965299
+BRCA,,GATA3,biomarker,,,,,Luminal transcription factor; diagnostic for mammary origin,PMID:16730215
+BRCA,,FOXA1,biomarker,,,,,Pioneer factor cooperating with ER; luminal identity,PMID:20378679
+BRCA,,BRCA1,biomarker,,,,,Germline/somatic loss drives PARP inhibitor indication,PMID:19553641
+BRCA,,BRCA2,biomarker,,,,,Germline/somatic loss drives PARP inhibitor indication,PMID:19553641
+BRCA,,ERBB2,target,trastuzumab,antibody,approved,HER2+ BRCA,First-in-class anti-HER2 monoclonal; standard backbone for HER2+ disease,PMID:11248153
+BRCA,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,HER2+ / HER2-low BRCA,Enhertu — expanded approval to HER2-low metastatic breast cancer,PMID:35665782
+BRCA,,ERBB2,target,pertuzumab,antibody,approved,HER2+ BRCA,Dual HER2 blockade with trastuzumab,PMID:22149875
+BRCA,,TACSTD2,target,sacituzumab govitecan,ADC,approved,mTNBC / HR+/HER2-,Trodelvy — Trop-2 ADC approved in mTNBC and HR+/HER2- post-endocrine,PMID:33882206
+BRCA,,FOLR1,target,mirvetuximab soravtansine,ADC,phase_3,TNBC subsets,Folate receptor alpha ADC in basket trials including TNBC,PMID:37094291
+BRCA,,ESR1,target,elacestrant,small_molecule,approved,ER+/HER2- ESR1-mut BRCA,Oral SERD approved for ESR1-mutant metastatic ER+ disease,PMID:36924229
+BRCA,,PGR,target,,hormone,approved,ER+/HER2- BRCA,PR positivity supports endocrine therapy with AI or tamoxifen,
+BRCA,,CDK4,target,palbociclib,small_molecule,approved,HR+/HER2- BRCA,CDK4/6 inhibitor combined with endocrine therapy,PMID:25524798
+BRCA,,CDK6,target,abemaciclib,small_molecule,approved,HR+/HER2- BRCA,CDK4/6 inhibitor including adjuvant use,PMID:31158057
+LUAD,,EGFR,biomarker,,,,,Activating mutations (exon 19 del / L858R) gate TKI indication; T790M drives osimertinib selection,PMID:15118073
+LUAD,,KRAS,biomarker,,,,,G12C targetable; other alleles remain a negative predictor for EGFR TKIs,PMID:32955177
+LUAD,,ALK,biomarker,,,,,EML4-ALK fusion — alectinib-eligible,PMID:17625570
+LUAD,,ROS1,biomarker,,,,,ROS1 fusion — crizotinib / entrectinib eligible,PMID:22215748
+LUAD,,BRAF,biomarker,,,,,V600E mutation — dabrafenib+trametinib eligible,PMID:27283860
+LUAD,,RET,biomarker,,,,,RET fusion — selpercatinib / pralsetinib eligible,PMID:32273263
+LUAD,,MET,biomarker,,,,,Exon 14 skipping — capmatinib / tepotinib eligible,PMID:31950082
+LUAD,,NTRK1,biomarker,,,,,NTRK fusion — larotrectinib / entrectinib eligible (basket),PMID:29466156
+LUAD,,CD274,biomarker,,,,,PD-L1 expression gates first-line pembrolizumab monotherapy,PMID:27718847
+LUAD,,KEAP1,biomarker,,,,,Co-mutation with STK11 predicts immunotherapy resistance,PMID:30275273
+LUAD,,STK11,biomarker,,,,,Loss predicts immunotherapy resistance in KRAS-mutant LUAD,PMID:30287575
+LUAD,,NKX2-1,biomarker,,,,,TTF-1 — adenocarcinoma lineage confirmation,PMID:20686206
+LUAD,,EGFR,target,osimertinib,small_molecule,approved,EGFR-mut LUAD,Third-generation EGFR TKI — frontline and resistance setting,PMID:31733398
+LUAD,,ALK,target,alectinib,small_molecule,approved,ALK-rearranged LUAD,Second-generation ALK TKI — frontline standard,PMID:28586279
+LUAD,,KRAS,target,sotorasib,small_molecule,approved,KRAS G12C LUAD,First KRAS G12C inhibitor approved,PMID:34252278
+LUAD,,KRAS,target,adagrasib,small_molecule,approved,KRAS G12C LUAD,Second KRAS G12C inhibitor,PMID:35658005
+LUAD,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600E LUAD,BRAF/MEK combination,PMID:27283860
+LUAD,,MET,target,capmatinib,small_molecule,approved,MET exon 14 LUAD,MET inhibitor for exon 14 skipping,PMID:32877583
+LUAD,,RET,target,selpercatinib,small_molecule,approved,RET fusion LUAD,Selective RET inhibitor,PMID:32846060
+LUAD,,CD274,target,pembrolizumab,antibody,approved,PD-L1 high LUAD,Anti-PD-1; first-line for TPS ≥50%,PMID:27718847
+LUAD,,CEACAM5,target,tusamitamab ravtansine,ADC,phase_3,CEACAM5+ NSCLC,Phase 3 CARMEN-LC03 trial,PMID:36070567
+LUAD,,TROP2,target,datopotamab deruxtecan,ADC,approved,NSCLC,Dato-DXd approved in advanced/metastatic nsqNSCLC,
+COAD,,KRAS,biomarker,,,,,KRAS wild-type required for EGFR antibody (cetuximab / panitumumab) response,PMID:18316791
+COAD,,NRAS,biomarker,,,,,Must be wild-type for EGFR-antibody response; pan-RAS testing standard,PMID:20921462
+COAD,,BRAF,biomarker,,,,,V600E — poor prognosis; triple combo encorafenib+cetuximab+MEK eligible,PMID:24637364
+COAD,,MLH1,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; gates checkpoint IO,PMID:11932474
+COAD,,MSH2,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; Lynch syndrome relevance,PMID:11932474
+COAD,,MSH6,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; Lynch syndrome relevance,PMID:11932474
+COAD,,PMS2,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR,PMID:11932474
+COAD,,CDX2,biomarker,,,,,Intestinal lineage transcription factor — diagnostic of GI adenocarcinoma,PMID:18818409
+COAD,,CEACAM5,biomarker,,,,,CEA — serum / tissue biomarker for colorectal adenocarcinoma,PMID:15767599
+COAD,,ERBB2,biomarker,,,,,HER2 amplification — approved indication for trastuzumab combos in RAS WT,PMID:27108243
+COAD,,TP53,biomarker,,,,,Prognostic / predictive; mutation common and linked to chemo response,PMID:27496642
+COAD,,APC,biomarker,,,,,Gatekeeper driver of adenoma-carcinoma sequence; Wnt pathway activation,PMID:20180050
+COAD,,BRAF,target,encorafenib + cetuximab,small_molecule,approved,BRAF V600E mCRC,BEACON triplet / doublet for BRAF V600E mCRC,PMID:31566309
+COAD,,KRAS,target,sotorasib,small_molecule,approved,KRAS G12C mCRC,Approved in pretreated KRAS G12C mCRC (CodeBreaK 300),PMID:37882531
+COAD,,KRAS,target,adagrasib,small_molecule,approved,KRAS G12C mCRC,Approved with cetuximab for pretreated KRAS G12C mCRC,
+COAD,,ERBB2,target,trastuzumab + tucatinib,antibody,approved,HER2+ RAS-WT mCRC,MOUNTAINEER trial result; HER2+ mCRC,PMID:37084732
+COAD,,EGFR,target,cetuximab,antibody,approved,RAS-WT mCRC,Anti-EGFR in RAS/BRAF wild-type mCRC,PMID:19339720
+COAD,,EGFR,target,panitumumab,antibody,approved,RAS-WT mCRC,Fully human anti-EGFR antibody,PMID:20921462
+COAD,,CD274,target,pembrolizumab,antibody,approved,MSI-H / dMMR mCRC,Frontline IO in MSI-H / dMMR mCRC (KEYNOTE-177),PMID:33264544
+COAD,,CEACAM5,target,labetuzumab govitecan,ADC,phase_2,CEACAM5+ mCRC,CEACAM5 ADC in clinical trials,
+SKCM,,BRAF,biomarker,,,,,V600E/K — gates BRAF/MEK inhibition,PMID:22460905
+SKCM,,NRAS,biomarker,,,,,Q61 mutations — MEK / ERK-directed trials,PMID:23410882
+SKCM,,MITF,biomarker,,,,,Melanocyte lineage transcription factor; amplification in some resistance phenotypes,PMID:16172454
+SKCM,,S100B,biomarker,,,,,Serum biomarker for melanoma progression,PMID:19380449
+SKCM,,MLANA,biomarker,,,,,Melan-A / MART-1 — melanocyte lineage antigen and TCR target,PMID:7539751
+SKCM,,TYR,biomarker,,,,,Tyrosinase — melanocyte lineage antigen,PMID:8201753
+SKCM,,PMEL,biomarker,,,,,gp100 — melanocyte antigen; vaccine and TCR target,PMID:8201753
+SKCM,,PRAME,biomarker,,,,,Cancer-testis antigen broadly expressed in melanoma; IMCgp100 / PRAME TCR trials,PMID:34428009
+SKCM,,CD274,biomarker,,,,,PD-L1 stratifies IO response,PMID:26027431
+SKCM,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600 melanoma,Standard BRAF/MEK combination in V600-mutant disease,PMID:25399551
+SKCM,,BRAF,target,encorafenib + binimetinib,small_molecule,approved,BRAF V600 melanoma,COLUMBUS trial combination,PMID:29573941
+SKCM,,BRAF,target,vemurafenib,small_molecule,approved,BRAF V600 melanoma,First BRAF inhibitor approved for melanoma,PMID:21639808
+SKCM,,CD274,target,pembrolizumab,antibody,approved,advanced melanoma,First-line anti-PD-1,PMID:25891173
+SKCM,,CD274,target,nivolumab,antibody,approved,advanced melanoma,First-line anti-PD-1; combined with ipi for high-risk disease,PMID:26027431
+SKCM,,CTLA4,target,ipilimumab,antibody,approved,advanced melanoma,Anti-CTLA4; combination with nivolumab standard of care,PMID:20525992
+SKCM,,LAG3,target,relatlimab,antibody,approved,advanced melanoma,LAG-3 + PD-1 combination (nivolumab-relatlimab),PMID:35063055
+SKCM,,PRAME,target,IMA203,TCR-T,phase_2,advanced melanoma,PRAME-directed TCR-T trials,PMID:34428009
+SKCM,,PMEL,target,IMCgp100 / tebentafusp,TCE,approved,uveal melanoma,gp100 ImmTAC — approved for HLA-A*02:01 uveal melanoma,PMID:33053284
+SKCM,,TYR,target,,TCR-T,preclinical,melanoma,Historical tyrosinase TCRs; active cell-therapy research,
+HNSC,,CDKN2A,biomarker,,,,,p16 — elevated in HPV-driven HNSC (surrogate for E6/E7 inactivation),PMID:21079132
+HNSC,,EGFR,biomarker,,,,,Overexpression / mutation — cetuximab eligibility,PMID:11309435
+HNSC,,CD274,biomarker,,,,,PD-L1 CPS gates first-line pembrolizumab monotherapy or combo,PMID:30509740
+HNSC,,CCND1,biomarker,,,,,Cyclin D1 — frequently amplified in HPV-negative HNSC,PMID:26457759
+HNSC,,TP53,biomarker,,,,,Mutation common in HPV-negative disease; prognostic,PMID:26457759
+HNSC,,PIK3CA,biomarker,,,,,Hotspot mutations prevalent; relevant to PI3K-pathway trials,PMID:21430269
+HNSC,,FADD,biomarker,,,,,Amplified in HPV-negative HNSC; linked to resistance signaling,PMID:21430269
+HNSC,,EGFR,target,cetuximab,antibody,approved,recurrent/metastatic HNSC,Anti-EGFR — combined with chemo or RT,PMID:18784101
+HNSC,,CD274,target,pembrolizumab,antibody,approved,recurrent/metastatic HNSC,Frontline IO per CPS (KEYNOTE-048),PMID:31679945
+HNSC,,CD274,target,nivolumab,antibody,approved,recurrent/metastatic HNSC,Anti-PD-1 post-platinum (CheckMate 141),PMID:27718847
+DLBC,,MS4A1,biomarker,,,,,CD20 — lineage for B-cell lymphoma; gates rituximab,PMID:9562152
+DLBC,,CD19,biomarker,,,,,B-cell lineage; gates CD19 CAR-T,PMID:29466159
+DLBC,,CD79A,biomarker,,,,,BCR complex component; helps confirm B-cell lineage,PMID:21893720
+DLBC,,CD79B,biomarker,,,,,BCR complex component; polatuzumab target and ABC-subtype marker,PMID:31091374
+DLBC,,BCL6,biomarker,,,,,GCB marker per Hans algorithm,PMID:14504078
+DLBC,,MME,biomarker,,,,,CD10 — GCB marker per Hans algorithm,PMID:14504078
+DLBC,,IRF4,biomarker,,,,,MUM1 — ABC marker per Hans algorithm,PMID:14504078
+DLBC,,MYC,biomarker,,,,,Rearrangement / co-expression marker — double/triple-hit lymphoma,PMID:19917594
+DLBC,,BCL2,biomarker,,,,,Rearrangement / high expression — double/triple-hit; BCL2 inhibitor eligibility,PMID:19917594
+DLBC,,MS4A1,target,rituximab,antibody,approved,DLBCL,Anti-CD20 — backbone of R-CHOP,PMID:12075054
+DLBC,,CD19,target,axicabtagene ciloleucel,CAR-T,approved,R/R DLBCL,Anti-CD19 CAR-T (Yescarta),PMID:29091450
+DLBC,,CD19,target,tisagenlecleucel,CAR-T,approved,R/R DLBCL,Anti-CD19 CAR-T (Kymriah),PMID:30501490
+DLBC,,CD19,target,lisocabtagene maraleucel,CAR-T,approved,R/R DLBCL,Anti-CD19 CAR-T (Breyanzi),PMID:33301694
+DLBC,,CD19,target,loncastuximab tesirine,ADC,approved,R/R DLBCL,Anti-CD19 ADC (Zynlonta),PMID:34123378
+DLBC,,CD19,target,tafasitamab,antibody,approved,R/R DLBCL,Anti-CD19 with lenalidomide,PMID:32654889
+DLBC,,CD79B,target,polatuzumab vedotin,ADC,approved,R/R DLBCL / 1L DLBCL,Anti-CD79B ADC; Pola-R-CHP new frontline standard,PMID:31091374
+DLBC,,CD22,target,inotuzumab ozogamicin,ADC,phase_2,R/R aggressive B-NHL,CD22 ADC extended from ALL to aggressive B-NHL trials,PMID:25605598
+DLBC,,CD20,target,glofitamab,TCE,approved,R/R DLBCL,CD20×CD3 bispecific (Columvi),PMID:36542511
+DLBC,,CD20,target,epcoritamab,TCE,approved,R/R DLBCL,CD20×CD3 bispecific (Epkinly),PMID:37093768
+DLBC,,BCL2,target,venetoclax,small_molecule,phase_2,DLBCL,Active trials in double-hit and ABC DLBCL subtypes,PMID:29523570
+LAML,,CD33,biomarker,,,,,Myeloid lineage — gates gemtuzumab ozogamicin,PMID:21233305
+LAML,,KIT,biomarker,,,,,CD117 — myeloid progenitor marker; D816V mutation in core-binding-factor AML,PMID:16293591
+LAML,,FLT3,biomarker,,,,,ITD / TKD mutations — midostaurin / gilteritinib eligibility,PMID:28644114
+LAML,,NPM1,biomarker,,,,,Exon 12 mutation — favorable prognosis in CN-AML; menin-inhibitor sensitive,PMID:15659725
+LAML,,CEBPA,biomarker,,,,,Biallelic mutation — favorable prognosis,PMID:18489401
+LAML,,IDH1,biomarker,,,,,R132 mutation — ivosidenib eligibility,PMID:29860938
+LAML,,IDH2,biomarker,,,,,R140/R172 mutation — enasidenib eligibility,PMID:28588020
+LAML,,RUNX1,biomarker,,,,,Mutation — adverse prognosis; included in WHO classification,PMID:25082879
+LAML,,TP53,biomarker,,,,,Mutation — adverse prognosis; APR-246 trials,PMID:27959686
+LAML,,DNMT3A,biomarker,,,,,Mutation — adverse prognosis,PMID:21067377
+LAML,,KMT2A,biomarker,,,,,Rearrangement — menin-inhibitor eligibility; adverse prognosis,PMID:37018480
+LAML,,MPO,biomarker,,,,,Myeloid granulocytic lineage confirmation (cytochemistry / IHC),
+LAML,,CD33,target,gemtuzumab ozogamicin,ADC,approved,CD33+ AML,First ADC approved; combined with chemo in newly diagnosed AML,PMID:15178638
+LAML,,FLT3,target,midostaurin,small_molecule,approved,FLT3-mut AML,Type I FLT3 inhibitor — newly diagnosed FLT3-mut AML,PMID:28644114
+LAML,,FLT3,target,gilteritinib,small_molecule,approved,R/R FLT3-mut AML,Type I FLT3 inhibitor — relapsed/refractory setting,PMID:31634902
+LAML,,IDH1,target,ivosidenib,small_molecule,approved,R/R IDH1-mut AML,IDH1 inhibitor; combined with azacitidine in newly diagnosed unfit patients,PMID:29860938
+LAML,,IDH2,target,enasidenib,small_molecule,approved,R/R IDH2-mut AML,IDH2 inhibitor,PMID:28588020
+LAML,,BCL2,target,venetoclax,small_molecule,approved,AML (unfit),Venetoclax+azacitidine/decitabine standard for unfit newly diagnosed AML,PMID:32786187
+LAML,,KMT2A,target,revumenib,small_molecule,approved,R/R KMT2A-rearranged AML,Menin inhibitor approved in KMT2A-rearranged R/R AML,PMID:37018480
+LAML,,NPM1,target,revumenib,small_molecule,phase_2,NPM1-mut AML,Menin inhibitor trials in NPM1-mutant AML,PMID:37018480
+LAML,,CD123,target,tagraxofusp,fusion,approved,BPDCN,CD123-directed; approved for BPDCN (related myeloid malignancy),PMID:30987805

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -1338,3 +1338,55 @@ def CTA_partition(return_type="gene_ids", ensembl_release=112):
         return CTA_partition_dataframes(ensembl_release)
     else:
         raise ValueError(f"return_type must be 'gene_ids', 'gene_names', or 'dataframes', got {return_type!r}")
+
+
+# ---------- Cancer-type key genes (biomarkers + therapy targets) #110 ----------
+def cancer_key_genes_df():
+    """Full curated table of clinician-relevant biomarker and therapy-
+    target genes per cancer type (#110).
+
+    One row per (cancer_code, symbol, role, agent?) — so genes with
+    multiple approved agents appear as multiple rows. Columns:
+    ``cancer_code, subtype, symbol, role (biomarker|target), agent,
+    agent_class, phase (approved|phase_3|phase_2|phase_1|preclinical),
+    indication, rationale, source``.
+
+    The curation bar is "genes a clinician would ask about because they
+    have clear prognostic value or gate access to an active therapy."
+    Some cancer types have no well-validated targets and are omitted
+    from the CSV rather than padded — an empty lookup is a valid
+    result.
+    """
+    from .load_dataset import get_data
+
+    return get_data("cancer-key-genes")
+
+
+def cancer_biomarker_genes(cancer_code):
+    """Ordered list of biomarker gene symbols for ``cancer_code``.
+
+    Empty list when the cancer type is not yet curated — callers should
+    treat that as "no clinician-relevant biomarker panel available" and
+    render an appropriate placeholder, not synthesize fallback genes.
+    """
+    df = cancer_key_genes_df()
+    sub = df[(df["cancer_code"] == cancer_code) & (df["role"] == "biomarker")]
+    return list(sub["symbol"].dropna().astype(str).unique())
+
+
+def cancer_therapy_targets(cancer_code):
+    """Subset of :func:`cancer_key_genes_df` for therapy-target rows of
+    ``cancer_code``. Returns a DataFrame so callers can render the
+    Phase / Indication / Agent columns without re-joining.
+    """
+    df = cancer_key_genes_df()
+    sub = df[(df["cancer_code"] == cancer_code) & (df["role"] == "target")]
+    return sub.copy().reset_index(drop=True)
+
+
+def cancer_key_genes_cancer_types():
+    """Return the set of cancer codes currently curated in the CSV.
+    Use to show a follow-up banner for non-covered cancer types.
+    """
+    df = cancer_key_genes_df()
+    return sorted(df["cancer_code"].dropna().astype(str).unique())

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -1,0 +1,282 @@
+# Licensed under the Apache License, Version 2.0
+
+"""Sample-provenance page — one synthesized 'what is this sample' doc (#106).
+
+The existing reports (summary, analysis, targets, brief, actionable)
+each surface different parts of the 5-stage attribution chain:
+
+    library prep -> preservation -> coarse TME -> fine subtypes -> tumor core
+
+Readers have to reassemble the chain mentally. The provenance page is
+the assembled view in one ~30-line document plus a simple stacked-bar
+figure, cross-linked from the other reports.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+
+
+def _compartment_label(comp: str) -> str:
+    return comp.replace("matched_normal_", "matched-normal ").replace("_", " ")
+
+
+def build_provenance_md(
+    analysis,
+    ranges_df,
+    decomp_results,
+    cancer_code: str,
+    sample_id: Optional[str] = None,
+) -> str:
+    """Render ``*-provenance.md`` — the 5-stage attribution chain.
+
+    Each stage states its input and what it deducts from the naive
+    "all signal is tumor" interpretation so the reader can follow the
+    chain from raw TPMs to a conservative tumor core.
+    """
+    sample_context = analysis.get("sample_context")
+    purity = analysis.get("purity") or {}
+    lines: List[str] = []
+    header_id = f": {sample_id}" if sample_id else ""
+    lines.append(f"# Sample provenance{header_id}\n")
+    lines.append(
+        "<!-- What is in this sample, stage by stage. Each step "
+        "explains what it deducts before the next one. -->"
+    )
+    lines.append("")
+
+    # Stage 1 — library prep
+    lines.append("## 1. Library prep\n")
+    if sample_context is not None:
+        prep = getattr(sample_context, "library_prep", "unknown")
+        confidence = float(getattr(sample_context, "library_prep_confidence", 0.0) or 0.0)
+        prep_label = prep.replace("_", " ")
+        lines.append(
+            f"Inferred: **{prep_label}** (confidence {confidence:.0%}). "
+        )
+        if prep == "exome_capture":
+            lines.append(
+                "Implication: mitochondrial, rRNA, and non-polyadenylated "
+                "transcripts are absent by design. Their near-zero fractions "
+                "are the expected pattern, not a sign of degradation."
+            )
+        elif prep == "poly_a":
+            lines.append(
+                "Implication: rRNA and non-polyadenylated transcripts are "
+                "absent by design; mitochondrial is depressed but present."
+            )
+        elif prep == "ribo_depleted":
+            lines.append(
+                "Implication: ribosomal RNAs are reduced but a small residual "
+                "remains. Mitochondrial transcripts are retained and can rise "
+                "with degradation."
+            )
+        elif prep == "total_rna":
+            lines.append(
+                "Implication: rRNA dominates the library unless normalized. "
+                "Treat raw TPM signals with caution until rRNA-corrected."
+            )
+        else:
+            lines.append(
+                "Implication: prep could not be inferred with high confidence; "
+                "the downstream expectation bands fall back to tolerant defaults."
+            )
+    else:
+        lines.append("*Library prep could not be inferred from this input.*")
+    lines.append("")
+
+    # Stage 2 — preservation / degradation
+    lines.append("## 2. Preservation\n")
+    if sample_context is not None:
+        pres = getattr(sample_context, "preservation", "unknown").replace("_", " ")
+        sev = getattr(sample_context, "degradation_severity", "none")
+        idx = getattr(sample_context, "degradation_index", None)
+        idx_str = f" (length-pair index {idx:.2f})" if idx is not None else ""
+        lines.append(f"Inferred: **{pres}**, degradation severity **{sev}**{idx_str}.")
+        if sev in ("moderate", "severe"):
+            lines.append(
+                "\nImplication: long-transcript quantification is biased "
+                "downward — the purity CI has been widened and long-gene "
+                "therapy targets are de-emphasized in the ranking."
+            )
+        elif pres == "ffpe":
+            lines.append(
+                "\nImplication: FFPE preservation is accounted for but no "
+                "heavy degradation was detected."
+            )
+    lines.append("")
+
+    # Stage 3 — coarse composition
+    lines.append("## 3. Coarse composition\n")
+    best = decomp_results[0] if decomp_results else None
+    if best is not None:
+        tumor_frac = float(getattr(best, "purity", 0.0) or 0.0)
+        fractions = dict(getattr(best, "fractions", {}) or {})
+        non_tumor = sorted(
+            ((c, f) for c, f in fractions.items() if c != "tumor" and f > 0),
+            key=lambda kv: -kv[1],
+        )
+        top = non_tumor[:5]
+        parts = [f"**tumor {tumor_frac:.0%}**"]
+        for comp, frac in top:
+            if frac >= 0.005:
+                parts.append(f"{_compartment_label(comp)} {frac:.0%}")
+        rest_frac = sum(f for _, f in non_tumor if f < 0.005)
+        if rest_frac > 0:
+            parts.append(f"other {rest_frac:.0%}")
+        lines.append("Fitted fractions: " + ", ".join(parts) + ".")
+        lines.append(
+            "\nEach non-tumor component is subtracted from the observed "
+            "TPM per gene (#108). A target whose signal is mostly assigned "
+            "to a non-tumor compartment is flagged TME-dominant in the "
+            "target tables."
+        )
+    else:
+        lines.append("*No decomposition result available for this sample.*")
+    lines.append("")
+
+    # Stage 4 — activated subtypes
+    lines.append("## 4. Subtype refinements\n")
+    if best is not None:
+        trace = getattr(best, "component_trace", None)
+        subtype_notes = []
+        if trace is not None and not trace.empty:
+            for _, row in trace.iterrows():
+                comp = str(row.get("component", ""))
+                frac = float(row.get("fraction") or 0.0)
+                if frac < 0.01:
+                    continue
+                if comp.startswith("matched_normal_"):
+                    subtype_notes.append(
+                        f"Matched-normal {comp.replace('matched_normal_', '')} "
+                        f"compartment present at {frac:.0%} — subtracted "
+                        "before target-expression ranking."
+                    )
+                elif any(k in comp.lower() for k in ("caf", "tam", "mdsc", "treg")):
+                    subtype_notes.append(
+                        f"Activated subtype **{comp}** contributing {frac:.0%}."
+                    )
+        if subtype_notes:
+            for n in subtype_notes:
+                lines.append(f"- {n}")
+        else:
+            lines.append(
+                "No activated-subtype refinements flagged above the 1% "
+                "threshold. Tumor-subtracted TPMs use the coarse compartment "
+                "fit only."
+            )
+    lines.append("")
+
+    # Stage 5 — tumor core
+    lines.append("## 5. Tumor-specific core\n")
+    if ranges_df is not None and len(ranges_df):
+        if "attribution" in ranges_df.columns:
+            has_attr = ranges_df["attribution"].apply(
+                lambda v: isinstance(v, dict) and len(v) > 0
+            )
+            core = ranges_df[has_attr & (ranges_df["attr_tumor_tpm"].astype(float) > 1.0)]
+            n_core = int(len(core))
+            lines.append(
+                f"After subtracting the fitted non-tumor compartments, "
+                f"**{n_core} genes** retain ≥1 TPM of tumor-attributed "
+                "expression."
+            )
+            # Top 5 tumor-core genes.
+            top = core.sort_values("attr_tumor_tpm", ascending=False).head(5)
+            if len(top):
+                names = ", ".join(
+                    f"{str(r['symbol'])} ({float(r['attr_tumor_tpm']):.0f})"
+                    for _, r in top.iterrows()
+                )
+                lines.append(f"\nTop tumor-core genes (symbol, tumor TPM): {names}.")
+    else:
+        lines.append("*No target-expression ranges available.*")
+    lines.append("")
+
+    # Chain summary + cross-links
+    overall = purity.get("overall_estimate")
+    if overall is not None:
+        lines.append(
+            f"**Chain summary:** observed expression → library-prep-aware "
+            f"artifact expectations → preservation-adjusted quantification → "
+            f"decomposition subtracts {1 - float(overall):.0%} as non-tumor "
+            "compartments → residual is the tumor-specific core used for "
+            "therapy-target ranking."
+        )
+    lines.append("")
+    lines.append(
+        "*See also: `*-brief.md`, `*-actionable.md`, `*-summary.md`, "
+        "`*-analysis.md`, `*-targets.md`.*"
+    )
+    return "\n".join(lines)
+
+
+def plot_provenance_funnel(
+    analysis,
+    ranges_df,
+    decomp_results,
+    save_to_filename: str,
+    save_dpi: int = 150,
+):
+    """Render ``*-provenance.png`` — horizontal stacked bar showing the
+    compartment fractions with tumor-core on the right and non-tumor
+    compartments to its left, one simple figure per sample.
+
+    Returns the filename on success, ``None`` when the inputs don't
+    support a meaningful plot (e.g. no decomposition).
+    """
+    import matplotlib.pyplot as plt
+
+    best = decomp_results[0] if decomp_results else None
+    if best is None:
+        return None
+    fractions = dict(getattr(best, "fractions", {}) or {})
+    if not fractions:
+        return None
+
+    tumor_frac = float(fractions.pop("tumor", 0.0))
+    non_tumor = sorted(
+        ((c, f) for c, f in fractions.items() if f > 0.005),
+        key=lambda kv: -kv[1],
+    )
+    rest_frac = sum(f for c, f in fractions.items() if f <= 0.005 and f > 0)
+
+    labels = ["tumor core"] + [_compartment_label(c) for c, _ in non_tumor]
+    values = [tumor_frac] + [f for _, f in non_tumor]
+    if rest_frac > 0:
+        labels.append("other")
+        values.append(rest_frac)
+    values = np.array(values, dtype=float)
+
+    colors = ["#e74c3c"] + [
+        plt.cm.tab20.colors[i % len(plt.cm.tab20.colors)]
+        for i in range(len(values) - 1)
+    ]
+
+    fig, ax = plt.subplots(figsize=(10, 2.6))
+    left = 0.0
+    for label, val, color in zip(labels, values, colors):
+        ax.barh([0], [val], left=[left], color=color, edgecolor="white", label=label)
+        if val > 0.03:
+            ax.text(
+                left + val / 2, 0, f"{label}\n{val:.0%}",
+                ha="center", va="center", fontsize=9, color="white", fontweight="bold",
+            )
+        left += val
+
+    ax.set_xlim(0, max(1.0, left))
+    ax.set_yticks([])
+    ax.set_xlabel("Fraction of sample composition", fontsize=10)
+    ax.set_title(
+        "Sample composition chain — tumor core vs non-tumor compartments",
+        fontsize=11, fontweight="bold",
+    )
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.2),
+              ncol=min(4, len(labels)), fontsize=8, frameon=False)
+
+    plt.tight_layout()
+    fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+    plt.close(fig)
+    return save_to_filename

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -1,0 +1,163 @@
+"""Tests for the two-tier brief / actionable handoff (#111)."""
+
+import pandas as pd
+
+from pirlygenes.brief import build_brief, build_actionable
+from pirlygenes.confidence import ConfidenceTier
+
+
+def _make_analysis(purity_point=0.28, ci_low=0.19, ci_high=0.40,
+                   purity_tier_label="moderate",
+                   degradation="mild", library_prep="exome_capture",
+                   preservation="ffpe"):
+    class _Ctx:
+        pass
+
+    ctx = _Ctx()
+    ctx.library_prep = library_prep
+    ctx.library_prep_confidence = 0.9
+    ctx.preservation = preservation
+    ctx.preservation_confidence = 0.85
+    ctx.degradation_severity = degradation
+    ctx.degradation_index = 0.6
+    ctx.missing_mt = False
+    ctx.signals = {}
+    ctx.flags = []
+
+    return {
+        "cancer_type": "PRAD",
+        "cancer_name": "Prostate adenocarcinoma",
+        "purity": {
+            "overall_estimate": purity_point,
+            "overall_lower": ci_low,
+            "overall_upper": ci_high,
+        },
+        "purity_confidence": ConfidenceTier(
+            tier=purity_tier_label,
+            reasons=(
+                ["moderate purity CI span (21 pp)", "low-purity regime (28%)"]
+                if purity_tier_label in {"moderate", "low"} else []
+            ),
+        ),
+        "sample_context": ctx,
+        "therapy_response_scores": {},
+    }
+
+
+def _make_ranges_df():
+    return pd.DataFrame([
+        {
+            "symbol": "FOLH1", "observed_tpm": 142.0,
+            "attribution": {"endothelial": 12.0},
+            "attr_tumor_tpm": 128.0, "attr_tumor_fraction": 0.90,
+            "attr_top_compartment": "endothelial", "attr_top_compartment_tpm": 12.0,
+            "tme_dominant": False, "tme_explainable": False,
+        },
+        {
+            "symbol": "STEAP1", "observed_tpm": 78.0,
+            "attribution": {"fibroblast": 10.0, "endothelial": 6.0},
+            "attr_tumor_tpm": 62.0, "attr_tumor_fraction": 0.79,
+            "attr_top_compartment": "fibroblast", "attr_top_compartment_tpm": 10.0,
+            "tme_dominant": False, "tme_explainable": False,
+        },
+        {
+            "symbol": "DLL3", "observed_tpm": 0.5,
+            "attribution": {}, "attr_tumor_tpm": 0.0, "attr_tumor_fraction": 0.0,
+            "attr_top_compartment": "", "attr_top_compartment_tpm": 0.0,
+            "tme_dominant": False, "tme_explainable": False,
+        },
+        {
+            "symbol": "AR", "observed_tpm": 50.0,
+            "attribution": {"endothelial": 2.0},
+            "attr_tumor_tpm": 48.0, "attr_tumor_fraction": 0.96,
+            "attr_top_compartment": "endothelial", "attr_top_compartment_tpm": 2.0,
+            "tme_dominant": False, "tme_explainable": False,
+        },
+    ])
+
+
+def test_brief_is_compact():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="Castrate-resistant pattern.",
+        sample_id="sample_X",
+    )
+    lines = md.splitlines()
+    # ≤ 40 lines is the contract.
+    assert len(lines) <= 40, f"brief is {len(lines)} lines, must be ≤ 40:\n{md}"
+
+    # Key structural elements present.
+    assert "# Brief" in md
+    assert "**Cancer call:**" in md
+    assert "**Purity:**" in md
+    assert "**Disease state:**" in md
+    assert "Top candidate therapies" in md
+
+
+def test_brief_excludes_absent_targets():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="",
+    )
+    # DLL3 is absent (0.5 TPM) — must not appear in the top bullets.
+    assert "DLL3" not in md, "brief should skip absent targets from the top list"
+
+
+def test_brief_reports_tumor_attributed_for_present_targets():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="",
+    )
+    # FOLH1 has tumor-attr 128; the bullet should mention it.
+    assert "FOLH1" in md
+    assert "128" in md or "**FOLH1**" in md
+
+
+def test_brief_no_internal_jargon():
+    analysis = _make_analysis(purity_tier_label="low")
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="",
+    )
+    # Forbidden jargon — internal variable names and pipeline terms.
+    for token in [
+        "NNLS", "Spearman", "x1.10", "×1.10",
+        "tme_fold_med", "_combine_purity_estimates",
+        "overexplained_tpm", "sig_stability",
+    ]:
+        assert token not in md, f"jargon leak: {token}"
+
+
+def test_brief_handles_uncurated_cancer_type():
+    analysis = _make_analysis()
+    analysis["cancer_type"] = "KIRC"  # not in the curated CSV yet
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis, ranges_df, cancer_code="KIRC",
+        disease_state="",
+    )
+    assert "not yet in the curated key-genes panel" in md
+
+
+def test_actionable_is_longer_but_structured():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    md = build_actionable(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="Castrate-resistant.",
+        sample_id="sample_X",
+    )
+    # Actionable should be > 15 lines (more detail than the brief).
+    assert len(md.splitlines()) > 15
+
+    # Key section headings.
+    for heading in ["Sample and confidence", "Cancer call and disease state",
+                    "Therapy landscape", "Biomarker panel"]:
+        assert heading in md, f"missing heading: {heading}"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,92 @@
+"""Smoke tests for the provenance page (#106)."""
+
+import pandas as pd
+
+from pirlygenes.provenance import build_provenance_md, plot_provenance_funnel
+
+
+class _Ctx:
+    def __init__(self, prep="exome_capture", preservation="ffpe",
+                 severity="mild", index=0.55, confidence=0.9):
+        self.library_prep = prep
+        self.library_prep_confidence = confidence
+        self.preservation = preservation
+        self.preservation_confidence = 0.85
+        self.degradation_severity = severity
+        self.degradation_index = index
+        self.missing_mt = False
+        self.signals = {}
+        self.flags = []
+
+
+class _Decomp:
+    def __init__(self, purity=0.28):
+        self.purity = purity
+        self.fractions = {
+            "tumor": purity,
+            "T_cell": 0.03,
+            "endothelial": 0.03,
+            "fibroblast": 0.25,
+            "myeloid": 0.15,
+            "matched_normal_prostate": 0.26,
+        }
+        self.component_trace = pd.DataFrame([
+            {"component": "T_cell", "fraction": 0.03},
+            {"component": "matched_normal_prostate", "fraction": 0.26},
+        ])
+
+
+def _ranges_df():
+    return pd.DataFrame([
+        {"symbol": "FOLH1", "observed_tpm": 142.0,
+         "attribution": {"endothelial": 12.0},
+         "attr_tumor_tpm": 128.0, "attr_tumor_fraction": 0.90},
+        {"symbol": "STEAP1", "observed_tpm": 78.0,
+         "attribution": {"fibroblast": 10.0},
+         "attr_tumor_tpm": 62.0, "attr_tumor_fraction": 0.79},
+    ])
+
+
+def test_provenance_md_walks_the_five_stages():
+    analysis = {
+        "sample_context": _Ctx(),
+        "purity": {"overall_estimate": 0.28, "overall_lower": 0.19, "overall_upper": 0.40},
+    }
+    md = build_provenance_md(
+        analysis, _ranges_df(), [_Decomp()],
+        cancer_code="PRAD", sample_id="sample_X",
+    )
+    # Each numbered stage must appear.
+    for heading in ["1. Library prep", "2. Preservation",
+                    "3. Coarse composition", "4. Subtype refinements",
+                    "5. Tumor-specific core"]:
+        assert heading in md, f"missing stage heading: {heading}"
+    assert "exome capture" in md
+    assert "FOLH1" in md or "tumor-core" in md.lower()
+
+
+def test_provenance_handles_missing_decomposition():
+    analysis = {
+        "sample_context": _Ctx(),
+        "purity": {"overall_estimate": 0.28, "overall_lower": 0.19, "overall_upper": 0.40},
+    }
+    md = build_provenance_md(
+        analysis, _ranges_df(), decomp_results=[],
+        cancer_code="PRAD",
+    )
+    # Still renders — just with a no-decomposition note.
+    assert "No decomposition result" in md
+
+
+def test_provenance_funnel_renders_png(tmp_path):
+    analysis = {
+        "sample_context": _Ctx(),
+        "purity": {"overall_estimate": 0.28, "overall_lower": 0.19, "overall_upper": 0.40},
+    }
+    out = tmp_path / "prov.png"
+    result = plot_provenance_funnel(
+        analysis, _ranges_df(), [_Decomp()],
+        save_to_filename=str(out),
+    )
+    assert result == str(out)
+    assert out.exists() and out.stat().st_size > 1000


### PR DESCRIPTION
## Summary

Batch 4 lands the actionable-handoff half of the v4.8 sweep.

### #110 — cancer-type therapy landscape + biomarker panel

- New \`data/cancer-key-genes.csv\` — 149 curated rows across 8 cancer types (PRAD, BRCA, LUAD, COAD, SKCM, HNSC, DLBC, LAML). Schema: \`cancer_code, subtype, symbol, role (biomarker|target), agent, agent_class, phase, indication, rationale, source\`. Curation bar: "genes a clinician would ask about because they have clear prognostic value or gate access to a proven therapy".
- New loaders in \`gene_sets_cancer.py\`: \`cancer_key_genes_df\`, \`cancer_biomarker_genes\`, \`cancer_therapy_targets\`, \`cancer_key_genes_cancer_types\`.
- Two new sections in \`targets.md\` scoped to the resolved cancer type: **Biomarker Panel** (lineage + diagnostic markers, no drug column) and **Therapy Target Landscape** (agents with an approved / trialed indication, cross-referenced to the sample, approved-first ordering).
- Uncovered cancer types render "not yet curated" notes instead of a raw-expression fallback. Follow-up tracked in #117.

### #111 — two-tier markdown handoff

- New \`pirlygenes/brief.py\`:
  - \`build_brief\` → \`*-brief.md\` — one-page handoff (≤ 40 lines), strict structure: cancer call, purity + confidence tier, disease state, sample context, top-3 therapies, caveats. Absent / <30%-tumor-fraction targets are skipped from the top bullets.
  - \`build_actionable\` → \`*-actionable.md\` — longer treatment-review doc with Sample and confidence / Cancer call / Therapy landscape / Biomarker panel / Caveats.
- Consumes #108 per-target attribution, #109 purity_confidence tier, and #110 curated panels.
- No JSON mirror (per the \`feedback_markdown_not_json\` memory — audience is clinicians + LLMs, both read markdown fine).

### #106 — sample-provenance page + figure

- New \`pirlygenes/provenance.py\`:
  - \`build_provenance_md\` → \`*-provenance.md\` walking the 5-stage attribution chain (library prep → preservation → coarse composition → subtype refinements → tumor core) in numbered sections.
  - \`plot_provenance_funnel\` → \`*-provenance.png\` horizontal stacked bar with tumor-core + non-tumor compartments.

## Tests

- \`./test.sh\` — **364 passed, 1 skipped**. 15 new tests (6 brief, 3 provenance, plus earlier 9 confidence).
- \`./lint.sh\` clean.

## Not in this PR

- Remaining-cancer-type curation (#117 tracking issue opened for Tranches A / B / C).
- Trufflepig migration repo (next).

## Cross-references

- Memory note: \`feedback_clinician_relevant_curation\` documents the bar.
- Memory note: \`feedback_markdown_not_json\` documents the "no JSON" decision.