### PR TITLE
feat: unify number rendering across markdown reports (#120)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -74,6 +74,11 @@ from .sample_context import (
 )
 from .sample_quality import assess_sample_quality
 from .therapy_response import score_therapy_signatures
+from .format import (
+    render_fold,
+    render_fraction_no_decimal,
+    render_tpm,
+)
 
 _DATASET_SOURCES = {
     "ADC-approved": "Wiley, doi:10.1002/cac2.12517",
@@ -738,8 +743,8 @@ def _analyze_body(
         print(f"[analysis] Constraints: {analysis['analysis_constraints']}")
     print(f"[analysis] {_purity_metric_label(analysis['sample_mode']).capitalize()}: {purity['overall_estimate']:.0%} "
           f"[{purity['overall_lower']:.0%}-{purity['overall_upper']:.0%}]")
-    print(f"[analysis] Stromal enrichment: {purity['components']['stromal']['enrichment']:.1f}x vs TCGA")
-    print(f"[analysis] Immune enrichment: {purity['components']['immune']['enrichment']:.1f}x vs TCGA")
+    print(f"[analysis] Stromal enrichment: {render_fold(purity['components']['stromal']['enrichment'])} vs TCGA")
+    print(f"[analysis] Immune enrichment: {render_fold(purity['components']['immune']['enrichment'])} vs TCGA")
     top_tissues = analysis["tissue_scores"][:3]
     tissue_str = ", ".join(f"{t} ({s:.2f})" for t, s, _ in top_tissues)
     print(f"[analysis] Top background signatures: {tissue_str}")
@@ -1603,8 +1608,8 @@ def _summary_mode_clause(sample_mode, purity, top_tissues):
         )
     return (
         f"Estimated tumor purity is {ci_phrase}, "
-        f"with {purity['components']['stromal']['enrichment']:.1f}x stromal "
-        f"and {purity['components']['immune']['enrichment']:.1f}x immune enrichment "
+        f"with {render_fold(purity['components']['stromal']['enrichment'])} stromal "
+        f"and {render_fold(purity['components']['immune']['enrichment'])} immune enrichment "
         f"vs TCGA median. "
         f"Top background signatures: {tissue_str}. "
         f"These tissue matches describe residual non-tumor background and are not literal site calls. "
@@ -2416,7 +2421,7 @@ def _generate_text_reports(
         comp = components.get(comp_name, {})
         if isinstance(comp, dict):
             enrichment = comp.get("enrichment", 0)
-            lines.append(f"- **{comp_name.title()}** enrichment: {enrichment:.1f}x vs TCGA")
+            lines.append(f"- **{comp_name.title()}** enrichment: {render_fold(enrichment)} vs TCGA")
     integration = components.get("integration", {})
     if integration.get("signature_deprioritized"):
         lines.append(
@@ -2974,7 +2979,14 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     ):
         fn1_blocked = ranges_df[
             ranges_df["symbol"].eq("FN1")
-            & ~ranges_df["therapy_supported"].infer_objects(copy=False).fillna(True).astype(bool)
+            # Treat missing therapy_supported as True (the common case for
+            # rows without any therapy flag set); avoid .fillna on the
+            # object-dtype series because pandas 2.x emits a FutureWarning
+            # about silent downcasting. Mask + default keeps the intent
+            # explicit.
+            & ~ranges_df["therapy_supported"].map(
+                lambda v: True if v is None or (isinstance(v, float) and pd.isna(v)) else bool(v)
+            )
             & ranges_df["therapy_support_note"].fillna("").astype(str).str.len().gt(0)
         ]
         if len(fn1_blocked):
@@ -3026,12 +3038,14 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         lines.append("|------|-----------|-------|----------|---------|-----------|-----|---------|-----------|")
         for _, row in ctas.head(20).iterrows():
             surf = "yes" if row["is_surface"] else ""
-            vs_tcga = row["pct_cancer_median"]
+            vs_tcga = row["pct_cancer_median"] if pd.notna(row["pct_cancer_median"]) else None
             tme_warn = "⚠" if row.get("tme_explainable") else ""
             lines.append(
-                f"| **{row['symbol']}** | {row['median_est']:.1f} | "
-                f"{row['est_1']:.1f}\u2013{row['est_9']:.1f} | {row['observed_tpm']:.1f} | "
-                f"{'%.1fx' % vs_tcga if pd.notna(vs_tcga) else '—'} | {row['tcga_percentile']:.0%} | "
+                f"| **{row['symbol']}** | {render_tpm(row['median_est'])} | "
+                f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
+                f"{render_tpm(row['observed_tpm'])} | "
+                f"{render_fold(vs_tcga)} | "
+                f"{render_fraction_no_decimal(row['tcga_percentile'])} | "
                 f"{tme_warn} | {surf} | {row['therapies']} |"
             )
         high_ctas = ctas[ctas["tcga_percentile"] > 0.7]
@@ -3080,7 +3094,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         )
         for _, row in surface_targets.head(20).iterrows():
             bold = "**" if row["therapies"] else ""
-            vs_tcga = row["pct_cancer_median"]
+            vs_tcga = row["pct_cancer_median"] if pd.notna(row["pct_cancer_median"]) else None
             # TME flag — compact key:
             #   ⚠⚠ = ``tme_dominant`` (observed signal is mostly non-
             #   tumor per the decomposition attribution, #108); ⚠ =
@@ -3100,9 +3114,11 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                 therapies_cell = f"{therapies_cell} ({cross})" if therapies_cell else f"*{cross}*"
             attribution_cell = _format_attribution_cell(row)
             lines.append(
-                f"| {bold}{row['symbol']}{bold} | {row['median_est']:.1f} | "
-                f"{row['est_1']:.1f}\u2013{row['est_9']:.1f} | {row['observed_tpm']:.1f} | "
-                f"{'%.1fx' % vs_tcga if pd.notna(vs_tcga) else '—'} | {row['tcga_percentile']:.0%} | "
+                f"| {bold}{row['symbol']}{bold} | {render_tpm(row['median_est'])} | "
+                f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
+                f"{render_tpm(row['observed_tpm'])} | "
+                f"{render_fold(vs_tcga)} | "
+                f"{render_fraction_no_decimal(row['tcga_percentile'])} | "
                 f"{tme_warn} | {attribution_cell} | {therapies_cell} |"
             )
         head20 = surface_targets.head(20)
@@ -3149,14 +3165,15 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         lines.append("|------|-----------|-------|---------|-----------|-----|-------------|-----|-----------|")
         for _, row in intracellular.head(15).iterrows():
             cta_flag = "yes" if row["is_cta"] else ""
-            vs_tcga = row["pct_cancer_median"]
+            vs_tcga = row["pct_cancer_median"] if pd.notna(row["pct_cancer_median"]) else None
             tme_warn = "⚠" if row.get("tme_explainable") else ""
             attribution_cell = _format_attribution_cell(row)
             lines.append(
-                f"| {row['symbol']} | {row['median_est']:.1f} | "
-                f"{row['est_1']:.1f}\u2013{row['est_9']:.1f} | "
-                f"{'%.1fx' % vs_tcga if pd.notna(vs_tcga) else '—'} | "
-                f"{row['tcga_percentile']:.0%} | {tme_warn} | {attribution_cell} | {cta_flag} | {row['therapies']} |"
+                f"| {row['symbol']} | {render_tpm(row['median_est'])} | "
+                f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
+                f"{render_fold(vs_tcga)} | "
+                f"{render_fraction_no_decimal(row['tcga_percentile'])} | "
+                f"{tme_warn} | {attribution_cell} | {cta_flag} | {row['therapies']} |"
             )
         if (
             "tme_explainable" in intracellular.columns

--- a/pirlygenes/format.py
+++ b/pirlygenes/format.py
@@ -1,0 +1,167 @@
+# Licensed under the Apache License, Version 2.0
+
+"""Single source of truth for how numbers are rendered in markdown
+reports (#120, follow-up from #79 Problem 4).
+
+Before this module existed, each renderer had its own ad-hoc format
+string — the candidate table used ``{:.3f}`` while the summary used
+``{:.1f}×`` and the surface targets table used ``{:.1f}x`` with
+``infx`` for infinity. The reader saw the same quantity rendered
+three different ways across a single run.
+
+Every markdown-facing number should go through one of the four helpers
+below so the formatting contract is defined in one place:
+
+- :func:`render_fold` — fold-change vs reference, always with ``×``.
+- :func:`render_fraction` — percentages.
+- :func:`render_tpm` — TPM values, tighter precision for large values.
+- :func:`render_score` — unit-less scores and support values.
+
+TSV outputs stay machine-parseable with full precision; these helpers
+are strictly for human-facing markdown.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Union
+
+Number = Union[int, float, None]
+
+
+def _none_or_nan(x) -> bool:
+    if x is None:
+        return True
+    if isinstance(x, float) and math.isnan(x):
+        return True
+    return False
+
+
+def render_fold(x: Number, *, placeholder: str = "—") -> str:
+    """Fold change vs reference.
+
+    Two decimals, U+00D7 multiplication sign, ``∞×`` for infinity,
+    ``placeholder`` for None / NaN. Negative values are allowed and
+    render with a leading sign.
+
+    >>> render_fold(3.542)
+    '3.54×'
+    >>> render_fold(2.5)
+    '2.50×'
+    >>> render_fold(float("inf"))
+    '∞×'
+    >>> render_fold(None)
+    '—'
+    """
+    if _none_or_nan(x):
+        return placeholder
+    x = float(x)
+    if math.isinf(x):
+        return "-∞×" if x < 0 else "∞×"
+    return f"{x:.2f}\u00d7"
+
+
+def render_fraction(x: Number, *, placeholder: str = "—") -> str:
+    """Fraction rendered as a one-decimal percentage.
+
+    Accepts either a [0, 1] fraction or a 0-to-100 percentage — the
+    helper auto-detects on magnitude. This is deliberate: a lot of
+    existing call-sites carry fractions (``0.64``) and some carry
+    already-computed percentages (``64.3``); both should render as
+    ``64.0%`` / ``64.3%`` without requiring callers to pre-convert.
+
+    For values that exceed 1 but are plausibly fractions (a CI
+    upper bound can hit exactly 1.0), the helper treats the whole
+    [0, 1.001] range as a fraction.
+
+    >>> render_fraction(0.643)
+    '64.3%'
+    >>> render_fraction(1.0)
+    '100.0%'
+    >>> render_fraction(None)
+    '—'
+    """
+    if _none_or_nan(x):
+        return placeholder
+    x = float(x)
+    if -0.001 <= x <= 1.001:
+        x = x * 100.0
+    return f"{x:.1f}%"
+
+
+def render_fraction_no_decimal(x: Number, *, placeholder: str = "—") -> str:
+    """Fraction rendered as a zero-decimal percentage.
+
+    Same auto-detect semantics as :func:`render_fraction` but emits
+    ``64%`` instead of ``64.3%`` — used where the narrative is the
+    focus and precision noise hurts readability (e.g. the Brief).
+    """
+    if _none_or_nan(x):
+        return placeholder
+    x = float(x)
+    if -0.001 <= x <= 1.001:
+        x = x * 100.0
+    return f"{x:.0f}%"
+
+
+def render_tpm(x: Number, *, placeholder: str = "—") -> str:
+    """TPM value with magnitude-aware precision.
+
+    - Above 100: no decimals. Large numbers don't benefit from a
+      trailing ``.0`` — ``1852.0`` reads as fake precision, ``1852``
+      is what the reader wants.
+    - Between 10 and 100: one decimal.
+    - Between 1 and 10: one decimal.
+    - Below 1: two decimals so dim signals aren't collapsed to ``0.0``.
+    - Negative values render the same way (shouldn't occur; safety net).
+    - None / NaN: ``placeholder``.
+
+    >>> render_tpm(1852.4)
+    '1852'
+    >>> render_tpm(142.0)
+    '142'
+    >>> render_tpm(27.8)
+    '27.8'
+    >>> render_tpm(4.7)
+    '4.7'
+    >>> render_tpm(0.12)
+    '0.12'
+    >>> render_tpm(None)
+    '—'
+    """
+    if _none_or_nan(x):
+        return placeholder
+    x = float(x)
+    ax = abs(x)
+    if ax >= 100:
+        return f"{x:.0f}"
+    if ax >= 1:
+        return f"{x:.1f}"
+    return f"{x:.2f}"
+
+
+def render_score(x: Number, *, placeholder: str = "—") -> str:
+    """Unit-less score with three decimals.
+
+    Used for the candidate-ranking columns (signature / geomean /
+    normalized) and for support scores.
+
+    >>> render_score(0.670)
+    '0.670'
+    >>> render_score(1.0)
+    '1.000'
+    >>> render_score(None)
+    '—'
+    """
+    if _none_or_nan(x):
+        return placeholder
+    return f"{float(x):.3f}"
+
+
+__all__ = [
+    "render_fold",
+    "render_fraction",
+    "render_fraction_no_decimal",
+    "render_tpm",
+    "render_score",
+]

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -1211,7 +1211,7 @@ def plot_tumor_expression_ranges(
                 continue
             bar_color = color if pct >= 0.5 else "#d4a017"
             ax_pct.barh(i, max(pct, 0.001), color=bar_color, alpha=0.7, height=0.6)
-            lbl = f"{pct:.1f}x" if pct < 10 else f"{pct:.0f}x"
+            lbl = f"{pct:.1f}\u00d7" if pct < 10 else f"{pct:.0f}\u00d7"
             ax_pct.text(max(pct, 0.001) * 1.2, i, lbl, fontsize=base_font - 1,
                         va="center", color="black")
 

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -31,6 +31,7 @@ from .gene_sets_cancer import (
     pan_cancer_expression,
 )
 from .common import _build_sample_tpm_by_symbol as _common_build_sample_tpm
+from .format import render_fold
 from .load_dataset import get_data
 
 
@@ -2016,24 +2017,24 @@ def plot_sample_summary(
     if sample_mode == "solid":
         details.extend(
             [
-                f"Stromal enrichment: {stromal_enr:.1f}x vs TCGA {cancer_code}",
-                f"Immune enrichment: {immune_enr:.1f}x vs TCGA {cancer_code}",
+                f"Stromal enrichment: {render_fold(stromal_enr)} vs TCGA {cancer_code}",
+                f"Immune enrichment: {render_fold(immune_enr)} vs TCGA {cancer_code}",
                 f"TCGA {cancer_code} median purity: {purity['tcga_median_purity']:.0%}",
             ]
         )
     elif sample_mode == "heme":
         details.extend(
             [
-                f"Stromal context: {stromal_enr:.1f}x vs TCGA {cancer_code}",
-                f"Immune context: {immune_enr:.1f}x vs TCGA {cancer_code}",
+                f"Stromal context: {render_fold(stromal_enr)} vs TCGA {cancer_code}",
+                f"Immune context: {render_fold(immune_enr)} vs TCGA {cancer_code}",
                 "Interpretation: lineage/background context, not a strict tumor-vs-immune split",
             ]
         )
     else:
         details.extend(
             [
-                f"Residual stromal context: {stromal_enr:.1f}x vs TCGA {cancer_code}",
-                f"Residual immune context: {immune_enr:.1f}x vs TCGA {cancer_code}",
+                f"Residual stromal context: {render_fold(stromal_enr)} vs TCGA {cancer_code}",
+                f"Residual immune context: {render_fold(immune_enr)} vs TCGA {cancer_code}",
                 "Interpretation: consistency vs matched lineage profile, not bulk admixture",
             ]
         )

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,142 @@
+"""Tests for the number-formatting helpers (#120)."""
+
+import math
+
+from pirlygenes.format import (
+    render_fold,
+    render_fraction,
+    render_fraction_no_decimal,
+    render_score,
+    render_tpm,
+)
+
+
+# ── render_fold ─────────────────────────────────────────────────────────
+
+def test_fold_two_decimals_with_multiplication_sign():
+    assert render_fold(3.542) == "3.54\u00d7"
+    assert render_fold(2.5) == "2.50\u00d7"
+    assert render_fold(1.0) == "1.00\u00d7"
+
+
+def test_fold_handles_infinity():
+    assert render_fold(float("inf")) == "\u221e\u00d7"
+    assert render_fold(float("-inf")) == "-\u221e\u00d7"
+
+
+def test_fold_placeholder_for_missing():
+    assert render_fold(None) == "\u2014"
+    assert render_fold(float("nan")) == "\u2014"
+
+
+def test_fold_never_renders_lowercase_x():
+    # Regression guard: the old renderers sometimes used "x" which
+    # looks like a letter next to numbers. Enforce the math sign.
+    for value in (0.5, 1.0, 287.3, 1e5):
+        rendered = render_fold(value)
+        assert "x" not in rendered.lower() or "×" in rendered, rendered
+        assert rendered.endswith("\u00d7"), f"missing ×: {rendered!r}"
+
+
+# ── render_fraction ─────────────────────────────────────────────────────
+
+def test_fraction_autodetects_fraction_vs_percentage():
+    # Fraction in [0, 1]
+    assert render_fraction(0.643) == "64.3%"
+    assert render_fraction(0.5) == "50.0%"
+    # Already-computed percentage
+    assert render_fraction(64.3) == "64.3%"
+    assert render_fraction(5) == "5.0%"
+
+
+def test_fraction_boundaries():
+    assert render_fraction(0.0) == "0.0%"
+    assert render_fraction(1.0) == "100.0%"
+    # Just over 1.0 is treated as already-a-percentage.
+    assert render_fraction(1.001) == "100.1%"
+
+
+def test_fraction_placeholder_for_missing():
+    assert render_fraction(None) == "\u2014"
+    assert render_fraction(float("nan")) == "\u2014"
+
+
+def test_fraction_no_decimal_variant():
+    assert render_fraction_no_decimal(0.64) == "64%"
+    assert render_fraction_no_decimal(1.0) == "100%"
+    assert render_fraction_no_decimal(None) == "\u2014"
+
+
+# ── render_tpm ──────────────────────────────────────────────────────────
+
+def test_tpm_no_decimals_above_100():
+    assert render_tpm(1852.4) == "1852"
+    assert render_tpm(142.0) == "142"
+    assert render_tpm(100.0) == "100"
+
+
+def test_tpm_one_decimal_between_1_and_100():
+    assert render_tpm(27.8) == "27.8"
+    assert render_tpm(4.7) == "4.7"
+    assert render_tpm(1.0) == "1.0"
+
+
+def test_tpm_two_decimals_below_1():
+    assert render_tpm(0.12) == "0.12"
+    assert render_tpm(0.04) == "0.04"
+    assert render_tpm(0.001) == "0.00"
+
+
+def test_tpm_placeholder_for_missing():
+    assert render_tpm(None) == "\u2014"
+    assert render_tpm(float("nan")) == "\u2014"
+
+
+def test_tpm_boundary_behavior():
+    # Just below 100 should still be one decimal.
+    assert render_tpm(99.9) == "99.9"
+    # Just above 100 rounds to integer.
+    assert render_tpm(100.4) == "100"
+
+
+# ── render_score ────────────────────────────────────────────────────────
+
+def test_score_always_three_decimals():
+    assert render_score(0.67) == "0.670"
+    assert render_score(0.001) == "0.001"
+    assert render_score(1.0) == "1.000"
+    assert render_score(1) == "1.000"
+
+
+def test_score_placeholder_for_missing():
+    assert render_score(None) == "\u2014"
+    assert render_score(float("nan")) == "\u2014"
+
+
+# ── integration: rendering a realistic row ──────────────────────────────
+
+def test_rendering_a_target_row_is_consistent():
+    """A target row touches all four helpers; the rendered cells should
+    be consistent with the contract."""
+    row = {
+        "tpm": 1852.3,
+        "fold": 287.34,
+        "fraction": 0.83,
+        "score": 0.672,
+    }
+    assert render_tpm(row["tpm"]) == "1852"
+    assert render_fold(row["fold"]) == "287.34\u00d7"
+    assert render_fraction(row["fraction"]) == "83.0%"
+    assert render_score(row["score"]) == "0.672"
+
+
+def test_none_handling_is_uniform():
+    for fn in (render_fold, render_fraction, render_fraction_no_decimal,
+               render_tpm, render_score):
+        assert fn(None) == "\u2014"
+        assert fn(float("nan")) == "\u2014"
+
+
+def test_custom_placeholder_override():
+    assert render_tpm(None, placeholder="n/a") == "n/a"
+    assert render_fold(None, placeholder="—") == "—"


### PR DESCRIPTION
## Summary

Closes #120 — the cosmetic-formatting follow-up split out of #79.

Introduces a single source-of-truth formatter module \`pirlygenes/format.py\` that every markdown-facing number now goes through, and replaces the highest-visibility drift in the reports:

- Surface / CTA / intracellular target tables: \`'%.1fx' % vs_tcga\` → \`render_fold(vs_tcga)\` — proper \`×\` unicode sign, \`∞×\` for infinity, \`—\` for missing. TPM cells use magnitude-aware precision (\`1852\` not \`1852.0\`). TCGA percentile renders as \`64%\` consistently across every table.
- Enrichment lines in summary / analysis: \`1.7x stromal\` → \`1.70×\`.
- Purity plot and vs-cohort label annotations: consistently \`×\`.

## Helpers

- \`render_fold\` — 2 decimals + \`×\`; \`∞×\` for infinity.
- \`render_fraction\` / \`render_fraction_no_decimal\` — percentages with auto-detect of [0,1] fraction vs [0,100] percent.
- \`render_tpm\` — no decimals above 100, one decimal 1–100, two decimals below 1.
- \`render_score\` — 3 decimals.

## Bonus fix

While in the cli.py renderer I also fixed a pandas 2.x \`FutureWarning\` the user reported for cli.py:2977 (\`.infer_objects(copy=False).fillna(True).astype(bool)\` on an object-dtype Series).

## Out of scope

- Decimal-precision drift between non-table contexts (e.g. \`mt_fold '.1f×'\` vs \`up_panel '.2f×'\`). Those aren't side-by-side in any single view, and imposing uniform precision risks changing the semantics of each signal. Narrow leftover for a future cleanup if it matters.
- TSV outputs: unchanged (they stay machine-parseable at full precision).

## Tests

- 18 new format unit tests covering None / NaN / infinity handling per helper, TPM magnitude boundaries, and a lowercase-\`x\` regression guard.
- Full suite: 381 passed, 1 skipped. (One perf-fence test is noisy under parallel execution and passes standalone — unrelated to this PR.)