### PR TITLE
feat: purity-method comparison plot on a single axis (#124)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -22,6 +22,7 @@ from .tumor_purity import (
     get_tumor_purity_parameters,
     plot_sample_summary,
     plot_tumor_purity,
+    plot_purity_method_comparison,
     plot_cancer_type_hypotheses,
     plot_background_tissues,
     plot_mhc_expression,
@@ -1070,6 +1071,28 @@ def _analyze_body(
         # adopted) so the figure agrees with the rest of the report
         # instead of silently recomputing a signature-only estimate.
         purity_result=analysis["purity"],
+    )
+    _plt.close("all")
+
+    # #124: side-by-side comparison of every purity estimation method
+    # on a single purity axis. The existing plot_tumor_purity panel
+    # mixes enrichment scales with purity % on the same row, which
+    # hides how much the methods agree / disagree. This dedicated
+    # figure renders signature / lineage / ESTIMATE stromal / ESTIMATE
+    # immune / ESTIMATE combined / decomposition / adopted overall on
+    # one purity axis with CI bars, plus TCGA cohort median reference.
+    print("[plot] Generating purity-method comparison plot...")
+    methods_png = (
+        "%s-purity-methods.png" % prefix if prefix else "purity-methods.png"
+    )
+    best_for_methods = (
+        decomp_results[0] if decomp_results else None
+    )
+    plot_purity_method_comparison(
+        analysis["purity"],
+        save_to_filename=methods_png,
+        save_dpi=output_dpi,
+        decomposition_result=best_for_methods,
     )
     _plt.close("all")
 

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -1331,6 +1331,244 @@ def plot_tumor_purity(
     return fig, result
 
 
+def plot_purity_method_comparison(
+    purity_result,
+    save_to_filename=None,
+    save_dpi=300,
+    figsize=(10, 5.5),
+    decomposition_result=None,
+    title=None,
+):
+    """Compare every purity estimation method on one axis (#124).
+
+    The existing :func:`plot_tumor_purity` mixes purity percentages and
+    enrichment values on the same component panel, which makes the
+    methods hard to compare at a glance. This dedicated figure renders
+    every method on a single ``purity %`` axis with CIs as horizontal
+    bars where they exist, plus reference lines for the TCGA cohort
+    median and the adopted overall estimate.
+
+    Parameters
+    ----------
+    purity_result : dict
+        Return value of :func:`estimate_tumor_purity` or the promoted
+        ``analysis["purity"]``.
+    decomposition_result : DecompositionResult, optional
+        If provided, the decomposition's fitted tumor fraction is
+        added as its own row — useful when the decomposition adopted
+        its lineage-panel call back into ``analysis["purity"]`` and
+        the reader wants to see that signal plotted alongside the
+        signature / lineage / ESTIMATE estimates.
+
+    Returns the matplotlib figure; saves to ``save_to_filename`` when
+    provided.
+    """
+    import matplotlib.pyplot as plt
+
+    comp = purity_result.get("components", {}) or {}
+    cancer_code = purity_result.get("cancer_type") or ""
+    tcga_median = purity_result.get("tcga_median_purity")
+    integration_source = (comp.get("integration") or {}).get("source") or ""
+    signature_deprioritized = (comp.get("integration") or {}).get("signature_deprioritized", False)
+
+    # Re-derive stromal_purity / immune_purity from their enrichment
+    # values using the same odds-model conversion estimate_tumor_purity
+    # uses internally. Otherwise these two methods land on a different
+    # axis than the others.
+    stromal_purity = None
+    immune_purity = None
+    if tcga_median and tcga_median > 0:
+        odds_nontumor = (1.0 - tcga_median) / max(tcga_median, 1e-6)
+        stromal_enr = (comp.get("stromal") or {}).get("enrichment")
+        immune_enr = (comp.get("immune") or {}).get("enrichment")
+        if stromal_enr is not None:
+            stromal_purity = 1.0 / (1.0 + odds_nontumor * max(float(stromal_enr), 0.0))
+        if immune_enr is not None:
+            immune_purity = 1.0 / (1.0 + odds_nontumor * max(float(immune_enr), 0.0))
+
+    sig_comp = comp.get("signature") or {}
+    lin_comp = comp.get("lineage") or {}
+
+    # Row schema: (label, point, lower, upper, family, n_genes, note)
+    rows = []
+
+    if sig_comp.get("purity") is not None:
+        n = len(sig_comp.get("genes") or [])
+        rows.append((
+            "Tumor-specific signature",
+            float(sig_comp["purity"]),
+            _safe_float(sig_comp.get("lower")),
+            _safe_float(sig_comp.get("upper")),
+            "signature",
+            n,
+            " (deprioritized)" if signature_deprioritized else "",
+        ))
+
+    if lin_comp.get("purity") is not None:
+        n = len(lin_comp.get("genes") or [])
+        rows.append((
+            "Lineage panel",
+            float(lin_comp["purity"]),
+            _safe_float(lin_comp.get("lower")),
+            _safe_float(lin_comp.get("upper")),
+            "lineage",
+            n,
+            "",
+        ))
+
+    if stromal_purity is not None:
+        n = (comp.get("stromal") or {}).get("n_genes", 0)
+        rows.append((
+            "ESTIMATE stromal",
+            stromal_purity,
+            None,
+            None,
+            "estimate",
+            n,
+            "",
+        ))
+
+    if immune_purity is not None:
+        n = (comp.get("immune") or {}).get("n_genes", 0)
+        rows.append((
+            "ESTIMATE immune",
+            immune_purity,
+            None,
+            None,
+            "estimate",
+            n,
+            "",
+        ))
+
+    if comp.get("estimate_purity") is not None:
+        rows.append((
+            "ESTIMATE combined",
+            float(comp["estimate_purity"]),
+            None,
+            None,
+            "estimate",
+            0,
+            "",
+        ))
+
+    if decomposition_result is not None:
+        decomp_purity = getattr(decomposition_result, "purity", None)
+        if decomp_purity is not None:
+            rows.append((
+                "Decomposition (NNLS)",
+                float(decomp_purity),
+                None,
+                None,
+                "decomposition",
+                0,
+                f" [{getattr(decomposition_result, 'cancer_type', '')} / "
+                f"{getattr(decomposition_result, 'template', '')}]",
+            ))
+
+    overall = purity_result.get("overall_estimate")
+    overall_lower = purity_result.get("overall_lower")
+    overall_upper = purity_result.get("overall_upper")
+    if overall is not None:
+        rows.append((
+            "Adopted overall",
+            float(overall),
+            _safe_float(overall_lower),
+            _safe_float(overall_upper),
+            "adopted",
+            0,
+            "",
+        ))
+
+    # Family → color
+    family_color = {
+        "signature": "#2166ac",
+        "lineage": "#2ca25f",
+        "estimate": "#d6604d",
+        "decomposition": "#762a83",
+        "adopted": "#1a1a1a",
+    }
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # TCGA cohort median as reference line, labelled on the right edge.
+    if tcga_median is not None:
+        ax.axvline(
+            float(tcga_median) * 100, color="#888888",
+            linestyle="--", linewidth=1.0, alpha=0.8,
+            label=f"TCGA {cancer_code} median ({float(tcga_median):.0%})",
+        )
+
+    # Adopted overall marker as a thin vertical line so every row's
+    # alignment vs the final call is immediately visible.
+    if overall is not None:
+        ax.axvline(
+            float(overall) * 100, color="#1a1a1a",
+            linestyle=":", linewidth=1.5, alpha=0.8,
+        )
+
+    y_positions = list(range(len(rows)))
+    y_labels = []
+    for y, (label, point, lower, upper, family, n_genes, note) in zip(y_positions, rows):
+        color = family_color.get(family, "#555555")
+        point_pct = point * 100
+        # Error bar (if CI available)
+        if lower is not None and upper is not None:
+            ax.plot(
+                [lower * 100, upper * 100], [y, y],
+                color=color, linewidth=6, alpha=0.25, solid_capstyle="round",
+            )
+        # Point marker
+        ax.plot(
+            [point_pct], [y],
+            marker="o", markersize=12, color=color,
+            markeredgecolor="white", markeredgewidth=1.4,
+            linestyle="",
+        )
+        # Value text
+        ax.text(
+            point_pct + 1.5, y, f"{point_pct:.0f}%",
+            va="center", fontsize=10, fontweight="bold", color=color,
+        )
+        # Row label
+        gene_note = f" ({n_genes} genes)" if n_genes else ""
+        y_labels.append(f"{label}{gene_note}{note}")
+
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels(y_labels, fontsize=10)
+    ax.invert_yaxis()
+    ax.set_xlim(-2, 105)
+    ax.set_xlabel("Purity estimate (%)", fontsize=11)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    if title is None:
+        if overall is not None and overall_lower is not None and overall_upper is not None:
+            title = (
+                f"Purity estimation methods — {cancer_code} · "
+                f"adopted {overall * 100:.0f}% "
+                f"(CI {overall_lower * 100:.0f}–{overall_upper * 100:.0f}%)"
+            )
+        else:
+            title = f"Purity estimation methods — {cancer_code}"
+        if integration_source:
+            title += f" · integration: {integration_source}"
+    ax.set_title(title, fontsize=11, fontweight="bold", loc="left")
+    ax.legend(loc="lower right", fontsize=8, frameon=False)
+
+    fig.tight_layout()
+    if save_to_filename:
+        fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+        print(f"Saved {save_to_filename}")
+    return fig
+
+
+def _safe_float(x):
+    try:
+        return float(x) if x is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 # -------------------- tissue scoring --------------------
 
 

--- a/tests/test_plot_purity_methods.py
+++ b/tests/test_plot_purity_methods.py
@@ -1,0 +1,128 @@
+"""Tests for the purity-method comparison plot (#124)."""
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from pirlygenes.tumor_purity import plot_purity_method_comparison
+
+
+def _purity_result(**overrides):
+    base = {
+        "cancer_type": "PRAD",
+        "tcga_median_purity": 0.69,
+        "overall_estimate": 0.28,
+        "overall_lower": 0.19,
+        "overall_upper": 0.40,
+        "components": {
+            "signature": {
+                "purity": 0.30,
+                "lower": 0.18,
+                "upper": 0.45,
+                "stability": 0.6,
+                "genes": ["AR", "KLK3", "KLK2", "STEAP1", "FOLH1"],
+                "per_gene": [],
+            },
+            "lineage": {
+                "purity": 0.32,
+                "lower": 0.22,
+                "upper": 0.48,
+                "stability": 0.8,
+                "genes": ["AR", "NKX3-1", "HOXB13"],
+                "per_gene": [],
+                "concordance": 0.7,
+                "detection_fraction": 0.85,
+                "support_factor": 0.9,
+            },
+            "stromal": {"enrichment": 1.8, "n_genes": 141},
+            "immune": {"enrichment": 2.2, "n_genes": 141},
+            "estimate_purity": 0.35,
+            "integration": {
+                "source": "signature+lineage",
+                "signature_deprioritized": False,
+            },
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_comparison_plot_renders_all_methods(tmp_path: Path):
+    result = _purity_result()
+    out = tmp_path / "cmp.png"
+    fig = plot_purity_method_comparison(result, save_to_filename=str(out))
+    assert fig is not None
+    assert out.exists() and out.stat().st_size > 1000
+
+    # Each method's label should appear as a y-tick label.
+    labels = [t.get_text() for t in fig.axes[0].get_yticklabels()]
+    assert any("Tumor-specific signature" in label for label in labels)
+    assert any("Lineage panel" in label for label in labels)
+    assert any("ESTIMATE stromal" in label for label in labels)
+    assert any("ESTIMATE immune" in label for label in labels)
+    assert any("ESTIMATE combined" in label for label in labels)
+    assert any("Adopted overall" in label for label in labels)
+
+
+def test_comparison_plot_includes_decomposition_when_provided(tmp_path: Path):
+    class _Decomp:
+        purity = 0.34
+        cancer_type = "PRAD"
+        template = "solid_primary"
+
+    out = tmp_path / "cmp_with_decomp.png"
+    fig = plot_purity_method_comparison(
+        _purity_result(),
+        save_to_filename=str(out),
+        decomposition_result=_Decomp(),
+    )
+    labels = [t.get_text() for t in fig.axes[0].get_yticklabels()]
+    assert any("Decomposition" in label for label in labels)
+    # Template name surfaces in the label so multiple decomp results
+    # are distinguishable.
+    assert any("solid_primary" in label for label in labels)
+
+
+def test_comparison_plot_handles_missing_components(tmp_path: Path):
+    """Samples with only signature / only lineage / only ESTIMATE must still
+    produce a plot with the available methods and not crash on None."""
+    result = _purity_result()
+    # Drop lineage completely — simulates a cancer type with no lineage panel.
+    result["components"]["lineage"] = {
+        "purity": None, "lower": None, "upper": None,
+        "genes": [], "per_gene": [],
+    }
+    result["components"]["signature"]["lower"] = None
+    result["components"]["signature"]["upper"] = None
+
+    out = tmp_path / "cmp_sparse.png"
+    fig = plot_purity_method_comparison(result, save_to_filename=str(out))
+    labels = [t.get_text() for t in fig.axes[0].get_yticklabels()]
+    assert any("Tumor-specific signature" in label for label in labels)
+    # Lineage panel should NOT appear (no purity) — plot stays honest.
+    assert not any(label.startswith("Lineage panel") for label in labels)
+
+
+def test_comparison_plot_highlights_deprioritized_signature(tmp_path: Path):
+    result = _purity_result()
+    result["components"]["integration"]["signature_deprioritized"] = True
+    out = tmp_path / "cmp_depri.png"
+    fig = plot_purity_method_comparison(result, save_to_filename=str(out))
+    labels = [t.get_text() for t in fig.axes[0].get_yticklabels()]
+    sig_label = next(lbl for lbl in labels if "Tumor-specific signature" in lbl)
+    assert "deprioritized" in sig_label
+
+
+def test_comparison_plot_without_overall_still_renders(tmp_path: Path):
+    """If the pipeline couldn't produce an adopted overall estimate, the
+    plot should show the available methods without a reference line."""
+    result = _purity_result()
+    result["overall_estimate"] = None
+    result["overall_lower"] = None
+    result["overall_upper"] = None
+    out = tmp_path / "cmp_no_overall.png"
+    fig = plot_purity_method_comparison(result, save_to_filename=str(out))
+    labels = [t.get_text() for t in fig.axes[0].get_yticklabels()]
+    assert not any("Adopted overall" in label for label in labels)


### PR DESCRIPTION
## Summary

Dedicated figure (\`*-purity-methods.png\`) comparing every purity estimation method on the same purity % axis, so readers can see how the methods agree / disagree at a glance. Complements (doesn't replace) the existing \`plot_tumor_purity\` composite.

## Why

The existing component panel in \`plot_tumor_purity\` renders stromal / immune as **enrichment** values (scaled 0–100 with \"× vs TCGA\" text) on the same axis as actual purity percentages. Readers can't tell at a glance which methods are giving the same number and which are diverging — the 16% → 23% question becomes hard to answer without cross-referencing the TSVs.

## What you see

Each method on its own row, all on the purity axis:

- **Tumor-specific signature** (cancer-type markers) — point + CI
- **Lineage panel** — point + CI, labelled with \"(deprioritized)\" when the integration path flagged it
- **ESTIMATE stromal** — odds-model-derived purity from the stromal enrichment
- **ESTIMATE immune** — same for immune
- **ESTIMATE combined** — sqrt of the two
- **Decomposition (NNLS)** — tumor fraction from the best-fit hypothesis, labelled with \`cancer_type / template\` (shown when a \`DecompositionResult\` is passed)
- **Adopted overall** — the headline call with CI

Plus vertical reference lines for the **TCGA cohort median** and the **adopted point estimate** so the reader can see every method's distance from both.

## Tests

5 unit tests covering full render, decomposition inclusion, sparse input (missing lineage), deprioritized-signature labelling, and no-overall-estimate fallback. Full suite: 387 passed.

## Related

- Follows up the \"16% → 23%\" question in the current discussion — this figure is what you'd look at to see whether a given run's methods agree or the adopted call pulled from a different source.
- Cross-refers to #86 (harmonized purity adoption), #101 (CI widening), #109 (confidence tier).