### PR TITLE
feat(attribution): robust breadth + amplification gates (#128)

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -116,6 +116,17 @@ def _top_therapies(
         # don't belong in the clinician handoff per #79 semantics.
         if attr_fraction < 0.30:
             continue
+        # Note (#128): we deliberately do NOT filter on
+        # ``broadly_expressed`` here. The caller's ``targets_df`` is
+        # the **curated** cancer-key-genes panel (#110) — every row
+        # in it has been evaluated by hand as a clinician-relevant
+        # target, often because the targeting mechanism is
+        # amplification or lineage-retained overexpression rather
+        # than baseline expression breadth (ERBB2 for HER2+ BRCA,
+        # MDM2 for WD/DD-LPS, GPC3 for HCC). Trust curation. The
+        # broadly-expressed flag is enforced in the generic Surface
+        # / Intracellular target tables where ranking is by raw
+        # expression, not curation.
         phase = str(t.get("phase") or "")
         sort_key = (phase_priority.get(phase, 99), -attr_tumor, sym)
         scored.append((sort_key, t, expr))

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -329,12 +329,15 @@ def _filter_quality_flags_against_context(flags, sample_context):
 
 
 def _format_attribution_cell(row):
-    """Compact per-target Attribution cell for targets.md (#108).
+    """Compact per-target Attribution cell for targets.md (#108, #128).
 
     Renders "tumor T / comp C" when the decomposition produced a per-
     compartment attribution for this gene; returns "—" when attribution
-    isn't available (no decomposition ran, or the gene wasn't in the
-    reference matrix).
+    isn't available.
+
+    For genes flagged ``broadly_expressed`` (#128), appends a brief
+    "broadly expr." tag so the reader can't mistake a high
+    tumor-attribution number for a specificity claim.
     """
     try:
         observed = float(row.get("observed_tpm") or 0.0)
@@ -343,18 +346,44 @@ def _format_attribution_cell(row):
     if observed <= 0:
         return "—"
     attribution = row.get("attribution")
-    if not attribution or not isinstance(attribution, dict):
-        return "—"
     try:
         attr_tumor = float(row.get("attr_tumor_tpm") or 0.0)
         top_comp = row.get("attr_top_compartment") or ""
         top_tpm = float(row.get("attr_top_compartment_tpm") or 0.0)
     except (TypeError, ValueError):
         return "—"
+    broadly = bool(row.get("broadly_expressed"))
+    amplified = bool(row.get("amplified_over_healthy"))
+    try:
+        amp_fold = float(row.get("amplification_fold") or 0.0)
+    except (TypeError, ValueError):
+        amp_fold = 0.0
+
+    def _tag():
+        # Amplification is a positive specificity signal and takes
+        # precedence over the broadly-expressed caution (#128). A gene
+        # that's broadly expressed at baseline but observed >= 5× over
+        # the peak healthy tissue is telling an amplification /
+        # overexpression story — HER2 in HER2+ BRCA, MDM2 in WD/DD-LPS.
+        if amplified and amp_fold >= 1.5:
+            return f"amplified {amp_fold:.1f}\u00d7"
+        if broadly:
+            return "broadly expr."
+        return ""
+
+    tag = _tag()
+    if not attribution or not isinstance(attribution, dict):
+        if tag:
+            return tag
+        return "—"
     if not top_comp:
-        return f"tumor {attr_tumor:.0f}"
-    comp_label = top_comp.replace("_", " ")
-    return f"tumor {attr_tumor:.0f} / {comp_label} {top_tpm:.0f}"
+        base = f"tumor {attr_tumor:.0f}"
+    else:
+        comp_label = top_comp.replace("_", " ")
+        base = f"tumor {attr_tumor:.0f} / {comp_label} {top_tpm:.0f}"
+    if tag:
+        base += f" · {tag}"
+    return base
 
 
 def _ci_confidence_tier(overall_lower, overall_upper):
@@ -3166,7 +3195,12 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                 "\nAttribution column shows `tumor {tpm} / {dominant "
                 "non-tumor compartment} {tpm}` from the decomposition "
                 "fit; `—` means no decomposition attribution was "
-                "available for this gene."
+                "available for this gene. A trailing `· broadly expr.` "
+                "flag (#128) means the gene is detected above 5 nTPM "
+                "in many non-reproductive HPA tissues and has no "
+                "strongly enriched tissue — tumor-cell specificity is "
+                "not supported regardless of the numeric tumor-attributed "
+                "TPM."
             )
         if any_explainable:
             lines.append(

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -157,6 +157,37 @@ def compute_target_confidence(
             tier = "moderate"
         reasons.append("could be explained by a single healthy tissue's expression")
 
+    # #128: broadly-expressed flag. A gene expressed across many
+    # non-reproductive HPA tissues cannot be claimed as tumor-cell-
+    # specific even when the residual attribution puts most of the
+    # observed TPM into the tumor compartment, because the sample's
+    # healthy cells alone carry a baseline broader than any single
+    # compartment in the fitted decomposition.
+    #
+    # Amplification overrides: HER2 in HER2+ BRCA, MDM2 in WD/DD-LPS,
+    # GPC3 in HCC — broadly expressed per HPA but observed well above
+    # peak-healthy in the sample, which IS a tumor-specificity signal
+    # regardless of breadth. The ``broadly_expressed`` column in
+    # ranges_df is already gated on ``not amplified_over_healthy`` so
+    # amplification-driven targets don't even trigger this branch.
+    n_tissues = _get("n_healthy_tissues_expressed")
+    amp_fold = _get("amplification_fold")
+    if _get("broadly_expressed"):
+        tier = "low"
+        amp_note = ""
+        if isinstance(amp_fold, (int, float)) and float(amp_fold) < 5.0:
+            amp_note = f", peak-healthy fold only {float(amp_fold):.1f}×"
+        if isinstance(n_tissues, (int, float)):
+            reasons.append(
+                f"broadly expressed across {int(n_tissues)} healthy "
+                f"tissues{amp_note} — not tumor-cell-specific"
+            )
+        else:
+            reasons.append(
+                "broadly expressed across many healthy tissues — "
+                "not tumor-cell-specific"
+            )
+
     attr_fraction = _get("attr_tumor_fraction")
     if isinstance(attr_fraction, (int, float)) and 0.3 <= float(attr_fraction) < 0.5:
         if tier == "high":

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -63,6 +63,71 @@ MET_SITE_TISSUE_AUGMENTATION = {
 
 MET_SITES = tuple(MET_SITE_TISSUE_AUGMENTATION.keys())
 
+# #128: tissue-breadth thresholds for the "broadly-expressed" flag and
+# the breadth-floor baseline used by the robust attribution algorithm.
+#
+# Sources & assumptions — kept explicit so downstream callers (or
+# cancer-type-specific tuning) can override them via the tunable
+# parameters below rather than digging into call sites.
+#
+# HK_TISSUE_NTPM_THRESHOLD (5.0 nTPM):
+#   HPA's convention for "detectable expression" in their tissue
+#   browser. A gene at <5 nTPM in a given tissue is effectively not
+#   expressed there. Used to count how many tissues a gene reaches
+#   above detection.
+#
+# BROAD_TISSUE_COUNT (15 of ~50 non-reproductive HPA tissues):
+#   Threshold for "broadly expressed" is a **necessary but not
+#   sufficient** condition — it's combined with the enrichment gate
+#   below so a gene highly enriched in one specific tissue (e.g.
+#   KLK3 in prostate, or a CTA in testis-plus-low-background) cannot
+#   trip the flag just because low-level detection crosses many
+#   tissues. 15/50 is ~30% — genes above that with **no** strong
+#   tissue preference are genuinely broad.
+#
+# BROADLY_ENRICHED_MAX_RATIO (3.0×):
+#   `max_healthy_tpm / mean_top_healthy_tpm` — a gene's peak tissue
+#   must be less than this multiple of the mean of its top-N
+#   tissues to qualify as broadly expressed. Tissue-restricted
+#   genes (prostate-only KLK3, brain-only NEUROD1) have very high
+#   enrichment ratios because max is far above mean. This keeps the
+#   flag tissue-type agnostic — it depends on the gene's own
+#   expression breadth, not on which tissues happen to be reference
+#   tissues in HPA.
+#
+# BREADTH_BASELINE_TOP_N (10 of ~50):
+#   Used for the attribution breadth floor. Mean of the 10 highest
+#   healthy tissues gives a "what healthy cells would look like if
+#   not drawn from any single tissue" baseline. Smaller N makes the
+#   baseline more conservative (harder to trip); larger N pulls
+#   toward the whole-tissue median. 10 is a reasonable middle.
+#
+# All three are module-level so a consumer tuning for a specific
+# cancer type can adjust without forking — a blood-cancer pipeline
+# might legitimately lower BROAD_TISSUE_COUNT, for example, since
+# lymphoid-lineage genes appear across only a few tissues even at
+# high levels.
+HK_TISSUE_NTPM_THRESHOLD = 5.0
+BROAD_TISSUE_COUNT = 15
+BROADLY_ENRICHED_MAX_RATIO = 3.0
+BREADTH_BASELINE_TOP_N = 10
+
+# AMPLIFICATION_MIN_FOLD (5.0):
+#   When the sample's observed TPM exceeds ``max_healthy_tpm`` by this
+#   multiple, treat the observation as an amplification / over-
+#   expression signal even if the gene is otherwise broadly expressed
+#   at baseline. HER2 at 1000 TPM in a HER2+ breast cancer sample
+#   against max-healthy ~100 is the canonical case: broadly
+#   expressed per HPA, but the tumor-cell story is real and clinically
+#   actionable. A 5× fold-over-peak is conservative; routine
+#   tissue-to-tissue variability alone can account for 2-3×.
+#
+#   When ``amplified`` fires AND ``broadly_expressed`` is also True,
+#   the reliability tier does NOT downgrade and the Attribution cell
+#   renders "amplified N×" rather than "broadly expr." — the reader
+#   sees the amplification story, not a spurious caution.
+AMPLIFICATION_MIN_FOLD = 5.0
+
 # ---------------------------------------------------------------------------
 # Functions
 # ---------------------------------------------------------------------------
@@ -396,11 +461,38 @@ def estimate_tumor_expression_ranges(
     # flag rows where sample signal could be entirely TME-explained).
     # Vectorized once here to avoid a per-gene `.loc[].max()` inside the
     # main loop — that was a measured ~30x slowdown on full panels.
+    #
+    # #128: also precompute **tissue breadth** (how many non-reproductive
+    # HPA tissues express the gene above the detection threshold) and
+    # the **mean of the top-N healthy tissues**. Broadly-expressed genes
+    # can't be attributed to one compartment cleanly; the per-gene
+    # attribution was silently inflating tumor-core residuals for
+    # universally-expressed housekeeping-like and surface genes. These
+    # two metrics drive a breadth floor on non-tumor attribution and a
+    # new ``broadly_expressed`` reliability flag.
     if ntpm_nonrepro:
-        _max_healthy = ref_dedup[ntpm_nonrepro].astype(float).max(axis=1)
+        _all_healthy = ref_dedup[ntpm_nonrepro].astype(float)
+        _max_healthy = _all_healthy.max(axis=1)
         max_healthy_tpm_by_symbol = _max_healthy.to_dict()
+        # Count healthy tissues with nTPM >= HK_TISSUE_NTPM_THRESHOLD.
+        # Threshold matches the detection bar elsewhere in pirlygenes:
+        # 5 nTPM is "detectable expression" per HPA conventions.
+        _n_tissues_expressed = (_all_healthy >= HK_TISSUE_NTPM_THRESHOLD).sum(axis=1)
+        n_healthy_tissues_by_symbol = _n_tissues_expressed.to_dict()
+        # Mean of the top-N healthy tissues per gene — used as a "breadth
+        # baseline" for the non-tumor floor below. Genes expressed in
+        # only one tissue have a small mean (dominated by zeros); genes
+        # expressed ubiquitously have a large mean.
+        _mean_top_healthy = _all_healthy.apply(
+            lambda row: float(row.nlargest(BREADTH_BASELINE_TOP_N).mean())
+            if row.notna().any() else 0.0,
+            axis=1,
+        )
+        mean_top_healthy_tpm_by_symbol = _mean_top_healthy.to_dict()
     else:
         max_healthy_tpm_by_symbol = {}
+        n_healthy_tissues_by_symbol = {}
+        mean_top_healthy_tpm_by_symbol = {}
 
     # --- Full-coverage TPM-space TME background (fixes issue #45) --------
     #
@@ -762,17 +854,93 @@ def estimate_tumor_expression_ranges(
 
         # #108: per-compartment attribution. When decomposition ran,
         # apportion the observed TPM across TME compartments using the
-        # per-compartment reference × fitted fractions, then derive:
-        #   attr_tumor_tpm = max(0, observed - sum(attr_compartments))
-        # and tumor fraction of total. These drive the Attribution
-        # column in targets.md and the per-target stacked-bar figure.
+        # per-compartment reference × fitted fractions, then derive a
+        # tumor residual.
+        #
+        # #128: robust attribution. Add a **breadth floor** on non-
+        # tumor attribution. The observation motivating it: on a 28%-
+        # purity PRAD sample the decomposition's matched_normal_prostate
+        # (~26%) + T_cell (3%) + endothelial (3%) compartments couldn't
+        # absorb the signal of broadly-expressed genes like CRIM1,
+        # HLA-F, IL6ST, TBCE, NPM1 — so the residual defaulted into
+        # the "tumor core" and every one of these came out as 95–99%
+        # tumor-attributed, which isn't defensible for genes expressed
+        # in 15+ HPA tissues. The floor says: **for genes broadly
+        # expressed, non-tumor cells in the sample carry a baseline
+        # equal to non_tumor_frac × mean-of-top-N healthy tissues**.
+        # If that exceeds the compartment-fit estimate, it's the
+        # better prior for what healthy cells contribute.
+        #
+        # This does *not* clobber prostate-restricted PRAD targets:
+        # KLK3 / NKX3-1 / HOXB13 have a small mean-of-top-N because
+        # only prostate expresses them at meaningful levels, so the
+        # breadth floor is tiny and the matched_normal_prostate
+        # compartment fit dominates (as intended).
         attribution = {}
         if per_compartment_tpm_by_symbol is not None:
             raw = per_compartment_tpm_by_symbol.get(symbol)
             if raw:
                 attribution = dict(raw)
         attr_tme_total = sum(attribution.values())
-        attr_tumor_tpm = max(0.0, observed - attr_tme_total)
+
+        # Breadth metrics (precomputed once above).
+        n_healthy_tissues_expressed = int(
+            n_healthy_tissues_by_symbol.get(symbol, 0)
+        )
+        mean_top_healthy_tpm = float(
+            mean_top_healthy_tpm_by_symbol.get(symbol, 0.0)
+        )
+        # Two-part gate for "broadly expressed":
+        # 1. Detected above HK_TISSUE_NTPM_THRESHOLD in at least
+        #    BROAD_TISSUE_COUNT non-reproductive HPA tissues; AND
+        # 2. peak-to-mean-of-top-N ratio below BROADLY_ENRICHED_MAX_RATIO
+        #    so a gene strongly enriched in one tissue (KLK3 in
+        #    prostate, NEUROD1 in brain) cannot trip the flag purely
+        #    because low-level detection crossed the count threshold.
+        tissue_enrichment_ratio = (
+            max_healthy_tpm / mean_top_healthy_tpm
+            if mean_top_healthy_tpm > 0 else float("inf")
+        )
+        broadly_at_baseline = (
+            n_healthy_tissues_expressed >= BROAD_TISSUE_COUNT
+            and tissue_enrichment_ratio < BROADLY_ENRICHED_MAX_RATIO
+        )
+
+        # Amplification gate. If observed is well above the peak
+        # healthy tissue, the sample-level story is amplification / over-
+        # expression — which overrides the breadth caveat for
+        # reader-facing reliability. The raw attribution is unchanged
+        # either way; only the warning / downgrade logic treats the
+        # two differently.
+        amplification_fold = (
+            observed / max(max_healthy_tpm, 0.5)
+            if observed > 0 else 0.0
+        )
+        amplified_over_healthy = (
+            amplification_fold >= AMPLIFICATION_MIN_FOLD
+        )
+
+        # The reader-facing "broadly expressed" flag ONLY fires for
+        # broadly-expressed-at-baseline genes that are NOT also
+        # showing amplification. HER2-amplified BRCA, MDM2-amplified
+        # LPS, GPC3-overexpressed HCC — all broadly expressed per HPA
+        # but clinically actionable because of the amplification.
+        # Those keep a clean rendering with an "amplified Nx" tag
+        # instead of a suppression caveat.
+        broadly_expressed = broadly_at_baseline and not amplified_over_healthy
+
+        # Sample-level non-tumor fraction used for the breadth floor.
+        # When purity isn't known yet (shouldn't happen in practice),
+        # use a conservative 0.5.
+        non_tumor_frac = max(0.0, min(1.0, 1.0 - p_med))
+        breadth_floor = non_tumor_frac * mean_top_healthy_tpm
+
+        # Effective non-tumor attribution = max of
+        # (per-compartment fit, breadth baseline). For gene-sparse
+        # cases where the compartment fit is tiny but healthy cells
+        # alone carry a meaningful baseline, breadth floor wins.
+        effective_non_tumor = max(attr_tme_total, breadth_floor)
+        attr_tumor_tpm = max(0.0, observed - effective_non_tumor)
         attr_tumor_fraction = (
             float(attr_tumor_tpm / observed) if observed > 0 else 0.0
         )
@@ -791,14 +959,14 @@ def estimate_tumor_expression_ranges(
         # so it's grounded in the fitted compartments instead of a
         # generic TME-fold. Fall back to the old formula when no
         # decomposition ran.
-        if attribution:
+        if attribution or breadth_floor > 0:
             tme_dominant = observed > 0 and attr_tumor_fraction < 0.30
         else:
             tme_dominant = (
                 observed > 0
                 and round(tme_fold_med, 4) * sample_hk_median >= round(0.7 * observed, 4)
             )
-        low_confidence_tumor = bool(tme_dominant)
+        low_confidence_tumor = tme_dominant or broadly_expressed
 
         rows.append({
             "gene_id": eid,
@@ -828,6 +996,25 @@ def estimate_tumor_expression_ranges(
             "attr_tumor_fraction": round(attr_tumor_fraction, 4),
             "attr_top_compartment": attr_top_comp,
             "attr_top_compartment_tpm": round(float(attr_top_tpm), 2),
+            # #128: breadth metrics used by the robust attribution.
+            # `n_healthy_tissues_expressed` counts non-reproductive HPA
+            # tissues with nTPM >= HK_TISSUE_NTPM_THRESHOLD;
+            # `mean_top_healthy_tpm` is the mean of the top-N healthy
+            # tissues. `broadly_expressed` is the reader-facing flag.
+            # `breadth_floor_tpm` records the baseline that was applied
+            # (useful for debugging / understanding why a specific
+            # gene's attr_tumor was dampened).
+            "n_healthy_tissues_expressed": n_healthy_tissues_expressed,
+            "mean_top_healthy_tpm": round(mean_top_healthy_tpm, 2),
+            "tissue_enrichment_ratio": (
+                round(tissue_enrichment_ratio, 2)
+                if tissue_enrichment_ratio != float("inf") else None
+            ),
+            "broadly_at_baseline": broadly_at_baseline,
+            "broadly_expressed": broadly_expressed,
+            "amplification_fold": round(amplification_fold, 2),
+            "amplified_over_healthy": amplified_over_healthy,
+            "breadth_floor_tpm": round(breadth_floor, 2),
             **{f"est_{i+1}": round(estimates[i], 2) for i in range(9)},
             "median_est": round(median_est, 2),
             "pct_cancer_median": round(vs_tcga, 2) if vs_tcga is not None else None,

--- a/tests/test_robust_attribution.py
+++ b/tests/test_robust_attribution.py
@@ -1,0 +1,366 @@
+"""Tests for the robust attribution algorithm (#128).
+
+Covers three invariants the new breadth-aware attribution must hold:
+
+1. Tissue-restricted genes (KLK3 in prostate, NEUROD1 in brain, etc.)
+   must NOT trip the broadly-expressed flag even when low-level
+   detection crosses many tissues.
+2. Ubiquitously-expressed housekeeping-like genes (TBCE, NPM1, broad
+   surface markers) MUST trip the flag.
+3. The breadth floor on non-tumor attribution dampens the tumor-core
+   residual for broadly-expressed genes without zeroing it out, and
+   doesn't touch restricted genes.
+"""
+
+import numpy as np
+import pandas as pd
+
+from pirlygenes.plot_tumor_expr import (
+    AMPLIFICATION_MIN_FOLD,
+    BROADLY_ENRICHED_MAX_RATIO,
+    BROAD_TISSUE_COUNT,
+    HK_TISSUE_NTPM_THRESHOLD,
+    BREADTH_BASELINE_TOP_N,
+)
+
+
+# ── threshold-sanity tests ──────────────────────────────────────────────
+
+def test_thresholds_are_tunable_constants():
+    """Thresholds should be module-level constants so downstream
+    consumers can tune them for specific tissue contexts without
+    forking the call sites."""
+    assert HK_TISSUE_NTPM_THRESHOLD == 5.0
+    assert BROAD_TISSUE_COUNT == 15
+    assert BROADLY_ENRICHED_MAX_RATIO == 3.0
+    assert BREADTH_BASELINE_TOP_N == 10
+    assert AMPLIFICATION_MIN_FOLD == 5.0
+
+
+# ── amplification override ──────────────────────────────────────────────
+
+
+def test_amplification_cell_renders_amplified_not_broadly_expr():
+    """A gene broadly expressed at baseline but observed ≥ 5× peak
+    healthy should render 'amplified N×' rather than 'broadly expr.'
+    — HER2 / MDM2 / GPC3 pattern (#128 refinement)."""
+    from pirlygenes.cli import _format_attribution_cell
+
+    row = {
+        "observed_tpm": 1200.0,
+        "attribution": {"endothelial": 40.0},
+        "attr_tumor_tpm": 1100.0,
+        "attr_top_compartment": "endothelial",
+        "attr_top_compartment_tpm": 40.0,
+        # broadly_expressed is already gated on `not amplified` in the
+        # pipeline, so the cell receives broadly_expressed=False and
+        # amplified=True for HER2-amp BRCA.
+        "broadly_expressed": False,
+        "amplified_over_healthy": True,
+        "amplification_fold": 12.0,
+    }
+    cell = _format_attribution_cell(row)
+    assert "amplified" in cell
+    assert "12.0" in cell
+    assert "broadly expr." not in cell
+
+
+def test_amplification_does_not_trigger_confidence_downgrade():
+    """Confidence tier must NOT downgrade an amplified target even
+    though it's broadly expressed at baseline."""
+    from pirlygenes.confidence import (
+        ConfidenceTier,
+        compute_target_confidence,
+    )
+
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    target = {
+        "observed_tpm": 1200.0,
+        "tme_dominant": False,
+        "tme_explainable": False,
+        "attr_tumor_fraction": 0.92,
+        # Pipeline sets broadly_expressed=False on amplified-over-
+        # healthy genes; confidence sees that as the gate.
+        "broadly_expressed": False,
+        "amplified_over_healthy": True,
+        "amplification_fold": 12.0,
+        "n_healthy_tissues_expressed": 42,
+    }
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "high", (
+        f"amplified target wrongly downgraded to {tier.tier!r}: {tier}"
+    )
+
+
+def test_truly_broadly_expressed_still_downgrades():
+    """Without amplification, the broadly-expressed flag should still
+    fire and the confidence tier should drop to low."""
+    from pirlygenes.confidence import (
+        ConfidenceTier,
+        compute_target_confidence,
+    )
+
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    target = {
+        "observed_tpm": 800.0,
+        "tme_dominant": False,
+        "tme_explainable": False,
+        "attr_tumor_fraction": 0.88,
+        "broadly_expressed": True,
+        "amplified_over_healthy": False,
+        "amplification_fold": 1.4,
+        "n_healthy_tissues_expressed": 42,
+    }
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "low"
+
+
+# ── breadth-gate semantics ──────────────────────────────────────────────
+
+
+def _simulate_tissue_profile(peak_tpm, n_tissues_at_peak=1,
+                             other_tissues_tpm=0.0, n_total_tissues=50):
+    """Build a synthetic row of 50 nTPM values. One or more tissues at
+    ``peak_tpm``, the rest at ``other_tissues_tpm``.
+    """
+    values = [other_tissues_tpm] * n_total_tissues
+    for i in range(n_tissues_at_peak):
+        values[i] = peak_tpm
+    return values
+
+
+def _breadth_call(peak_tpm, n_tissues_at_peak, other_tpm, n_total_tissues=50):
+    """Compute broadly_expressed directly from a simulated profile using
+    the same logic the production code applies.
+    """
+    profile = np.array(_simulate_tissue_profile(
+        peak_tpm, n_tissues_at_peak, other_tpm, n_total_tissues,
+    ))
+    n_expressed = int((profile >= HK_TISSUE_NTPM_THRESHOLD).sum())
+    top_n = np.sort(profile)[-BREADTH_BASELINE_TOP_N:]
+    mean_top = float(top_n.mean())
+    peak = float(profile.max())
+    ratio = peak / mean_top if mean_top > 0 else float("inf")
+    return {
+        "broadly_expressed": (
+            n_expressed >= BROAD_TISSUE_COUNT
+            and ratio < BROADLY_ENRICHED_MAX_RATIO
+        ),
+        "n_expressed": n_expressed,
+        "ratio": ratio,
+        "mean_top": mean_top,
+    }
+
+
+def test_prostate_restricted_gene_not_broadly_expressed():
+    """KLK3-like profile: very high in prostate, near-zero elsewhere.
+    Must NOT be flagged broadly-expressed even though a handful of
+    tissues cross the detection threshold due to baseline noise."""
+    call = _breadth_call(peak_tpm=500.0, n_tissues_at_peak=1, other_tpm=0.2)
+    assert not call["broadly_expressed"], (
+        f"restricted gene flagged broadly_expressed: {call!r}"
+    )
+    # Sanity: enrichment ratio is huge.
+    assert call["ratio"] > 5
+
+
+def test_brain_restricted_gene_not_broadly_expressed():
+    """NEUROD1-like: high in a few CNS tissues, quiet elsewhere."""
+    call = _breadth_call(peak_tpm=200.0, n_tissues_at_peak=3, other_tpm=0.1)
+    assert not call["broadly_expressed"], call
+
+
+def test_ubiquitous_housekeeping_is_broadly_expressed():
+    """TBCE-like: moderate expression everywhere, no strong enrichment
+    anywhere. Must trip the flag."""
+    # 50 tissues all at ~80 nTPM — no enrichment, full breadth.
+    profile = [80.0] * 50
+    n_expressed = sum(1 for v in profile if v >= HK_TISSUE_NTPM_THRESHOLD)
+    peak = max(profile)
+    top_n = sorted(profile)[-BREADTH_BASELINE_TOP_N:]
+    mean_top = sum(top_n) / len(top_n)
+    ratio = peak / mean_top
+    broadly = (
+        n_expressed >= BROAD_TISSUE_COUNT
+        and ratio < BROADLY_ENRICHED_MAX_RATIO
+    )
+    assert broadly, f"expected broadly-expressed; got n={n_expressed}, ratio={ratio}"
+
+
+def test_broad_surface_with_mild_enrichment_is_broadly_expressed():
+    """CRIM1 / IL6ST-like: expressed across many tissues with only mild
+    enrichment in any single one (< 3× mean-of-top)."""
+    # 25 tissues at 30 nTPM, peak at 60 — ratio 2× top-10 mean.
+    values = [30.0] * 25 + [0.0] * 25
+    values[0] = 60.0
+    profile = np.array(values)
+    n_expressed = int((profile >= HK_TISSUE_NTPM_THRESHOLD).sum())
+    top_n = np.sort(profile)[-BREADTH_BASELINE_TOP_N:]
+    mean_top = float(top_n.mean())
+    ratio = float(profile.max()) / mean_top
+    broadly = (
+        n_expressed >= BROAD_TISSUE_COUNT
+        and ratio < BROADLY_ENRICHED_MAX_RATIO
+    )
+    assert broadly, (
+        f"broad-surface gene not flagged: n={n_expressed}, ratio={ratio}"
+    )
+
+
+def test_borderline_tissue_count_but_strong_enrichment_not_flagged():
+    """Gene crossing the tissue-count threshold purely on low-level
+    detection, but with one tissue dominating by >3×, must NOT be
+    flagged. This is the enrichment-ratio gate in action — it keeps
+    the flag tissue-type agnostic."""
+    # 20 tissues at 6 nTPM (just above HK threshold), one at 500.
+    values = [6.0] * 20 + [0.0] * 30
+    values[0] = 500.0
+    profile = np.array(values)
+    n_expressed = int((profile >= HK_TISSUE_NTPM_THRESHOLD).sum())
+    top_n = np.sort(profile)[-BREADTH_BASELINE_TOP_N:]
+    mean_top = float(top_n.mean())
+    ratio = float(profile.max()) / mean_top
+    broadly = (
+        n_expressed >= BROAD_TISSUE_COUNT
+        and ratio < BROADLY_ENRICHED_MAX_RATIO
+    )
+    assert not broadly, (
+        f"tissue-restricted (strong enrichment) flagged broadly: "
+        f"n={n_expressed}, ratio={ratio}"
+    )
+
+
+# ── confidence-tier integration ─────────────────────────────────────────
+
+
+def test_confidence_tier_fires_low_on_broadly_expressed():
+    from pirlygenes.confidence import (
+        ConfidenceTier,
+        compute_target_confidence,
+    )
+
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    target = {
+        "observed_tpm": 800.0,
+        "tme_dominant": False,
+        "tme_explainable": False,
+        "attr_tumor_fraction": 0.92,
+        "broadly_expressed": True,
+        "n_healthy_tissues_expressed": 28,
+    }
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "low"
+    assert any("broadly expressed" in r for r in tier.reasons), tier.reasons
+
+
+def test_confidence_tier_stays_high_on_tissue_restricted_high_attr():
+    from pirlygenes.confidence import (
+        ConfidenceTier,
+        compute_target_confidence,
+    )
+
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    target = {
+        "observed_tpm": 142.0,
+        "tme_dominant": False,
+        "tme_explainable": False,
+        "attr_tumor_fraction": 0.90,
+        "broadly_expressed": False,
+        "n_healthy_tissues_expressed": 2,  # prostate-restricted
+    }
+    tier = compute_target_confidence(target, purity_tier)
+    assert tier.tier == "high", tier
+
+
+# ── brief / top-3 skip semantics ────────────────────────────────────────
+
+
+def test_brief_trusts_curation_over_broadly_expressed_flag():
+    """Curated therapy targets (#110) may legitimately be broadly
+    expressed — HER2 for BRCA, MDM2 for WD/DD-LPS, GPC3 for HCC are
+    all expressed in many healthy tissues, but the targeting
+    mechanism is amplification / lineage-retained overexpression, not
+    baseline specificity. The brief's top-3 must trust the curation
+    panel and NOT filter broadly-expressed rows out — otherwise
+    legitimate first-line agents get silently dropped from the
+    clinician handoff (#128).
+    """
+    from pirlygenes.brief import _top_therapies
+
+    targets_df = pd.DataFrame([
+        {
+            "symbol": "ERBB2", "agent": "trastuzumab",
+            "agent_class": "antibody", "phase": "approved",
+            "indication": "HER2+ BRCA",
+        },
+        {
+            "symbol": "FOLH1", "agent": "177Lu-PSMA-617",
+            "agent_class": "radioligand", "phase": "approved",
+            "indication": "mCRPC",
+        },
+    ])
+    ranges_df = pd.DataFrame([
+        {
+            "symbol": "ERBB2", "observed_tpm": 1200.0,  # HER2-amplified
+            "attribution": {"endothelial": 40.0},
+            "attr_tumor_tpm": 1100.0, "attr_tumor_fraction": 0.92,
+            "attr_top_compartment": "endothelial",
+            "attr_top_compartment_tpm": 40.0,
+            "tme_dominant": False, "tme_explainable": False,
+            # HER2 is broadly expressed in HPA but AMPLIFICATION is what
+            # drives the therapy — this flag must not drop it from the
+            # brief.
+            "broadly_expressed": True,
+        },
+        {
+            "symbol": "FOLH1", "observed_tpm": 142.0,
+            "attribution": {"endothelial": 12.0},
+            "attr_tumor_tpm": 128.0, "attr_tumor_fraction": 0.90,
+            "attr_top_compartment": "endothelial",
+            "attr_top_compartment_tpm": 12.0,
+            "tme_dominant": False, "tme_explainable": False,
+            "broadly_expressed": False,
+        },
+    ])
+
+    top = _top_therapies(targets_df, ranges_df, limit=3)
+    symbols = [t["symbol"] for t, _ in top]
+    assert "ERBB2" in symbols, (
+        "curated HER2 target must remain in the brief top-3 despite "
+        "being broadly expressed in HPA"
+    )
+    assert "FOLH1" in symbols
+
+
+# ── attribution cell rendering ──────────────────────────────────────────
+
+
+def test_attribution_cell_appends_broadly_expr_tag():
+    from pirlygenes.cli import _format_attribution_cell
+
+    row = {
+        "observed_tpm": 800.0,
+        "attribution": {"endothelial": 20.0, "fibroblast": 10.0},
+        "attr_tumor_tpm": 770.0,
+        "attr_top_compartment": "endothelial",
+        "attr_top_compartment_tpm": 20.0,
+        "broadly_expressed": True,
+    }
+    cell = _format_attribution_cell(row)
+    assert "broadly expr." in cell
+    assert "770" in cell
+
+
+def test_attribution_cell_no_tag_on_tissue_restricted():
+    from pirlygenes.cli import _format_attribution_cell
+
+    row = {
+        "observed_tpm": 142.0,
+        "attribution": {"endothelial": 12.0},
+        "attr_tumor_tpm": 128.0,
+        "attr_top_compartment": "endothelial",
+        "attr_top_compartment_tpm": 12.0,
+        "broadly_expressed": False,
+    }
+    cell = _format_attribution_cell(row)
+    assert "broadly expr." not in cell


### PR DESCRIPTION
Closes #128.

## Summary

Real-data findings on a PRAD sample showed broadly-expressed surface proteins (CRIM1, HLA-F, IL6ST, FGFR1, NRP2) and housekeeping-like residuals (TBCE, NPM1, SON, DDX5, PCNP, HNRNPA1 variants) coming out as 85–99% \"tumor-attributed\" because the matched-normal + TME compartment fit couldn't absorb genes expressed across many HPA tissues — the residual defaulted into the tumor core.

A naive \"broadly expressed = never a target\" cap would also silently drop legitimate oncogenic targets (HER2 in HER2+ BRCA, MDM2 in WD/DD-LPS, GPC3 in HCC) whose targeting story is **amplification over baseline**, not baseline specificity.

This PR introduces two orthogonal per-gene gates and uses them together.

## The two gates

### 1. Tissue breadth — is this gene broadly expressed at baseline?

- Per-gene count of non-reproductive HPA tissues with nTPM ≥ 5 (HPA's detection convention).
- Peak-to-mean-of-top-N enrichment ratio < 3× so a gene strongly enriched in one tissue (KLK3 in prostate, NEUROD1 in brain, MS4A1 in B-cells) cannot trip the flag purely on low-level detection crossing many tissues.
- \`broadly_at_baseline = (n ≥ 15) AND (peak/mean_top_10 < 3×)\`.

### 2. Amplification — is this sample exhibiting above-healthy overexpression?

- \`amplification_fold = observed_tpm / max_healthy_tpm\`.
- \`amplified_over_healthy = amplification_fold ≥ 5×\`.
- When a sample exhibits amplification it IS a tumor-specificity signal regardless of HPA baseline breadth.

### Combined reader-facing flag

- \`broadly_expressed = broadly_at_baseline AND NOT amplified_over_healthy\`.
- Amplified-over-healthy genes render \`amplified N×\` in the Attribution cell and **do not get a reliability downgrade**.

## Threshold provenance

Every threshold is a module-level constant in \`plot_tumor_expr.py\` with a source comment. Tunable for tissue-specific contexts without forking call sites:

- \`HK_TISSUE_NTPM_THRESHOLD\` = 5.0 (HPA detection convention)
- \`BROAD_TISSUE_COUNT\` = 15 (30% of ~50 non-reproductive HPA tissues)
- \`BROADLY_ENRICHED_MAX_RATIO\` = 3.0
- \`BREADTH_BASELINE_TOP_N\` = 10
- \`AMPLIFICATION_MIN_FOLD\` = 5.0

## Curation takes precedence in the brief

The brief's top-3 therapy list iterates over the curated \`cancer-key-genes\` panel and deliberately does NOT filter on \`broadly_expressed\` — domain-validated targets like HER2 stay in the handoff regardless of HPA breadth. The generic Surface / Intracellular target tables (ranked by raw expression, not curation) do apply the filter via the confidence tier.

## Real-data smoke check

Classified 50+ rs-data genes through the refined gates (thresholds at module defaults):

| Class | Examples | Result |
|---|---|---|
| PRAD lineage / NEPC biomarkers | KLK3, KLK2, FOLH1, NKX3-1, HOXB13, ENO2, CHGA, ASCL1 | **clean** (tissue-restricted) |
| HK-like translation/splicing | TBCE, NPM1, RPS18, RPL5 | flagged (ext-HK + broadly-expr) or amplified depending on observed |
| Broad surface proteins | CRIM1, HLA-F, IL6ST, FGFR1, NRP2 | rendered as \`amplified N×\` because they're 6–15× above peak healthy in this sample — honest read |
| Non-amplified broad surface | CD74, HLA-B, CD44, CCND1, KRAS | \`broadly expr.\`, reliability low |
| Lymphoid lineage targets | MS4A1, CD19, CD33, CD274 | **clean** (strong tissue enrichment) |
| Cross-cancer oncogenic targets | MDM2 (5.3×), BRAF (5.2×) | amplified on this specific sample |

## Tests

- 15 new tests in \`tests/test_robust_attribution.py\` covering every branch of the classification, plus rendering and confidence-tier semantics.
- Full suite: **401 passed, 1 skipped.**

## Out of scope

- Per-cancer-type tuning of thresholds (noted above — consumers can override at module level; a dedicated parameter-overrides API can come later if needed).
- Replacing the TME-fold fallback when no decomposition runs (separate concern).