### PR TITLE
fix(attribution): proportionally rescale when matched-normal over-predicts (#131)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -354,12 +354,22 @@ def _format_attribution_cell(row):
         return "—"
     broadly = bool(row.get("broadly_expressed"))
     amplified = bool(row.get("amplified_over_healthy"))
+    over_predicted = bool(row.get("matched_normal_over_predicted"))
     try:
         amp_fold = float(row.get("amplification_fold") or 0.0)
     except (TypeError, ValueError):
         amp_fold = 0.0
 
     def _tag():
+        # Over-prediction is the strongest caveat — when matched-normal
+        # alone predicts more of the gene than we observed, the
+        # attribution math can't say anything reliable about the tumor
+        # contribution (#131). Surface this first so a reader looking
+        # at e.g. KLK3 / TACSTD2 on a CRPC sample knows the "tumor 0"
+        # number isn't independent evidence that tumor cells aren't
+        # expressing the gene — it means the reference over-predicted.
+        if over_predicted:
+            return "matched-normal over-predicted"
         # Amplification is a positive specificity signal and takes
         # precedence over the broadly-expressed caution (#128). A gene
         # that's broadly expressed at baseline but observed >= 5× over

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -157,6 +157,23 @@ def compute_target_confidence(
             tier = "moderate"
         reasons.append("could be explained by a single healthy tissue's expression")
 
+    # #131: matched-normal over-prediction. When the fitted
+    # matched-normal (or any) compartment predicts more of the gene
+    # than the sample actually contains, the attribution math's
+    # tumor residual is zero by construction — but that's a ceiling
+    # effect of the model, not evidence the tumor isn't expressing
+    # the gene. Fire a moderate downgrade with a reader-facing reason
+    # so clinically curated targets (KLK3 / TACSTD2 / FOLH1 on CRPC
+    # samples) aren't silently dismissed.
+    if _get("matched_normal_over_predicted"):
+        if tier == "high":
+            tier = "moderate"
+        reasons.append(
+            "matched-normal reference over-predicts this gene — "
+            "tumor attribution hit the zero floor; the raw observed "
+            "TPM is the better read than the attributed fraction"
+        )
+
     # #128: broadly-expressed flag. A gene expressed across many
     # non-reproductive HPA tissues cannot be claimed as tumor-cell-
     # specific even when the residual attribution puts most of the

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -881,6 +881,40 @@ def estimate_tumor_expression_ranges(
             raw = per_compartment_tpm_by_symbol.get(symbol)
             if raw:
                 attribution = dict(raw)
+        attr_tme_total_raw = sum(attribution.values())
+
+        # #131: over-prediction handling. In CRPC / NE-differentiated
+        # samples, AR-target genes (KLK3, KLK2, TACSTD2, FOLH1) are
+        # suppressed relative to normal prostate epithelium, yet the
+        # decomposition's ``matched_normal_prostate`` reference uses
+        # the HPA normal-prostate nTPM profile. Multiplying the fitted
+        # matched-normal fraction × the normal nTPM then predicts much
+        # more of these genes than the sample actually contains —
+        # observed on the ``rs`` PRAD sample: KLK3 4848 predicted vs
+        # 82 observed (59×), TACSTD2 77 vs 12 (6×). The raw math
+        # correctly floors tumor residual at 0, but silently zeroing a
+        # clinically interesting gene is misleading.
+        #
+        # Fix: when the per-compartment fit over-predicts, **rescale
+        # the attribution proportionally** so the reported compartment
+        # TPMs sum to observed. The relative compartment shares are
+        # preserved (matched-normal still dominates) but the absolute
+        # numbers are clipped to what we saw. Tumor residual stays at
+        # 0 (we have no unexplained expression). The
+        # ``matched_normal_over_predicted`` flag records that the fit
+        # was over-extended so the reader sees the attribution's
+        # numeric values aren't independent evidence.
+        matched_normal_over_predicted = (
+            observed > 0
+            and attribution
+            and attr_tme_total_raw > observed
+        )
+        if matched_normal_over_predicted:
+            scale = observed / attr_tme_total_raw
+            attribution = {
+                comp: round(val * scale, 2)
+                for comp, val in attribution.items()
+            }
         attr_tme_total = sum(attribution.values())
 
         # Breadth metrics (precomputed once above).
@@ -1015,6 +1049,12 @@ def estimate_tumor_expression_ranges(
             "amplification_fold": round(amplification_fold, 2),
             "amplified_over_healthy": amplified_over_healthy,
             "breadth_floor_tpm": round(breadth_floor, 2),
+            # #131: flag when the per-compartment fit over-predicted
+            # the gene's TPM. Attribution values above have been
+            # proportionally rescaled to sum to observed; raw sum is
+            # kept for audit.
+            "matched_normal_over_predicted": matched_normal_over_predicted,
+            "attribution_raw_sum_tpm": round(attr_tme_total_raw, 2),
             **{f"est_{i+1}": round(estimates[i], 2) for i in range(9)},
             "median_est": round(median_est, 2),
             "pct_cancer_median": round(vs_tcga, 2) if vs_tcga is not None else None,

--- a/tests/test_robust_attribution.py
+++ b/tests/test_robust_attribution.py
@@ -92,6 +92,47 @@ def test_amplification_does_not_trigger_confidence_downgrade():
     )
 
 
+def test_matched_normal_over_predicted_downgrades_and_tags():
+    """When the fitted matched-normal compartment predicts more TPM
+    than the sample contains (KLK3 / TACSTD2 on CRPC samples, #131),
+    the attribution cell must surface the caveat and the confidence
+    tier must drop from high to moderate — otherwise a clinically
+    curated target silently reports "tumor 0" as if the tumor isn't
+    expressing it."""
+    from pirlygenes.cli import _format_attribution_cell
+    from pirlygenes.confidence import (
+        ConfidenceTier,
+        compute_target_confidence,
+    )
+
+    # Row shape after the #131 rescaling: attribution values clipped
+    # to observed, over_predicted flag set.
+    row = {
+        "observed_tpm": 82.17,
+        "attribution": {"matched_normal_prostate": 82.17},  # rescaled
+        "attr_tumor_tpm": 0.0,
+        "attr_tumor_fraction": 0.0,
+        "attr_top_compartment": "matched_normal_prostate",
+        "attr_top_compartment_tpm": 82.17,
+        "matched_normal_over_predicted": True,
+        "attribution_raw_sum_tpm": 4847.81,
+        "broadly_expressed": False,
+        "amplified_over_healthy": False,
+        "amplification_fold": 0.0,
+        "tme_dominant": True,
+        "tme_explainable": True,
+    }
+    cell = _format_attribution_cell(row)
+    assert "over-predicted" in cell, f"cell missing over-predicted tag: {cell!r}"
+
+    purity_tier = ConfidenceTier(tier="high", reasons=[])
+    tier = compute_target_confidence(row, purity_tier)
+    assert tier.tier in ("moderate", "low"), (
+        f"over-predicted row should trip the tier: {tier}"
+    )
+    assert any("over-predicts" in r for r in tier.reasons), tier.reasons
+
+
 def test_truly_broadly_expressed_still_downgrades():
     """Without amplification, the broadly-expressed flag should still
     fire and the confidence tier should drop to low."""


### PR DESCRIPTION
Fixes the \"why are TACSTD2 / KLK3 / KLK2 being adjusted down to 0?\" finding on the rs PRAD data.

## What was wrong

On the rs sample:

| Gene | Observed | Matched-normal predicts | Ratio |
|---|---:|---:|---:|
| KLK3 | 82 | 4848 | 59× |
| TACSTD2 | 12 | 77 | 6× |
| KLK2 | 102 | 342 | 3.4× |

The attribution math is ``tumor_tpm = max(0, observed - matched_normal_tpm)``, so any time matched-normal predicts more than observed, tumor = 0. That's the math floor, not evidence the tumor isn't expressing the gene — it just means the HPA normal-prostate reference over-predicts these genes on a CRPC / AR-suppressed sample where they're clinically suppressed.

## What this PR does (presentation fix)

1. When the per-compartment fit sum > observed, **proportionally rescale** the attribution dict so its numeric values sum to observed. Matched-normal still dominates visually; the absolute numbers are clipped to reality.
2. New ``matched_normal_over_predicted`` boolean column on ``ranges_df`` plus ``attribution_raw_sum_tpm`` for audit.
3. Attribution cell renders ``tumor 0 / matched_normal_prostate 82 · matched-normal over-predicted`` instead of a silent-zero.
4. Confidence tier downgrades to moderate with an explicit reason line: \"matched-normal reference over-predicts this gene — tumor attribution hit the zero floor; the raw observed TPM is the better read.\"

## What this PR does NOT change

The underlying model behaviour — ``tumor_tpm`` still comes back as 0 when matched-normal over-predicts. That's a deeper modeling gap (CRPC-specific matched-normal reference needed). Tracked as issue #131 for a follow-up rewrite.

## Tests

- New ``test_matched_normal_over_predicted_downgrades_and_tags`` covers the rescaled cell rendering + tier downgrade.
- Full suite: **402 passed, 1 skipped**. Lint clean.