### PR TITLE
feat(plot): fit quality + gated-pattern on decomposition-candidates figure (#123)

### DIFF
--- a/pirlygenes/decomposition/plot.py
+++ b/pirlygenes/decomposition/plot.py
@@ -240,12 +240,81 @@ def plot_decomposition_candidates(
 
     # Right-side per-row score text. Kept textual (not a second bar) so
     # it's not confused with a width-encoded quantity.
+    #
+    # #123: also surface **fit quality** (raw reconstruction_error —
+    # smaller is better) and **median marker support** (how well-
+    # supported each fitted compartment is by its own markers) so the
+    # reader can tell whether a candidate is high-scoring because it
+    # actually explains the sample or because the composite score
+    # happens to land high. Candidates flagged with warnings by the
+    # decomposition engine (purity floor, low marker support, template
+    # incomplete, etc.) get a hatched pattern overlaid on their bars —
+    # a visible signal that the row is gated, not just aggregated.
+    import matplotlib.patches as mpatches
+
     for i, row in enumerate(rows):
         score = float(row.score or 0.0)
         cancer = float(row.cancer_support_score or 0.0)
         site = float(row.template_tissue_score or 0.0)
-        ax.text(101, i, f"score {score:.2f}  (cancer {cancer:.2f} · site {site:.2f})",
-                va="center", ha="left", fontsize=8.5, color="#333333")
+        err = float(getattr(row, "reconstruction_error", 0.0) or 0.0)
+
+        # Median marker support across fitted compartments. Typical range
+        # 0.0 (no marker evidence) to ~1.0 (each compartment solidly
+        # supported by its markers). Falls back to 0.0 for rows without
+        # a component_trace (e.g. the template-incomplete early return).
+        try:
+            trace = getattr(row, "component_trace", None)
+            if trace is not None and not trace.empty and "marker_score" in trace.columns:
+                ms = trace["marker_score"].astype(float)
+                median_marker = float(np.nanmedian(ms)) if len(ms) else 0.0
+            else:
+                median_marker = 0.0
+        except Exception:
+            median_marker = 0.0
+
+        ax.text(
+            101, i - 0.18,
+            f"score {score:.2f}  (cancer {cancer:.2f} · site {site:.2f})",
+            va="center", ha="left", fontsize=8.5, color="#333333",
+        )
+        ax.text(
+            101, i + 0.20,
+            f"fit err {err:.2f} · markers {median_marker:.2f}",
+            va="center", ha="left", fontsize=8, color="#555555", style="italic",
+        )
+
+        # Hatched overlay when the engine flagged this row (purity-floor
+        # penalty, low marker support, etc.).
+        warnings_list = list(getattr(row, "warnings", None) or [])
+        if warnings_list:
+            ax.barh(
+                [i], [100], left=[0],
+                height=0.6,
+                facecolor="none",
+                edgecolor="#555555",
+                hatch="///",
+                linewidth=0.0,
+                alpha=0.35,
+                zorder=5,
+            )
+
+    # Legend artist for the hatched "gated" pattern — the stacked bars
+    # already carry the three segment labels.
+    any_warnings = any(
+        (getattr(r, "warnings", None) or []) for r in rows
+    )
+    existing_handles, existing_labels = ax.get_legend_handles_labels()
+    if any_warnings:
+        gated_patch = mpatches.Patch(
+            facecolor="none", edgecolor="#555555", hatch="///",
+            label="gated (see row warnings)",
+        )
+        ax.legend(
+            existing_handles + [gated_patch],
+            existing_labels + ["gated (see row warnings)"],
+            loc="lower center", bbox_to_anchor=(0.5, 1.02),
+            ncol=4, frameon=False, fontsize=9,
+        )
 
     ax.set_yticks(y)
     ax.set_yticklabels(labels, fontsize=9.5)
@@ -253,9 +322,13 @@ def plot_decomposition_candidates(
     ax.set_xlim(0, 100)
     ax.set_xlabel("Percent of sample")
     # Legend above the plot area so it never overlaps the last row's
-    # segment labels — the title still sits above the legend.
-    ax.legend(loc="lower center", bbox_to_anchor=(0.5, 1.02),
-              ncol=3, frameon=False, fontsize=9)
+    # segment labels — the title still sits above the legend. Legend
+    # entries include the hatched "gated" pattern only when at least
+    # one row has an engine-issued warning (so unaffected plots stay
+    # uncluttered).
+    if not any_warnings:
+        ax.legend(loc="lower center", bbox_to_anchor=(0.5, 1.02),
+                  ncol=3, frameon=False, fontsize=9)
     # Title kept single-line — the per-bar segments + legend already
     # explain that each row is one candidate's composition.
     ax.set_title("Sample decomposition candidates", fontweight="bold", pad=28)

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -692,6 +692,86 @@ def test_plot_decomposition_candidates_empty_results_returns_none():
     assert plot_decomposition_candidates([]) is None
 
 
+def test_plot_decomposition_candidates_surfaces_fit_and_markers(tmp_path):
+    """#123: the candidates figure must surface per-row
+    reconstruction_error (as 'fit err') and median marker score (as
+    'markers'), so two similarly-scored candidates can be distinguished
+    by which one actually explains the sample. Also: rows with engine
+    warnings should be rendered with a hatched overlay (gated flag)
+    so purity-floor / marker-support / template-incomplete candidates
+    stand out visually."""
+    import matplotlib
+    matplotlib.use("Agg")
+    from types import SimpleNamespace
+    import pandas as pd
+    from pirlygenes.decomposition import plot_decomposition_candidates
+
+    trace_strong = pd.DataFrame([
+        {"component": "T_cell", "fraction": 0.03, "marker_score": 0.42,
+         "top_markers": "TRAC,CD3D", "n_markers": 3},
+        {"component": "myeloid", "fraction": 0.02, "marker_score": 0.38,
+         "top_markers": "LYZ,CD68", "n_markers": 3},
+    ])
+    trace_weak = pd.DataFrame([
+        {"component": "T_cell", "fraction": 0.01, "marker_score": 0.08,
+         "top_markers": "", "n_markers": 1},
+    ])
+
+    rows = [
+        SimpleNamespace(
+            cancer_type="PRAD", template="solid_primary",
+            purity=0.28, template_extra_fraction=0.60,
+            cancer_support_score=0.72, template_tissue_score=0.80,
+            score=0.72, reconstruction_error=0.18,
+            component_trace=trace_strong,
+            warnings=[],
+        ),
+        SimpleNamespace(
+            cancer_type="PRAD", template="met_liver",
+            purity=0.32, template_extra_fraction=0.50,
+            cancer_support_score=0.65, template_tissue_score=0.40,
+            score=0.45, reconstruction_error=0.55,
+            component_trace=trace_weak,
+            warnings=["Low marker support for template fit"],
+        ),
+    ]
+    out = tmp_path / "candidates_fit.png"
+    fig = plot_decomposition_candidates(rows, save_to_filename=str(out))
+    assert fig is not None
+    assert out.exists()
+    assert out.stat().st_size > 5_000
+
+    # Fit + markers annotation should be on the axes as a text artist.
+    ax = fig.axes[0]
+    texts = [t.get_text() for t in ax.texts]
+    assert any("fit err" in t and "markers" in t for t in texts), (
+        f"missing fit/markers annotation; texts: {texts}"
+    )
+
+
+def test_plot_decomposition_candidates_handles_missing_reconstruction_error(tmp_path):
+    """Old-style rows (SimpleNamespace without reconstruction_error /
+    component_trace) still render — the new annotation falls back to
+    fit err = 0.00 and markers = 0.00."""
+    import matplotlib
+    matplotlib.use("Agg")
+    from types import SimpleNamespace
+    from pirlygenes.decomposition import plot_decomposition_candidates
+
+    rows = [
+        SimpleNamespace(
+            cancer_type="COAD", template="solid_primary",
+            purity=0.45, template_extra_fraction=0.6,
+            cancer_support_score=0.7, template_tissue_score=0.85,
+            score=0.42,
+        ),
+    ]
+    out = tmp_path / "candidates_legacy.png"
+    fig = plot_decomposition_candidates(rows, save_to_filename=str(out))
+    assert fig is not None
+    assert out.exists()
+
+
 def test_auto_marker_selection_excludes_mhc_ii_and_ribosomal(monkeypatch):
     """#31: CD74 / HLA-D* / RPL* / RPS* must not be auto-picked as
     component-specific markers, even when their reference nTPM is high


### PR DESCRIPTION
Closes **#123**.

Surfaces three new signals per row on \`*-decomposition-candidates.png\`:

| Signal | Source | How it renders |
|---|---|---|
| **Reconstruction error** | \`DecompositionResult.reconstruction_error\` | Italic second-line text per row: \`fit err 0.18\` |
| **Median marker score** | \`component_trace[\"marker_score\"].median()\` | Same italic line: \`markers 0.42\` |
| **Engine warnings** | \`DecompositionResult.warnings\` | Hatched overlay on the candidate's bar; legend adds a \"gated\" entry only when at least one row is flagged |

### Before / after

Before, two similarly-scored candidates looked identical even when one fit tightly and the other barely fit. Now a reader sees per-row:

\`\`\`
PRAD / solid_primary  [tumor 28% | site 26% | immune/stroma 46%]
                       score 0.72  (cancer 0.72 · site 0.80)
                       fit err 0.18 · markers 0.42

PRAD / met_liver  ////////////////////////////// (hatched — gated)
                       score 0.45  (cancer 0.65 · site 0.40)
                       fit err 0.55 · markers 0.08
\`\`\`

The solid_primary candidate is clearly the better fit both in composite and in residual/marker evidence; the met_liver candidate's score is propped up by one signal but gated by a warning.

### Back-compat

Old-style callers (SimpleNamespace rows without \`reconstruction_error\` / \`component_trace\` / \`warnings\`) still render — \`getattr\` fallbacks resolve each missing field to 0 / empty. Covered by a new regression test.

### Tests

- \`test_plot_decomposition_candidates_surfaces_fit_and_markers\` — full-result rows emit fit/markers annotation; tolerates hatched overlay on warning rows.
- \`test_plot_decomposition_candidates_handles_missing_reconstruction_error\` — legacy SimpleNamespace rows render without error.
- Existing tests unchanged.

Full suite: **410 passed, 1 skipped**. Lint clean.