### PR TITLE
feat(cli): advisory lockfile on --output-dir to prevent concurrent-run corruption (#82)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -419,6 +419,103 @@ def _default_output_dir() -> str:
     return f"pirlygenes-{ts}"
 
 
+# ── Output-directory lock (#82) ─────────────────────────────────────────
+#
+# Two concurrent ``analyze`` invocations pointed at the same
+# ``--output-dir`` would happily overwrite each other's artifacts
+# because ``_clean_prefix_outputs`` wipes stale files at start and both
+# runs race to write to the same filenames. The result is a silently
+# inconsistent report (figures from one run, markdowns from the other).
+#
+# Cheap fix: write an advisory ``.pirlygenes.lock`` with the runner's
+# pid + start time. A second invocation into the same directory while
+# the lock-owner is still alive bails out with a clear error directing
+# the user to ``--force`` or a different ``--output-dir``.
+#
+# Not a true concurrency guarantee — a race still exists between the
+# stale-lock unlink and the new write — but the common accidental
+# double-launch case is caught and diagnosed instead of silently
+# corrupting the output.
+_LOCKFILE_NAME = ".pirlygenes.lock"
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Cheap liveness check.
+
+    ``os.kill(pid, 0)`` raises :class:`ProcessLookupError` when the
+    process does not exist and :class:`PermissionError` when it
+    exists but the caller can't signal it (which still counts as
+    alive for our purposes — we don't want a lock held by another
+    user to look stale just because we can't ping it).
+    """
+    if pid <= 0:
+        return False
+    import os as _os
+
+    try:
+        _os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _acquire_output_dir_lock(out_dir, force: bool = False):
+    """Claim the output dir for this process. Returns the lockfile Path
+    so the caller can unlink on exit.
+
+    Raises :class:`RuntimeError` with a clear message when another
+    pirlygenes process is already writing there and ``force`` is
+    False. Stale locks (pid no longer alive) are reclaimed with a
+    console note.
+    """
+    import json
+    import os as _os
+    from datetime import datetime
+
+    lock_path = out_dir / _LOCKFILE_NAME
+    if lock_path.exists():
+        try:
+            payload = json.loads(lock_path.read_text() or "{}")
+            holder_pid = int(payload.get("pid") or 0)
+            holder_started = str(payload.get("started_at") or "unknown time")
+        except (ValueError, OSError):
+            holder_pid = 0
+            holder_started = "unknown time"
+        if holder_pid and _pid_is_alive(holder_pid):
+            if not force:
+                raise RuntimeError(
+                    f"Another pirlygenes analyze process (pid={holder_pid}, "
+                    f"started {holder_started}) is writing to {out_dir}. "
+                    "Use a different --output-dir, wait for it to finish, "
+                    "or pass --force to override (only do this if you're "
+                    "sure the lock is stale)."
+                )
+            print(
+                f"[output] --force: ignoring live lock held by pid={holder_pid} "
+                "(started {holder_started})"
+            )
+        else:
+            print(
+                f"[output] Cleaning stale lockfile (pid={holder_pid} "
+                f"not running, started {holder_started})"
+            )
+
+    lock_path.write_text(
+        json.dumps(
+            {
+                "pid": _os.getpid(),
+                "started_at": datetime.now().isoformat(timespec="seconds"),
+            },
+            indent=2,
+        )
+    )
+    return lock_path
+
+
 def _clean_prefix_outputs(out_dir: Path, prefix_path: str) -> int:
     """Delete stale files from a prior run sharing the same output prefix.
 
@@ -508,6 +605,7 @@ def analyze(
     decomposition_templates: Optional[str] = None,
     therapy_target_top_k: int = 10,
     therapy_target_tpm_threshold: float = 30.0,
+    force: bool = False,
 ):
     """Analyze gene expression from a quantification file.
 
@@ -556,29 +654,38 @@ def analyze(
     out_dir.mkdir(parents=True, exist_ok=True)
     print(f"[output] Writing to {out_dir}/")
 
-    _analyze_body(
-        input_path=gene_input,
-        out_dir=out_dir,
-        output_image_prefix=output_image_prefix,
-        aggregate_gene_expression=aggregate_gene_expression,
-        label_genes=label_genes,
-        gene_name_col=gene_name_col,
-        gene_id_col=gene_id_col,
-        sample_id_col=sample_id_col,
-        sample_id_value=sample_id_value,
-        output_dpi=output_dpi,
-        plot_height=plot_height,
-        plot_aspect=plot_aspect,
-        cancer_type=cancer_type,
-        sample_mode=sample_mode,
-        tumor_context=tumor_context,
-        site_hint=site_hint,
-        met_site=met_site,
-        transcript_path=transcript_input,
-        decomposition_templates=decomposition_templates,
-        therapy_target_top_k=therapy_target_top_k,
-        therapy_target_tpm_threshold=therapy_target_tpm_threshold,
-    )
+    # #82: advisory lock so a second concurrent analyze into the same
+    # output dir fails fast instead of silently corrupting artifacts.
+    lock_path = _acquire_output_dir_lock(out_dir, force=force)
+    try:
+        _analyze_body(
+            input_path=gene_input,
+            out_dir=out_dir,
+            output_image_prefix=output_image_prefix,
+            aggregate_gene_expression=aggregate_gene_expression,
+            label_genes=label_genes,
+            gene_name_col=gene_name_col,
+            gene_id_col=gene_id_col,
+            sample_id_col=sample_id_col,
+            sample_id_value=sample_id_value,
+            output_dpi=output_dpi,
+            plot_height=plot_height,
+            plot_aspect=plot_aspect,
+            cancer_type=cancer_type,
+            sample_mode=sample_mode,
+            tumor_context=tumor_context,
+            site_hint=site_hint,
+            met_site=met_site,
+            transcript_path=transcript_input,
+            decomposition_templates=decomposition_templates,
+            therapy_target_top_k=therapy_target_top_k,
+            therapy_target_tpm_threshold=therapy_target_tpm_threshold,
+        )
+    finally:
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def _analyze_body(

--- a/tests/test_output_dir_lock.py
+++ b/tests/test_output_dir_lock.py
@@ -1,0 +1,92 @@
+"""Tests for the output-directory lockfile (#82)."""
+
+import json
+import os
+
+import pytest
+
+from pirlygenes.cli import (
+    _acquire_output_dir_lock,
+    _pid_is_alive,
+    _LOCKFILE_NAME,
+)
+
+
+def test_pid_is_alive_self():
+    """The current process pid must register as alive."""
+    assert _pid_is_alive(os.getpid())
+
+
+def test_pid_is_alive_nonexistent():
+    """A very high pid that doesn't exist should register as dead."""
+    # 2^22 - 1 is above typical pid_max on macOS/Linux; if by luck
+    # this is an alive pid the test is flaky, but extremely unlikely.
+    assert not _pid_is_alive(4_194_303)
+
+
+def test_pid_is_alive_invalid_returns_false():
+    """Negative / zero pids are treated as not-alive."""
+    assert not _pid_is_alive(0)
+    assert not _pid_is_alive(-1)
+
+
+def test_acquire_lock_writes_pid_and_timestamp(tmp_path):
+    lock_path = _acquire_output_dir_lock(tmp_path, force=False)
+    assert lock_path.exists()
+    assert lock_path.name == _LOCKFILE_NAME
+    payload = json.loads(lock_path.read_text())
+    assert payload["pid"] == os.getpid()
+    assert "started_at" in payload
+
+
+def test_acquire_lock_refuses_live_holder(tmp_path):
+    """A second acquire against a lockfile held by a live pid must
+    raise with a clear error. Simulate by writing a live-pid lockfile
+    (our own pid) and then trying to re-acquire."""
+    # Pre-seed lock with our own pid (which is definitely alive).
+    lock_path = tmp_path / _LOCKFILE_NAME
+    lock_path.write_text(json.dumps({"pid": os.getpid(), "started_at": "test"}))
+
+    with pytest.raises(RuntimeError) as exc:
+        _acquire_output_dir_lock(tmp_path, force=False)
+    msg = str(exc.value).lower()
+    assert "already" in msg or "lock" in msg
+    assert "--force" in str(exc.value)
+    assert str(os.getpid()) in str(exc.value)
+
+
+def test_acquire_lock_force_overrides_live_holder(tmp_path):
+    """``force=True`` claims the lock even when a live pid holds it."""
+    lock_path = tmp_path / _LOCKFILE_NAME
+    lock_path.write_text(json.dumps({"pid": os.getpid(), "started_at": "test"}))
+
+    new_lock = _acquire_output_dir_lock(tmp_path, force=True)
+    # Should have re-written the lock with this process's pid.
+    payload = json.loads(new_lock.read_text())
+    assert payload["pid"] == os.getpid()
+
+
+def test_acquire_lock_reclaims_stale_lockfile(tmp_path):
+    """A lockfile held by a dead pid is reclaimed silently without
+    requiring --force — crashed runs shouldn't leave a zombie lock
+    that blocks subsequent invocations."""
+    stale_pid = 4_194_303  # not a live pid
+    lock_path = tmp_path / _LOCKFILE_NAME
+    lock_path.write_text(json.dumps({"pid": stale_pid, "started_at": "stale"}))
+
+    # Must not raise — stale locks are auto-reclaimed.
+    new_lock = _acquire_output_dir_lock(tmp_path, force=False)
+    payload = json.loads(new_lock.read_text())
+    assert payload["pid"] == os.getpid()
+
+
+def test_acquire_lock_handles_corrupt_lockfile(tmp_path):
+    """A malformed JSON lockfile shouldn't crash acquire — treat it
+    as stale and reclaim."""
+    lock_path = tmp_path / _LOCKFILE_NAME
+    lock_path.write_text("not-json-at-all")
+
+    new_lock = _acquire_output_dir_lock(tmp_path, force=False)
+    assert new_lock.exists()
+    payload = json.loads(new_lock.read_text())
+    assert payload["pid"] == os.getpid()


### PR DESCRIPTION
Closes **#82**.

## What changes

- On \`analyze\` start, claim \`<output_dir>/.pirlygenes.lock\` with \`{pid, started_at}\`.
- If the lock already exists and its pid is alive → **refuse with a clear error** naming the pid / start time:

  \`\`\`
  RuntimeError: Another pirlygenes analyze process (pid=73421,
  started 2026-04-18T14:05:12) is writing to /tmp/rs-output. Use a
  different --output-dir, wait for it to finish, or pass --force to
  override (only do this if you're sure the lock is stale).
  \`\`\`

- **Stale locks auto-reclaim**: if the holder pid is no longer alive (crashed run, OS reboot) or the lockfile is malformed, acquire proceeds silently with a console note.
- New \`--force\` flag overrides the check for the "yes I know what I'm doing" case.
- Lock is released in a \`try/finally\` so exceptions during analyze don't leave a zombie lock.

## Not attempted

True filesystem-level concurrency — there's still a narrow race between unlinking a stale lock and writing the new one. The accidental-double-launch case from the issue (two shell sessions each running analyze on the same dir) is what this fix targets.

## Tests

8 unit tests (\`tests/test_output_dir_lock.py\`):

- \`_pid_is_alive\` for self / nonexistent / invalid
- Fresh lock writes pid + timestamp
- Live holder raises clear error with pid
- --force overrides live holder
- Stale (dead pid) auto-reclaims
- Corrupt / malformed JSON lockfile auto-reclaims

Full suite: **416 passed, 1 skipped**. Lint clean.