### PR TITLE
feat(data): Tranche B SARC subtype-tiled cancer-key-genes (#126)

### DIFF
--- a/pirlygenes/data/cancer-key-genes.csv
+++ b/pirlygenes/data/cancer-key-genes.csv
@@ -285,3 +285,68 @@ LIHC,,KDR,target,regorafenib,small_molecule,approved,advanced HCC (2L),Multikina
 LIHC,,VEGFR2,target,ramucirumab,antibody,approved,AFP+ advanced HCC (2L),Anti-VEGFR2 for AFP ≥ 400 (REACH-2),PMID:30665869
 LIHC,,GPC3,target,codrituzumab,antibody,phase_2,GPC3+ HCC,Glypican-3 antibody — earlier trials; active ADC / CAR-T programmes,PMID:28698288
 LIHC,,FGF19,target,fisogatinib,small_molecule,phase_1,FGF19+ HCC,FGFR4-selective inhibitor for FGF19-amplified HCC,PMID:31694886
+SARC,leiomyosarcoma,ACTA2,biomarker,,,,,Smooth-muscle actin — lineage marker for LMS,PMID:23954400
+SARC,leiomyosarcoma,CALD1,biomarker,,,,,Caldesmon (h-caldesmon) — smooth-muscle lineage confirmation in LMS,PMID:23954400
+SARC,leiomyosarcoma,MYH11,biomarker,,,,,Smooth-muscle myosin heavy chain — LMS lineage,PMID:23954400
+SARC,leiomyosarcoma,DES,biomarker,,,,,Desmin — confirms smooth-muscle / striated-muscle lineage,PMID:23954400
+SARC,leiomyosarcoma,CDKN2A,biomarker,,,,,Frequent loss in LMS; prognostic,PMID:23954400
+SARC,leiomyosarcoma,TP53,biomarker,,,,,High somatic mutation rate in LMS; adverse prognosis,PMID:23954400
+SARC,leiomyosarcoma,RB1,biomarker,,,,,Frequent inactivation in LMS,PMID:23954400
+SARC,leiomyosarcoma,,target,trabectedin,small_molecule,approved,advanced LMS,Alkylating agent — approved for L-sarcomas (LMS/liposarcoma) after anthracycline,PMID:26967202
+SARC,leiomyosarcoma,,target,pazopanib,small_molecule,approved,advanced non-adipocytic STS,Multikinase TKI — PALETTE trial; includes LMS,PMID:22595799
+SARC,leiomyosarcoma,,target,doxorubicin,small_molecule,approved,first-line STS,Anthracycline — backbone cytotoxic,PMID:22595799
+SARC,dedifferentiated_liposarcoma,MDM2,biomarker,,,,,Ring-chromosome 12q amplification with MDM2 — pathognomonic for WDLPS/DDLPS,PMID:20181787
+SARC,dedifferentiated_liposarcoma,CDK4,biomarker,,,,,Co-amplified with MDM2 on 12q13-15 — gates CDK4/6-inhibitor eligibility,PMID:20181787
+SARC,dedifferentiated_liposarcoma,HMGA2,biomarker,,,,,12q amplicon — lipogenic-lineage marker in WDLPS/DDLPS,PMID:20181787
+SARC,dedifferentiated_liposarcoma,FRS2,biomarker,,,,,12q co-amplification; FGFR-pathway adapter,PMID:20181787
+SARC,dedifferentiated_liposarcoma,TP53,biomarker,,,,,More common in DDLPS than WDLPS — adverse prognosis,PMID:20181787
+SARC,dedifferentiated_liposarcoma,MDM2,target,brigimadlin (BI 907828),small_molecule,phase_3,MDM2-amplified DDLPS,MDM2-p53 antagonist — Brightline-1 phase 3 trial,PMID:37467370
+SARC,dedifferentiated_liposarcoma,MDM2,target,milademetan,small_molecule,phase_3,MDM2-amplified DDLPS,MDM2-p53 antagonist — MANTRA phase 3 (failed primary) with ongoing combination exploration,PMID:37467370
+SARC,dedifferentiated_liposarcoma,CDK4,target,palbociclib,small_molecule,phase_2,CDK4-amplified WDLPS/DDLPS,CDK4/6 inhibitor — encouraging phase 2 results in WDLPS/DDLPS,PMID:26948088
+SARC,dedifferentiated_liposarcoma,CDK4,target,abemaciclib,small_molecule,phase_2,CDK4-amplified WDLPS/DDLPS,CDK4/6 inhibitor — SARC041 and other phase 2 studies,PMID:31924739
+SARC,dedifferentiated_liposarcoma,,target,trabectedin,small_molecule,approved,advanced liposarcoma,Approved L-sarcoma indication — includes myxoid and DDLPS,PMID:26967202
+SARC,myxoid_liposarcoma,DDIT3,biomarker,,,,,FUS-DDIT3 (formerly FUS-CHOP) fusion — pathognomonic for MRCLS,PMID:20181787
+SARC,myxoid_liposarcoma,MAGE-A4,biomarker,,,,,Expressed in ~40% of MRCLS — gates afami-cel / MAGE-A4 TCR-T eligibility,PMID:39141605
+SARC,myxoid_liposarcoma,CTAG1B,biomarker,,,,,NY-ESO-1 — expressed in majority of MRCLS; TCR-T target,PMID:25668005
+SARC,myxoid_liposarcoma,PRAME,biomarker,,,,,CT antigen expressed in MRCLS; TCR-T / ADC target,PMID:34428009
+SARC,myxoid_liposarcoma,PPARG,biomarker,,,,,Adipogenic master regulator; lineage confirmation,PMID:20181787
+SARC,myxoid_liposarcoma,MAGE-A4,target,afami-cel (afamitresgene autoleucel),TCR-T,phase_2,HLA-A*02+ MAGE-A4+ MRCLS,First-in-class engineered TCR-T — approved in synovial sarcoma; MRCLS cohorts in basket trials,PMID:39141605
+SARC,myxoid_liposarcoma,CTAG1B,target,letetresgene autoleucel,TCR-T,phase_2,HLA-A*02+ NY-ESO-1+ MRCLS,NY-ESO-1 TCR-T — phase 2 in synovial / MRCLS,PMID:25668005
+SARC,myxoid_liposarcoma,,target,trabectedin,small_molecule,approved,advanced MRCLS,Approved L-sarcoma indication — particularly active in MRCLS,PMID:26967202
+SARC,synovial_sarcoma,SS18,biomarker,,,,,SS18-SSX1/2/4 fusion (typically t(X;18)) — pathognomonic for synovial sarcoma,PMID:23583762
+SARC,synovial_sarcoma,MAGE-A4,biomarker,,,,,Expressed in majority of synovial sarcoma — gates afami-cel eligibility,PMID:39141605
+SARC,synovial_sarcoma,CTAG1B,biomarker,,,,,NY-ESO-1 — widely expressed; lete-cel target,PMID:25668005
+SARC,synovial_sarcoma,PRAME,biomarker,,,,,Broadly expressed CT antigen; candidate TCR-T target,PMID:34428009
+SARC,synovial_sarcoma,TLE1,biomarker,,,,,Diagnostic IHC marker — near-universal nuclear staining in synovial sarcoma,PMID:17255762
+SARC,synovial_sarcoma,BCL2,biomarker,,,,,Broadly overexpressed — candidate for BCL2-targeted therapy trials,PMID:11297487
+SARC,synovial_sarcoma,MAGE-A4,target,afami-cel (Tecelra),TCR-T,approved,HLA-A*02+ MAGE-A4+ advanced synovial sarcoma,First engineered TCR-T approved by FDA (2024) — SPEARHEAD-1 trial,PMID:39141605
+SARC,synovial_sarcoma,CTAG1B,target,letetresgene autoleucel (lete-cel),TCR-T,phase_2,HLA-A*02+ NY-ESO-1+ synovial sarcoma,NY-ESO-1 TCR-T — pivotal phase 2,PMID:38458182
+SARC,synovial_sarcoma,,target,pazopanib,small_molecule,approved,advanced non-adipocytic STS,Multikinase TKI — PALETTE trial; synovial sarcoma included,PMID:22595799
+SARC,synovial_sarcoma,,target,trabectedin,small_molecule,phase_3,advanced synovial sarcoma,Alkylating agent — activity documented in synovial sarcoma subgroups,PMID:26967202
+SARC,dsrct,EWSR1,biomarker,,,,,EWSR1-WT1 t(11;22)(p13;q12) fusion — pathognomonic for desmoplastic small round cell tumor,PMID:11559696
+SARC,dsrct,WT1,biomarker,,,,,C-terminal WT1 IHC — positive due to the EWSR1-WT1 fusion; diagnostic,PMID:11559696
+SARC,dsrct,DES,biomarker,,,,,Dot-like desmin IHC — characteristic DSRCT pattern,PMID:11559696
+SARC,dsrct,VIM,biomarker,,,,,Vimentin positivity alongside keratin — DSRCT polyphenotypic pattern,PMID:11559696
+SARC,dsrct,WT1,target,,TCR-T,phase_1,WT1+ DSRCT,WT1-directed TCR-T and peptide vaccines in early trials,PMID:35379757
+SARC,gist,KIT,biomarker,,,,,CD117 — activating mutation in majority of GIST; gates imatinib / sunitinib / avapritinib eligibility,PMID:12522257
+SARC,gist,PDGFRA,biomarker,,,,,Imatinib-sensitive mutations (e.g. V561D); D842V requires avapritinib,PMID:12522257
+SARC,gist,SDHB,biomarker,,,,,Loss identifies SDH-deficient (WT) GIST — paediatric/young adult subtype with different biology,PMID:21252315
+SARC,gist,SDHA,biomarker,,,,,Alternate SDH complex loss — similar SDH-deficient biology,PMID:21252315
+SARC,gist,BRAF,biomarker,,,,,V600E in wild-type GIST — BRAF-inhibitor candidate,PMID:23054102
+SARC,gist,NF1,biomarker,,,,,NF1 inactivation in wild-type GIST,PMID:23054102
+SARC,gist,KIT,target,imatinib,small_molecule,approved,unresectable/metastatic GIST,First-line KIT/PDGFRA inhibitor — standard of care,PMID:12181401
+SARC,gist,KIT,target,sunitinib,small_molecule,approved,imatinib-resistant GIST,Multikinase — second-line after imatinib failure,PMID:17046465
+SARC,gist,KIT,target,regorafenib,small_molecule,approved,third-line GIST,Multikinase — post-imatinib/sunitinib failure,PMID:23177515
+SARC,gist,KIT,target,ripretinib,small_molecule,approved,fourth-line GIST,Switch-control KIT/PDGFRA inhibitor — INVICTUS trial,PMID:32511981
+SARC,gist,PDGFRA,target,avapritinib,small_molecule,approved,PDGFRA D842V GIST,Selective PDGFRA D842V inhibitor — NAVIGATOR trial,PMID:32078923
+SARC,gist,NTRK1,target,larotrectinib,small_molecule,approved,NTRK-fusion GIST,Tumor-agnostic NTRK inhibitor — relevant to NTRK-fusion WT GIST,PMID:29466156
+SARC,ewing_sarcoma,EWSR1,biomarker,,,,,EWSR1-FLI1 t(11;22) fusion (~85%) or EWSR1-ERG — pathognomonic for Ewing sarcoma,PMID:20142596
+SARC,ewing_sarcoma,FLI1,biomarker,,,,,Fusion partner — IHC positive in Ewing,PMID:20142596
+SARC,ewing_sarcoma,NKX2-2,biomarker,,,,,Downstream EWSR1-FLI1 target; lineage marker,PMID:21339729
+SARC,ewing_sarcoma,CD99,biomarker,,,,,Membranous CD99 staining — sensitive but not specific Ewing IHC,PMID:20142596
+SARC,ewing_sarcoma,CAV1,biomarker,,,,,Caveolin-1 — marker of Ewing differentiation,PMID:21339729
+SARC,ewing_sarcoma,PRAME,biomarker,,,,,CT antigen expressed in Ewing; TCR-T target,PMID:34428009
+SARC,ewing_sarcoma,,target,trabectedin,small_molecule,phase_2,relapsed Ewing,Alkylating agent — active in Ewing per single-agent and combo trials,PMID:26967202
+SARC,ewing_sarcoma,CDK4,target,palbociclib,small_molecule,phase_2,relapsed Ewing,CDK4/6 inhibitor — ongoing phase 2,PMID:31924739
+SARC,ewing_sarcoma,,target,TK216,small_molecule,phase_1,relapsed Ewing,Small-molecule ETV fusion inhibitor — first-in-class trial,PMID:33872428
+SARC,ewing_sarcoma,PRAME,target,IMA203,TCR-T,phase_2,PRAME+ HLA-A*02+ Ewing,PRAME-directed TCR-T — basket phase 2 including Ewing,PMID:34428009

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -1362,25 +1362,38 @@ def cancer_key_genes_df():
     return get_data("cancer-key-genes")
 
 
-def cancer_biomarker_genes(cancer_code):
+def cancer_biomarker_genes(cancer_code, subtype=None):
     """Ordered list of biomarker gene symbols for ``cancer_code``.
 
     Empty list when the cancer type is not yet curated — callers should
     treat that as "no clinician-relevant biomarker panel available" and
     render an appropriate placeholder, not synthesize fallback genes.
+
+    ``subtype`` (optional) filters to a specific subtype string (e.g.
+    ``"synovial_sarcoma"`` under ``cancer_code="SARC"``, #126). When
+    ``None``, returns **all** biomarker rows for the cancer code
+    regardless of subtype — suitable for samples whose subtype isn't
+    yet determined at report time.
     """
     df = cancer_key_genes_df()
     sub = df[(df["cancer_code"] == cancer_code) & (df["role"] == "biomarker")]
+    if subtype is not None:
+        sub = sub[sub["subtype"].fillna("").astype(str) == subtype]
     return list(sub["symbol"].dropna().astype(str).unique())
 
 
-def cancer_therapy_targets(cancer_code):
+def cancer_therapy_targets(cancer_code, subtype=None):
     """Subset of :func:`cancer_key_genes_df` for therapy-target rows of
     ``cancer_code``. Returns a DataFrame so callers can render the
     Phase / Indication / Agent columns without re-joining.
+
+    ``subtype`` (optional) filters to a specific subtype; see
+    :func:`cancer_biomarker_genes` for semantics.
     """
     df = cancer_key_genes_df()
     sub = df[(df["cancer_code"] == cancer_code) & (df["role"] == "target")]
+    if subtype is not None:
+        sub = sub[sub["subtype"].fillna("").astype(str) == subtype]
     return sub.copy().reset_index(drop=True)
 
 
@@ -1390,3 +1403,19 @@ def cancer_key_genes_cancer_types():
     """
     df = cancer_key_genes_df()
     return sorted(df["cancer_code"].dropna().astype(str).unique())
+
+
+def cancer_key_genes_subtypes(cancer_code):
+    """Return the list of curated subtypes for ``cancer_code``.
+
+    SARC is the primary user — subtype-stratified for leiomyosarcoma
+    / WD-DDLPS / MRCLS / synovial_sarcoma / DSRCT / GIST /
+    ewing_sarcoma (#126). Returns ``[]`` for cancer codes without
+    subtype rows (curation is a single flat panel).
+    """
+    df = cancer_key_genes_df()
+    sub = df[df["cancer_code"] == cancer_code]
+    subtypes = (
+        sub["subtype"].fillna("").astype(str).replace("nan", "").str.strip()
+    )
+    return sorted(s for s in set(subtypes) if s)

--- a/tests/test_sarc_subtype_key_genes.py
+++ b/tests/test_sarc_subtype_key_genes.py
@@ -1,0 +1,137 @@
+"""Tests for SARC subtype-aware cancer-key-genes curation (#126)."""
+
+from pirlygenes.gene_sets_cancer import (
+    cancer_biomarker_genes,
+    cancer_therapy_targets,
+    cancer_key_genes_cancer_types,
+    cancer_key_genes_subtypes,
+)
+
+
+def test_sarc_is_in_curated_codes():
+    assert "SARC" in cancer_key_genes_cancer_types()
+
+
+def test_sarc_subtypes_present():
+    subtypes = cancer_key_genes_subtypes("SARC")
+    expected = {
+        "leiomyosarcoma",
+        "dedifferentiated_liposarcoma",
+        "myxoid_liposarcoma",
+        "synovial_sarcoma",
+        "dsrct",
+        "gist",
+        "ewing_sarcoma",
+    }
+    missing = expected - set(subtypes)
+    assert not missing, f"missing subtypes: {missing}"
+
+
+def test_synovial_sarcoma_has_afami_cel_target():
+    """afami-cel is the first FDA-approved engineered TCR-T — the
+    canonical synovial-sarcoma targeted therapy. Missing this row
+    means the curation is materially incomplete."""
+    tg = cancer_therapy_targets("SARC", subtype="synovial_sarcoma")
+    agents = set(tg["agent"].astype(str))
+    assert any("afami-cel" in a or "Tecelra" in a for a in agents), (
+        f"expected afami-cel / Tecelra in synovial_sarcoma targets; got {agents}"
+    )
+    # Target gene for afami-cel is MAGE-A4
+    mage = tg[tg["symbol"] == "MAGE-A4"]
+    assert len(mage) >= 1
+
+
+def test_gist_has_four_approved_kit_inhibitors():
+    """GIST has a well-established approved KIT/PDGFRA targeted-therapy
+    ladder — imatinib / sunitinib / regorafenib / ripretinib / avapritinib
+    at minimum should be present."""
+    tg = cancer_therapy_targets("SARC", subtype="gist")
+    agents = set(tg[tg["phase"] == "approved"]["agent"].astype(str).str.lower())
+    expected = {"imatinib", "sunitinib", "regorafenib", "ripretinib", "avapritinib"}
+    missing = expected - agents
+    assert not missing, f"missing approved GIST agents: {missing}"
+
+
+def test_gist_biomarkers_include_kit_and_sdh():
+    bm = cancer_biomarker_genes("SARC", subtype="gist")
+    # KIT is near-universal; SDH-deficient WT GIST is a distinct
+    # subtype that the curation should flag.
+    assert "KIT" in bm
+    assert "PDGFRA" in bm
+    assert any(g in bm for g in ("SDHA", "SDHB"))
+
+
+def test_dedifferentiated_liposarcoma_has_mdm2_amplification_and_targets():
+    """MDM2 amplification is pathognomonic for WDLPS/DDLPS; targeted
+    MDM2-p53 antagonists (brigimadlin / milademetan) and CDK4/6
+    inhibitors are the active target class."""
+    bm = cancer_biomarker_genes("SARC", subtype="dedifferentiated_liposarcoma")
+    assert "MDM2" in bm
+    assert "CDK4" in bm
+
+    tg = cancer_therapy_targets("SARC", subtype="dedifferentiated_liposarcoma")
+    agents = set(tg["agent"].astype(str))
+    assert any("brigimadlin" in a or "milademetan" in a for a in agents), (
+        f"expected brigimadlin / milademetan in DDLPS targets; got {agents}"
+    )
+
+
+def test_myxoid_liposarcoma_has_fus_ddit3_and_ct_antigen_targets():
+    """Myxoid LPS: FUS-DDIT3 is pathognomonic; NY-ESO-1 (CTAG1B) and
+    MAGE-A4 are TCR-T targets with active trials."""
+    bm = cancer_biomarker_genes("SARC", subtype="myxoid_liposarcoma")
+    assert "DDIT3" in bm
+    assert "CTAG1B" in bm  # NY-ESO-1
+    assert "MAGE-A4" in bm
+
+
+def test_synovial_has_ss18_fusion_marker():
+    bm = cancer_biomarker_genes("SARC", subtype="synovial_sarcoma")
+    assert "SS18" in bm
+    assert "TLE1" in bm  # diagnostic IHC
+
+
+def test_dsrct_has_ewsr1_wt1_fusion_markers():
+    bm = cancer_biomarker_genes("SARC", subtype="dsrct")
+    assert "EWSR1" in bm
+    assert "WT1" in bm
+
+
+def test_ewing_has_fusion_and_cd99():
+    bm = cancer_biomarker_genes("SARC", subtype="ewing_sarcoma")
+    assert "EWSR1" in bm
+    assert "CD99" in bm
+    assert "FLI1" in bm
+
+
+def test_subtype_filter_returns_only_matching_rows():
+    """A subtype filter must isolate rows; no cross-contamination
+    between leiomyosarcoma and synovial_sarcoma markers."""
+    lms = set(cancer_biomarker_genes("SARC", subtype="leiomyosarcoma"))
+    syn = set(cancer_biomarker_genes("SARC", subtype="synovial_sarcoma"))
+    # LMS markers (DES, CALD1) shouldn't leak into synovial panel.
+    assert "CALD1" not in syn
+    # Synovial-specific markers (SS18, TLE1) shouldn't leak into LMS.
+    assert "SS18" not in lms
+    assert "TLE1" not in lms
+
+
+def test_no_subtype_arg_returns_all_sarc_rows():
+    """Back-compat: ``cancer_biomarker_genes("SARC")`` without a
+    subtype filter returns the union — useful when the report renders
+    before subtype classification."""
+    all_sarc = set(cancer_biomarker_genes("SARC"))
+    gist_only = set(cancer_biomarker_genes("SARC", subtype="gist"))
+    lms_only = set(cancer_biomarker_genes("SARC", subtype="leiomyosarcoma"))
+    assert gist_only.issubset(all_sarc)
+    assert lms_only.issubset(all_sarc)
+
+
+def test_subtype_filter_on_non_sarc_returns_existing_rows_unchanged():
+    """The subtype kwarg must be opt-in; PRAD / BRCA / etc. don't
+    populate the subtype column and should return their full panel
+    when subtype is unset."""
+    prad = cancer_biomarker_genes("PRAD")
+    assert len(prad) >= 10
+    # With a subtype that doesn't exist, return empty (correct semantics)
+    assert cancer_biomarker_genes("PRAD", subtype="nonexistent") == []


### PR DESCRIPTION
Closes **#126**.

## Summary

65 new rows across 7 SARC subtypes (LMS / WD-DDLPS / MRCLS / synovial / DSRCT / GIST / Ewing) with subtype-tiled curation. Plus a new \`subtype=\` kwarg on \`cancer_biomarker_genes\` and \`cancer_therapy_targets\` so downstream consumers can pull subtype-specific rows when the sample's subtype is classified, or the union when it isn't.

| Subtype | BM | Target | Highlights |
|---|---:|---:|---|
| leiomyosarcoma | 7 | 3 | trabectedin, pazopanib, doxorubicin |
| dedifferentiated_liposarcoma | 5 | 5 | MDM2 amp → brigimadlin / milademetan; CDK4 amp → palbociclib / abemaciclib |
| myxoid_liposarcoma | 5 | 3 | FUS-DDIT3 fusion, CT-antigen TCR-T basket (afami-cel, lete-cel) |
| synovial_sarcoma | 6 | 4 | SS18 fusion; **afami-cel (Tecelra)** — first approved engineered TCR-T |
| dsrct | 4 | 1 | EWSR1-WT1 fusion; WT1 TCR-T early phase (sparse target landscape) |
| gist | 6 | 6 | KIT/PDGFRA/SDH/BRAF/NF1; full approved TKI ladder |
| ewing_sarcoma | 6 | 4 | EWSR1-FLI1/-ERG fusion; CDK4 palbo + PRAME TCR-T (IMA203) |

## API

\`\`\`python
from pirlygenes.gene_sets_cancer import (
    cancer_biomarker_genes, cancer_therapy_targets, cancer_key_genes_subtypes,
)

cancer_key_genes_subtypes("SARC")
# → ['dedifferentiated_liposarcoma', 'dsrct', 'ewing_sarcoma', 'gist',
#    'leiomyosarcoma', 'myxoid_liposarcoma', 'synovial_sarcoma']

cancer_therapy_targets("SARC", subtype="synovial_sarcoma")
# → rows for afami-cel, lete-cel, pazopanib, trabectedin

cancer_biomarker_genes("SARC")  # no subtype → union across subtypes
\`\`\`

## Tests

13 new tests in \`tests/test_sarc_subtype_key_genes.py\`:
- Subtype enumeration matches the 7 expected subtypes.
- afami-cel / Tecelra present in synovial_sarcoma targets.
- Full approved KIT inhibitor ladder (imatinib, sunitinib, regorafenib, ripretinib, avapritinib) present in GIST.
- MDM2 + CDK4 biomarkers + MDM2-p53 antagonist targets in DDLPS.
- FUS-DDIT3 fusion, CTAG1B (NY-ESO-1), MAGE-A4 in MRCLS.
- EWSR1 + WT1 in DSRCT; EWSR1 + FLI1 + CD99 in Ewing; SS18 + TLE1 in synovial.
- Subtype filter isolates rows — LMS markers (CALD1) don't leak into synovial panel, and vice versa.
- No-subtype call returns the union (back-compat for unclassified SARC samples).
- Full suite: **436 passed, 1 skipped**. Lint clean.

## Not in this PR

- Tranche C cancer types (#127 — THCA / LGG / GBM / CHOL / OV / TGCT) next.
- Other SARC subtypes mentioned but not in the issue's core list (alveolar rhabdomyosarcoma, solitary fibrous tumor, angiosarcoma) remain as follow-ups.