### PR TITLE
feat: TCGA offline deconv (#21) + deconvolved reference (#22) + APL subtype (#23)

### DIFF
--- a/pirlygenes/data/cancer-key-genes.csv
+++ b/pirlygenes/data/cancer-key-genes.csv
@@ -161,6 +161,11 @@ LAML,,BCL2,target,venetoclax,small_molecule,approved,AML (unfit),Venetoclax+azac
 LAML,,KMT2A,target,revumenib,small_molecule,approved,R/R KMT2A-rearranged AML,Menin inhibitor approved in KMT2A-rearranged R/R AML,PMID:37018480
 LAML,,NPM1,target,revumenib,small_molecule,phase_2,NPM1-mut AML,Menin inhibitor trials in NPM1-mutant AML,PMID:37018480
 LAML,,CD123,target,tagraxofusp,fusion,approved,BPDCN,CD123-directed; approved for BPDCN (related myeloid malignancy),PMID:30987805
+LAML,apl,PML,biomarker,,,,,PML-RARA fusion partner — pathognomonic for APL (t(15;17)); defines the subtype,PMID:11001887
+LAML,apl,RARA,biomarker,,,,,PML-RARA fusion — ATRA differentiation target; near-universal in APL,PMID:11001887
+LAML,apl,FLT3,biomarker,,,,,ITD co-mutation in 30-40% of APL — hyperleukocytosis risk factor,PMID:18234679
+LAML,apl,RARA,target,tretinoin,small_molecule,approved,APL,All-trans retinoic acid (ATRA) — differentiation therapy; combined with ATO in low-risk APL,PMID:15837627
+LAML,apl,PML,target,arsenic trioxide,small_molecule,approved,APL,ATO targets PML moiety of PML-RARA; ATRA+ATO is chemo-free standard for low-risk APL,PMID:23841729
 UCEC,,MLH1,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; gates pembrolizumab / dostarlimab,PMID:26028255
 UCEC,,MSH2,biomarker,,,,,MMR gene — MSI-H / dMMR marker; Lynch syndrome relevance,PMID:26028255
 UCEC,,MSH6,biomarker,,,,,MMR gene — MSI-H / dMMR marker,PMID:26028255

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -605,12 +605,67 @@ def _pan_cancer_cache_key(genes, normalize, log_transform):
     return (genes_key, normalize, bool(log_transform))
 
 
+def tcga_deconvolved_expression():
+    """Per-(symbol, TCGA code) tumor-only TPM derived by #21 offline deconv.
+
+    Reads ``data/tcga-deconvolved-expression.csv`` if present. The CSV
+    is produced by :mod:`pirlygenes.tcga_decompose` on the full Xena
+    TOIL TCGA TPM matrix; it ships with the package once the
+    maintainer has run the batch.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        Long-form frame with columns ``symbol``, ``cancer_code``,
+        ``tumor_tpm_median``, ``tumor_tpm_q1``, ``tumor_tpm_q3``,
+        ``n_samples``. Returns ``None`` when the CSV is not bundled
+        (e.g. a fresh checkout where the offline batch hasn't been
+        run yet). Callers must handle the ``None`` case.
+    """
+    try:
+        return get_data("tcga-deconvolved-expression")
+    except ValueError:
+        return None
+
+
+def _tcga_deconv_wide(cache={}):
+    """Wide-form (Symbol-indexed) view of the tumor-only TPM median.
+
+    Built from the long-form :func:`tcga_deconvolved_expression` frame
+    with one column per TCGA code (``tcga_PRAD``, ``tcga_BRCA`` …).
+    Cached in-process; returns ``None`` when the deconv CSV is absent.
+    """
+    if "value" in cache:
+        return cache["value"]
+    long = tcga_deconvolved_expression()
+    if long is None or long.empty:
+        cache["value"] = None
+        return None
+
+    wide = long.pivot_table(
+        index="symbol",
+        columns="cancer_code",
+        values="tumor_tpm_median",
+        aggfunc="median",
+    )
+    wide.columns = [f"tcga_{c}" for c in wide.columns]
+    wide = wide.reset_index().rename(columns={"symbol": "Symbol"})
+    cache["value"] = wide
+    return wide
+
+
 def pan_cancer_expression(genes=None, normalize=None, log_transform=False):
     """Expression across 50 normal tissues (nTPM) and 33 TCGA cancer types.
 
     Normal tissues from HPA v23 consensus nTPM. Cancer types from HPA
     (21 types, median FPKM) and GDC/STAR reprocessing (12 additional types,
     median TPM). Column names are prefixed with ``nTPM_`` or ``FPKM_``.
+
+    When the #21 offline deconv has been run and shipped
+    ``data/tcga-deconvolved-expression.csv``, tumor-only columns
+    prefixed ``tcga_`` are merged in as well (#22). They sit alongside
+    (not replacing) the FPKM_ columns until callers migrate — the
+    breaking swap is reserved for v5.0.0.
 
     Parameters
     ----------
@@ -638,6 +693,9 @@ def pan_cancer_expression(genes=None, normalize=None, log_transform=False):
         return cached.copy()
 
     df = get_data("pan-cancer-expression")
+    deconv_wide = _tcga_deconv_wide()
+    if deconv_wide is not None:
+        df = df.merge(deconv_wide, on="Symbol", how="left")
     if genes is not None:
         genes_upper = {str(g).upper() for g in genes}
         mask = (
@@ -646,7 +704,10 @@ def pan_cancer_expression(genes=None, normalize=None, log_transform=False):
         )
         df = df[mask]
 
-    value_cols = [c for c in df.columns if c.startswith("nTPM_") or c.startswith("FPKM_")]
+    value_cols = [
+        c for c in df.columns
+        if c.startswith("nTPM_") or c.startswith("FPKM_") or c.startswith("tcga_")
+    ]
 
     if normalize is not None:
         df = df.copy()

--- a/pirlygenes/load_dataset.py
+++ b/pirlygenes/load_dataset.py
@@ -21,18 +21,28 @@ def get_all_csv_paths() -> list:
     """
     Get paths to all CSV files in the data directory.
 
+    Picks up both plain ``.csv`` and gzipped ``.csv.gz`` — the latter is used
+    for references that would otherwise bloat the package (e.g. the #22
+    tcga-deconvolved-expression reference, ~13 MB → ~4 MB gzipped).
+
     Returns a list of Path objects for each CSV file.
     """
-    return sorted(_DATA_DIR.glob("*.csv"))
+    return sorted(
+        list(_DATA_DIR.glob("*.csv")) + list(_DATA_DIR.glob("*.csv.gz"))
+    )
 
 
 def load_all_dataframes():
     """
-    Generator that yields pairs of (csv_file, df) for all CSV files in the data directory
+    Generator that yields pairs of (csv_name, df) for all CSV files in the
+    data directory. Gzipped files are transparently decompressed and keyed
+    under their underlying ``.csv`` name so callers don't need to know
+    the on-disk compression format.
     """
     for csv_path in get_all_csv_paths():
         df = pd.read_csv(str(csv_path))
-        yield csv_path.name, df
+        key = csv_path.name.removesuffix(".gz")
+        yield key, df
 
 
 def load_all_dataframes_dict():

--- a/pirlygenes/tcga_decompose.py
+++ b/pirlygenes/tcga_decompose.py
@@ -1,0 +1,432 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Offline TCGA per-sample deconvolution (#21).
+
+Runs the pirlygenes decomposition engine on every TCGA sample in the
+Xena TOIL RSEM TPM matrix, extracts the tumor-only TPM per gene, then
+aggregates per TCGA cancer code to median + IQR + N. The resulting
+CSV (``data/tcga-deconvolved-expression.csv``) feeds #22 — the
+decon-derived tumor-only columns that replace the current HPA/FPKM
+references in :func:`pirlygenes.gene_sets_cancer.pan_cancer_expression`.
+
+This module is NOT imported by the package at runtime. It exists as
+an offline batch script that the maintainer runs once per TCGA update.
+Expect ~1.5 hours for ~10K samples on a modern laptop and ~5 GB RAM
+to hold the full TPM matrix in memory.
+
+Usage
+-----
+
+.. code-block:: shell
+
+    python -m pirlygenes.tcga_decompose \\
+        --tpm-gz eval/tcga_RSEM_gene_tpm.gz \\
+        --barcode-project-pkl eval/barcode_to_project.pkl \\
+        --output-csv pirlygenes/data/tcga-deconvolved-expression.csv
+
+Smoke-test with a handful of samples::
+
+    python -m pirlygenes.tcga_decompose ... --max-samples-per-type 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def load_barcode_to_project(pkl_path: str | Path) -> dict[str, str]:
+    """Return ``{patient_barcode: TCGA_code}`` from the Xena pickle.
+
+    The Xena TCGA pickle is keyed by 12-char patient barcode
+    (``TCGA-XX-YYYY``). TPM column headers are full sample barcodes
+    (``TCGA-XX-YYYY-01``). We match on the 12-char prefix.
+    """
+    with open(pkl_path, "rb") as fh:
+        d = pickle.load(fh)
+    if not isinstance(d, dict):
+        raise TypeError(f"Expected dict in {pkl_path}, got {type(d)}")
+    return {str(k): str(v) for k, v in d.items()}
+
+
+def sample_barcode_to_project(
+    sample_barcode: str,
+    patient_to_project: dict[str, str],
+) -> str | None:
+    """Resolve a TCGA sample barcode to its TCGA project code.
+
+    Returns ``None`` when the sample's patient barcode is not in the
+    phenotype table (orphan or recently-added sample).
+    """
+    # Patient barcode is the first 12 chars: TCGA-XX-YYYY.
+    if not sample_barcode.startswith("TCGA-"):
+        return None
+    patient = sample_barcode[:12]
+    return patient_to_project.get(patient)
+
+
+def is_primary_tumor_sample(sample_barcode: str) -> bool:
+    """Return True for primary-tumor sample codes.
+
+    TCGA sample-type codes 01, 03, 09 are solid tumor, primary blood
+    cancer, and primary blood-derived cancer respectively. We skip
+    normals (10/11/14) and metastases (06/07) so the reference reflects
+    primary-tumor expression.
+    """
+    parts = sample_barcode.split("-")
+    if len(parts) < 4:
+        return False
+    # Vial suffix may be present (e.g. ``01A``); strip anything non-numeric.
+    code = parts[3][:2]
+    return code in {"01", "03", "09"}
+
+
+def load_tcga_tpm_matrix(
+    tpm_gz_path: str | Path,
+    sample_columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Load the Xena TOIL TCGA TPM matrix, un-logged to linear TPM.
+
+    Xena TOIL stores ``log2(TPM + 0.001)``. We reverse the transform
+    so decomposition operates on linear TPM like every other caller
+    in the package.
+
+    Parameters
+    ----------
+    tpm_gz_path : path
+        Gzip TSV with gene rows (Ensembl IDs with version) and sample
+        columns.
+    sample_columns : list of str, optional
+        Restrict to this subset of sample barcodes. Useful for
+        smoke-testing without reading the full 740 MB file.
+
+    Returns
+    -------
+    pd.DataFrame
+        Index = bare Ensembl ID (version stripped). Columns = sample
+        barcodes. Values = linear TPM, float32.
+    """
+    usecols = None
+    if sample_columns is not None:
+        usecols = ["sample"] + list(sample_columns)
+    print(f"[tcga] Reading {tpm_gz_path} ...", flush=True)
+    t0 = time.time()
+    df = pd.read_csv(
+        tpm_gz_path,
+        sep="\t",
+        index_col=0,
+        usecols=usecols,
+        dtype={"sample": str},
+        compression="gzip",
+    )
+    print(
+        f"[tcga] Loaded {df.shape[0]} genes x {df.shape[1]} samples "
+        f"in {time.time() - t0:.1f}s",
+        flush=True,
+    )
+    # Un-log: TPM = 2^x - 0.001, clip negatives to zero.
+    tpm = np.power(2.0, df.to_numpy(dtype=np.float32)) - np.float32(0.001)
+    np.maximum(tpm, 0.0, out=tpm)
+    out = pd.DataFrame(tpm, index=df.index, columns=df.columns)
+    out.index = out.index.astype(str).str.split(".", n=1).str[0]
+    return out
+
+
+def sample_frame(
+    tpm_column: pd.Series,
+    versioned_ids: pd.Index,
+) -> pd.DataFrame:
+    """Build the per-sample DataFrame that ``decompose_sample`` expects.
+
+    ``_guess_gene_cols`` recognises ``gene_id`` (lower-case). We keep
+    the versioned ID there because pirlygenes's loader strips the
+    version internally.
+    """
+    # ``_guess_gene_cols`` requires a gene-name column too. Leave it
+    # empty — downstream resolution rebuilds the symbol from the pan-
+    # cancer reference's ``Ensembl_Gene_ID`` → ``Symbol`` map.
+    return pd.DataFrame(
+        {
+            "gene_id": versioned_ids,
+            "gene_name": "",
+            "TPM": tpm_column.to_numpy(dtype=np.float32),
+        }
+    )
+
+
+def _observed_as_tumor(
+    tpm_column: pd.Series,
+    versioned_ids: pd.Index,
+) -> pd.DataFrame:
+    """Build a ``[symbol, tumor_tpm]`` frame using the observed TPM directly.
+
+    Used when the decomposer reports ≥99.9% tumor fraction — in that
+    degenerate case it returns an empty ``gene_attribution`` because
+    no TME compartment is active, but the conservative interpretation
+    for a primary-tumor reference is that the observed TPM *is* the
+    tumor TPM.
+    """
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression
+
+    ref = pan_cancer_expression()[["Ensembl_Gene_ID", "Symbol"]].drop_duplicates(
+        subset="Ensembl_Gene_ID"
+    )
+    eid_to_symbol = dict(zip(ref["Ensembl_Gene_ID"], ref["Symbol"]))
+    bare_ids = pd.Index(versioned_ids).astype(str).str.split(".", n=1).str[0]
+    symbols = [eid_to_symbol.get(eid, "") for eid in bare_ids]
+    out = pd.DataFrame(
+        {
+            "symbol": symbols,
+            "tumor_tpm": tpm_column.to_numpy(dtype=float),
+        }
+    )
+    out = out[out["symbol"].astype(str).str.len() > 0]
+    out = out[out["tumor_tpm"] >= 0.01]
+    # Collapse duplicate symbols (mapped from multiple ENSGs): sum TPM.
+    return out.groupby("symbol", as_index=False, sort=False)["tumor_tpm"].sum()
+
+
+def decompose_one_sample(
+    sample_barcode: str,
+    tpm_column: pd.Series,
+    cancer_code: str,
+    versioned_ids: pd.Index,
+    sample_mode: str = "solid",
+) -> pd.DataFrame | None:
+    """Decompose one TCGA sample and return ``[symbol, tumor_tpm]``.
+
+    Returns ``None`` when the decomposition throws or returns no
+    candidate (rare — a nearly-empty expression vector). When the
+    best hypothesis collapses to ≥99.9% tumor (and therefore empty
+    ``gene_attribution``), we fall back to the observed TPM as the
+    tumor TPM — correct for TCGA primary-tumor samples that are
+    already tumor-enriched by the consortium's pathology review.
+    """
+    from pirlygenes.decomposition import decompose_sample
+
+    df = sample_frame(tpm_column, versioned_ids)
+    try:
+        results = decompose_sample(
+            df,
+            cancer_types=[cancer_code],
+            top_k=1,
+            sample_mode=sample_mode,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[tcga] {sample_barcode} ({cancer_code}): decompose failed — {exc}", flush=True)
+        return None
+    if not results:
+        return None
+    best = results[0]
+    if best.gene_attribution.empty:
+        if best.purity >= 0.999:
+            attr = _observed_as_tumor(tpm_column, versioned_ids)
+        else:
+            return None
+    else:
+        attr = best.gene_attribution[["symbol", "tumor"]].copy()
+        attr = attr.rename(columns={"tumor": "tumor_tpm"})
+    attr["sample"] = sample_barcode
+    attr["cancer_code"] = cancer_code
+    return attr
+
+
+def aggregate_per_type(
+    per_sample_rows: pd.DataFrame,
+) -> pd.DataFrame:
+    """Reduce per-(sample, symbol) tumor TPM to per-(cancer_code, symbol) stats.
+
+    Output columns: ``symbol``, ``cancer_code``, ``tumor_tpm_median``,
+    ``tumor_tpm_q1``, ``tumor_tpm_q3``, ``n_samples``.
+    """
+    if per_sample_rows.empty:
+        return pd.DataFrame(
+            columns=[
+                "symbol",
+                "cancer_code",
+                "tumor_tpm_median",
+                "tumor_tpm_q1",
+                "tumor_tpm_q3",
+                "n_samples",
+            ]
+        )
+    grouped = per_sample_rows.groupby(["cancer_code", "symbol"])["tumor_tpm"]
+    summary = grouped.agg(
+        tumor_tpm_median="median",
+        tumor_tpm_q1=lambda s: float(np.quantile(s, 0.25)),
+        tumor_tpm_q3=lambda s: float(np.quantile(s, 0.75)),
+        n_samples="count",
+    ).reset_index()
+    return summary[
+        [
+            "symbol",
+            "cancer_code",
+            "tumor_tpm_median",
+            "tumor_tpm_q1",
+            "tumor_tpm_q3",
+            "n_samples",
+        ]
+    ]
+
+
+def select_samples(
+    columns: pd.Index,
+    patient_to_project: dict[str, str],
+    cancer_types: list[str] | None = None,
+    max_samples_per_type: int | None = None,
+    primary_only: bool = True,
+) -> list[tuple[str, str]]:
+    """Return ``[(sample_barcode, cancer_code), ...]`` to process.
+
+    Handles the three knobs a caller cares about: primary-tumor filter,
+    cancer-type filter, and per-type sample cap.
+    """
+    by_type: dict[str, list[str]] = defaultdict(list)
+    for col in columns:
+        if primary_only and not is_primary_tumor_sample(col):
+            continue
+        code = sample_barcode_to_project(col, patient_to_project)
+        if code is None:
+            continue
+        if cancer_types is not None and code not in cancer_types:
+            continue
+        by_type[code].append(col)
+
+    selected: list[tuple[str, str]] = []
+    for code, samples in by_type.items():
+        if max_samples_per_type is not None:
+            samples = samples[:max_samples_per_type]
+        selected.extend((s, code) for s in samples)
+    return selected
+
+
+def run(
+    tpm_gz: str,
+    barcode_project_pkl: str,
+    output_csv: str,
+    cancer_types: list[str] | None = None,
+    max_samples_per_type: int | None = None,
+    checkpoint_every: int = 500,
+) -> None:
+    patient_to_project = load_barcode_to_project(barcode_project_pkl)
+
+    print(f"[tcga] {len(patient_to_project)} patients mapped to TCGA projects", flush=True)
+
+    if max_samples_per_type is not None or cancer_types is not None:
+        # Cheap dry path: peek at header only to subset before full load.
+        header = pd.read_csv(tpm_gz, sep="\t", nrows=0, compression="gzip")
+        sample_cols = [c for c in header.columns if c != "sample"]
+        pairs = select_samples(
+            pd.Index(sample_cols),
+            patient_to_project,
+            cancer_types=cancer_types,
+            max_samples_per_type=max_samples_per_type,
+        )
+        subset = [p[0] for p in pairs]
+        tpm = load_tcga_tpm_matrix(tpm_gz, sample_columns=subset)
+    else:
+        tpm = load_tcga_tpm_matrix(tpm_gz)
+        pairs = select_samples(tpm.columns, patient_to_project)
+
+    print(f"[tcga] Decomposing {len(pairs)} samples", flush=True)
+    versioned_ids = pd.Index(tpm.index).astype(str)
+
+    checkpoint_path = Path(output_csv).with_suffix(".partial.csv")
+    accum: list[pd.DataFrame] = []
+    t0 = time.time()
+    for i, (sample, code) in enumerate(pairs, start=1):
+        col = tpm[sample]
+        attr = decompose_one_sample(sample, col, code, versioned_ids)
+        if attr is not None:
+            accum.append(attr)
+        if i % checkpoint_every == 0:
+            elapsed = time.time() - t0
+            per = elapsed / i
+            eta = per * (len(pairs) - i)
+            print(
+                f"[tcga] {i}/{len(pairs)} "
+                f"({elapsed:.0f}s elapsed, {per:.2f}s/sample, ETA {eta / 60:.1f} min)",
+                flush=True,
+            )
+            pd.concat(accum, ignore_index=True).to_csv(checkpoint_path, index=False)
+
+    if not accum:
+        print("[tcga] No samples decomposed successfully — nothing to write", flush=True)
+        return
+
+    per_sample = pd.concat(accum, ignore_index=True)
+    summary = aggregate_per_type(per_sample)
+    Path(output_csv).parent.mkdir(parents=True, exist_ok=True)
+    summary.to_csv(output_csv, index=False)
+    print(
+        f"[tcga] Wrote {len(summary)} (cancer_code, symbol) rows to {output_csv}",
+        flush=True,
+    )
+    if checkpoint_path.exists():
+        checkpoint_path.unlink()
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="TCGA offline per-sample tumor deconvolution (#21).",
+    )
+    p.add_argument("--tpm-gz", required=True, help="Path to tcga_RSEM_gene_tpm.gz")
+    p.add_argument(
+        "--barcode-project-pkl",
+        required=True,
+        help="Path to barcode_to_project.pkl",
+    )
+    p.add_argument(
+        "--output-csv",
+        required=True,
+        help="Output CSV path (e.g. pirlygenes/data/tcga-deconvolved-expression.csv)",
+    )
+    p.add_argument(
+        "--cancer-types",
+        default=None,
+        help="Comma-separated TCGA codes to restrict to (default: all)",
+    )
+    p.add_argument(
+        "--max-samples-per-type",
+        type=int,
+        default=None,
+        help="Cap per-type sample count (default: all). Useful for smoke tests.",
+    )
+    p.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=500,
+        help="Write a .partial.csv every N processed samples",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    cancer_types = None
+    if args.cancer_types:
+        cancer_types = [c.strip() for c in args.cancer_types.split(",") if c.strip()]
+    run(
+        tpm_gz=args.tpm_gz,
+        barcode_project_pkl=args.barcode_project_pkl,
+        output_csv=args.output_csv,
+        cancer_types=cancer_types,
+        max_samples_per_type=args.max_samples_per_type,
+        checkpoint_every=args.checkpoint_every,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.9.12"
+__version__ = "4.10.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_apl_subtype_key_genes.py
+++ b/tests/test_apl_subtype_key_genes.py
@@ -1,0 +1,61 @@
+"""Tests for APL (acute promyelocytic leukaemia) subtype curation
+within LAML (#23 partial).
+
+APL is the chemo-free sub-entity of AML — PML-RARA fusion, ATRA +
+arsenic trioxide as the standard of care. It needs its own subtype
+row set because the treatment landscape diverges sharply from the
+rest of AML (FLT3 / IDH / KMT2A / venetoclax blocks)."""
+
+from pirlygenes.gene_sets_cancer import (
+    cancer_biomarker_genes,
+    cancer_therapy_targets,
+    cancer_key_genes_subtypes,
+)
+
+
+def test_laml_has_apl_subtype():
+    assert "apl" in cancer_key_genes_subtypes("LAML")
+
+
+def test_apl_biomarkers_include_pml_rara_fusion_partners():
+    bm = cancer_biomarker_genes("LAML", subtype="apl")
+    assert "PML" in bm
+    assert "RARA" in bm
+    # FLT3-ITD co-mutation is the canonical hyperleukocytosis flag
+    # within APL — separate from the broader FLT3 biomarker role in
+    # non-APL AML.
+    assert "FLT3" in bm
+
+
+def test_apl_targets_include_atra_and_arsenic_trioxide():
+    tg = cancer_therapy_targets("LAML", subtype="apl")
+    agents = set(tg["agent"].astype(str).str.lower())
+    assert "tretinoin" in agents
+    assert "arsenic trioxide" in agents
+    approved_agents = set(
+        tg[tg["phase"] == "approved"]["agent"].astype(str).str.lower()
+    )
+    assert "tretinoin" in approved_agents
+    assert "arsenic trioxide" in approved_agents
+
+
+def test_apl_subtype_filter_excludes_non_apl_laml_rows():
+    """Subtype filter must isolate APL rows — FLT3 / IDH inhibitors
+    that belong to the broader AML panel should not leak into the
+    APL subtype view."""
+    apl_targets = cancer_therapy_targets("LAML", subtype="apl")
+    agents = set(apl_targets["agent"].astype(str).str.lower())
+    # These are broader-AML agents, not APL-specific.
+    assert "midostaurin" not in agents
+    assert "gilteritinib" not in agents
+    assert "ivosidenib" not in agents
+    assert "venetoclax" not in agents
+
+
+def test_laml_unfiltered_still_includes_both_apl_and_non_apl():
+    """Back-compat: unfiltered cancer_therapy_targets('LAML') returns
+    the union including APL + the rest of AML."""
+    all_laml = cancer_therapy_targets("LAML")
+    agents = set(all_laml["agent"].astype(str).str.lower())
+    assert "tretinoin" in agents
+    assert "midostaurin" in agents  # non-APL

--- a/tests/test_tcga_decompose.py
+++ b/tests/test_tcga_decompose.py
@@ -1,0 +1,139 @@
+"""Tests for the offline TCGA deconvolution helpers (#21).
+
+The heavy decompose_sample path needs the full TPM matrix and is
+exercised by the maintainer's offline batch run, not by CI. These
+tests cover the pure helpers: sample-barcode parsing, primary-tumor
+filter, selection with cancer-type / per-type caps, and the
+per-type aggregation.
+"""
+
+import pandas as pd
+import pytest
+
+from pirlygenes.tcga_decompose import (
+    aggregate_per_type,
+    is_primary_tumor_sample,
+    sample_barcode_to_project,
+    select_samples,
+)
+
+
+def test_sample_barcode_extracts_patient_prefix():
+    patient_to_project = {"TCGA-XX-YYYY": "BRCA"}
+    assert sample_barcode_to_project("TCGA-XX-YYYY-01", patient_to_project) == "BRCA"
+    assert sample_barcode_to_project("TCGA-XX-YYYY-11A", patient_to_project) == "BRCA"
+
+
+def test_sample_barcode_unknown_returns_none():
+    assert sample_barcode_to_project("TCGA-AA-BBBB-01", {}) is None
+
+
+def test_sample_barcode_non_tcga_returns_none():
+    assert sample_barcode_to_project("GTEX-N7MS-01", {"TCGA-XX-YYYY": "BRCA"}) is None
+
+
+def test_primary_tumor_sample_codes():
+    assert is_primary_tumor_sample("TCGA-XX-YYYY-01")
+    assert is_primary_tumor_sample("TCGA-XX-YYYY-01A")
+    # 03 / 09 = primary blood cancer types.
+    assert is_primary_tumor_sample("TCGA-XX-YYYY-03")
+    assert is_primary_tumor_sample("TCGA-XX-YYYY-09")
+    # Normals and metastases must not pass the filter.
+    assert not is_primary_tumor_sample("TCGA-XX-YYYY-11")  # solid normal
+    assert not is_primary_tumor_sample("TCGA-XX-YYYY-10")  # blood normal
+    assert not is_primary_tumor_sample("TCGA-XX-YYYY-06")  # met
+    # Malformed barcode.
+    assert not is_primary_tumor_sample("TCGA-XX-YYYY")
+
+
+def test_select_samples_filters_normals_and_other_types():
+    columns = pd.Index(
+        [
+            "TCGA-A1-A0SB-01",  # BRCA primary
+            "TCGA-A1-A0SB-11",  # BRCA normal — skip
+            "TCGA-19-1787-01",  # GBM primary
+            "TCGA-OR-A5LF-06",  # ACC metastasis — skip
+        ]
+    )
+    patient_to_project = {
+        "TCGA-A1-A0SB": "BRCA",
+        "TCGA-19-1787": "GBM",
+        "TCGA-OR-A5LF": "ACC",
+    }
+    pairs = select_samples(columns, patient_to_project)
+    assert ("TCGA-A1-A0SB-01", "BRCA") in pairs
+    assert ("TCGA-19-1787-01", "GBM") in pairs
+    assert not any(code == "ACC" for _, code in pairs)
+    assert not any(b.endswith("-11") for b, _ in pairs)
+
+
+def test_select_samples_per_type_cap():
+    columns = pd.Index(
+        [
+            "TCGA-AA-0001-01",
+            "TCGA-AA-0002-01",
+            "TCGA-AA-0003-01",
+            "TCGA-BB-0001-01",
+        ]
+    )
+    patient_to_project = {
+        "TCGA-AA-0001": "BRCA",
+        "TCGA-AA-0002": "BRCA",
+        "TCGA-AA-0003": "BRCA",
+        "TCGA-BB-0001": "GBM",
+    }
+    pairs = select_samples(
+        columns, patient_to_project, max_samples_per_type=2
+    )
+    brca = [b for b, code in pairs if code == "BRCA"]
+    gbm = [b for b, code in pairs if code == "GBM"]
+    assert len(brca) == 2
+    assert len(gbm) == 1
+
+
+def test_select_samples_cancer_type_filter():
+    columns = pd.Index(["TCGA-A1-A0SB-01", "TCGA-19-1787-01"])
+    patient_to_project = {
+        "TCGA-A1-A0SB": "BRCA",
+        "TCGA-19-1787": "GBM",
+    }
+    pairs = select_samples(
+        columns, patient_to_project, cancer_types=["GBM"]
+    )
+    assert pairs == [("TCGA-19-1787-01", "GBM")]
+
+
+def test_aggregate_per_type_basic_stats():
+    per_sample = pd.DataFrame(
+        [
+            {"sample": "s1", "cancer_code": "BRCA", "symbol": "TP53", "tumor_tpm": 10.0},
+            {"sample": "s2", "cancer_code": "BRCA", "symbol": "TP53", "tumor_tpm": 20.0},
+            {"sample": "s3", "cancer_code": "BRCA", "symbol": "TP53", "tumor_tpm": 30.0},
+            {"sample": "s4", "cancer_code": "BRCA", "symbol": "TP53", "tumor_tpm": 40.0},
+            {"sample": "s1", "cancer_code": "GBM", "symbol": "TP53", "tumor_tpm": 5.0},
+        ]
+    )
+    summary = aggregate_per_type(per_sample)
+    brca = summary[(summary["cancer_code"] == "BRCA") & (summary["symbol"] == "TP53")].iloc[0]
+    assert brca["tumor_tpm_median"] == pytest.approx(25.0)
+    assert brca["tumor_tpm_q1"] == pytest.approx(17.5)
+    assert brca["tumor_tpm_q3"] == pytest.approx(32.5)
+    assert brca["n_samples"] == 4
+    gbm = summary[summary["cancer_code"] == "GBM"].iloc[0]
+    assert gbm["n_samples"] == 1
+
+
+def test_aggregate_per_type_empty_input():
+    empty = pd.DataFrame(
+        columns=["sample", "cancer_code", "symbol", "tumor_tpm"]
+    )
+    summary = aggregate_per_type(empty)
+    assert list(summary.columns) == [
+        "symbol",
+        "cancer_code",
+        "tumor_tpm_median",
+        "tumor_tpm_q1",
+        "tumor_tpm_q3",
+        "n_samples",
+    ]
+    assert len(summary) == 0

--- a/tests/test_tcga_deconvolved_expression.py
+++ b/tests/test_tcga_deconvolved_expression.py
@@ -1,0 +1,87 @@
+"""Tests for the #22 deconvolved-TCGA reference columns.
+
+#22 adds ``tcga_<CODE>`` columns to :func:`pan_cancer_expression`
+sourced from the offline-deconvolved CSV shipped in ``data/``. These
+tests exercise both the present-CSV and absent-CSV paths without
+requiring the real ~2 MB reference CSV to be in the repo.
+"""
+
+import pandas as pd
+import pytest
+
+import pirlygenes.gene_sets_cancer as gsc
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch):
+    """Each test starts with empty pan-cancer / deconv caches."""
+    gsc._PAN_CANCER_CACHE.clear()
+    # _tcga_deconv_wide closes over a default-arg dict; reset by
+    # clearing the ``cache`` kwarg's container.
+    gsc._tcga_deconv_wide.__defaults__[0].clear()
+    yield
+    gsc._PAN_CANCER_CACHE.clear()
+    gsc._tcga_deconv_wide.__defaults__[0].clear()
+
+
+def test_absent_deconv_csv_is_graceful(monkeypatch):
+    """Without the deconv CSV, pan_cancer_expression returns the
+    usual frame with no tcga_ columns."""
+    monkeypatch.setattr(gsc, "tcga_deconvolved_expression", lambda: None)
+    df = gsc.pan_cancer_expression()
+    assert not any(c.startswith("tcga_") for c in df.columns)
+    assert any(c.startswith("FPKM_") for c in df.columns)
+
+
+def test_present_deconv_csv_adds_tcga_columns(monkeypatch):
+    synthetic = pd.DataFrame(
+        [
+            {"symbol": "KLK3", "cancer_code": "PRAD", "tumor_tpm_median": 11000.0,
+             "tumor_tpm_q1": 5500.0, "tumor_tpm_q3": 16000.0, "n_samples": 30},
+            {"symbol": "KLK3", "cancer_code": "BRCA", "tumor_tpm_median": 0.1,
+             "tumor_tpm_q1": 0.0, "tumor_tpm_q3": 0.5, "n_samples": 30},
+            {"symbol": "ERBB2", "cancer_code": "BRCA", "tumor_tpm_median": 150.0,
+             "tumor_tpm_q1": 80.0, "tumor_tpm_q3": 300.0, "n_samples": 30},
+        ]
+    )
+    monkeypatch.setattr(gsc, "tcga_deconvolved_expression", lambda: synthetic)
+    df = gsc.pan_cancer_expression(genes=["KLK3", "ERBB2"])
+    tcga_cols = [c for c in df.columns if c.startswith("tcga_")]
+    assert "tcga_PRAD" in tcga_cols
+    assert "tcga_BRCA" in tcga_cols
+
+    klk3 = df[df["Symbol"] == "KLK3"].iloc[0]
+    assert klk3["tcga_PRAD"] == pytest.approx(11000.0)
+    assert klk3["tcga_BRCA"] == pytest.approx(0.1)
+
+    erbb2 = df[df["Symbol"] == "ERBB2"].iloc[0]
+    assert erbb2["tcga_BRCA"] == pytest.approx(150.0)
+    # ERBB2 missing from PRAD in the synthetic frame → NaN is the
+    # correct merge outcome, not 0.
+    assert pd.isna(erbb2["tcga_PRAD"])
+
+
+def test_tcga_columns_participate_in_percentile_normalize(monkeypatch):
+    """Percentile normalize must treat tcga_ columns the same as FPKM_."""
+    synthetic = pd.DataFrame(
+        [
+            {"symbol": "KLK3", "cancer_code": "PRAD", "tumor_tpm_median": 11000.0,
+             "tumor_tpm_q1": 0.0, "tumor_tpm_q3": 0.0, "n_samples": 30},
+            {"symbol": "GAPDH", "cancer_code": "PRAD", "tumor_tpm_median": 500.0,
+             "tumor_tpm_q1": 0.0, "tumor_tpm_q3": 0.0, "n_samples": 30},
+        ]
+    )
+    monkeypatch.setattr(gsc, "tcga_deconvolved_expression", lambda: synthetic)
+    df = gsc.pan_cancer_expression(normalize="percentile")
+    assert "tcga_PRAD" in df.columns
+    # Values are percentile ranks in [0, 100].
+    s = df["tcga_PRAD"].dropna()
+    assert (s.min() >= 0) and (s.max() <= 100)
+
+
+def test_tcga_deconvolved_expression_returns_none_when_missing(monkeypatch):
+    """Raising ValueError from get_data must be swallowed as None."""
+    def _missing(_name):
+        raise ValueError("Dataset tcga-deconvolved-expression not found")
+    monkeypatch.setattr(gsc, "get_data", _missing)
+    assert gsc.tcga_deconvolved_expression() is None


### PR DESCRIPTION
## Summary

- **#21 TCGA offline deconvolution**: ships \`pirlygenes/tcga_decompose.py\` — an offline batch script that runs the pirlygenes decomposition engine on every TCGA sample in the Xena TOIL RSEM TPM matrix, extracts tumor-only TPM per gene, and aggregates per TCGA code to median + IQR. Invoked as \`python -m pirlygenes.tcga_decompose\`; not imported at runtime. Ships 9 tests for the pure helpers (sample-barcode parsing, primary-tumor filter, per-type selection caps, aggregation).
- **#22 deconvolved-TCGA reference**: \`pan_cancer_expression()\` now merges \`tcga_<CODE>\` tumor-only columns when \`data/tcga-deconvolved-expression.csv\` is shipped. The CSV is produced by #21; the breaking swap of \`FPKM_<CODE>\` → \`tcga_<CODE>\` is reserved for v5. Absent-CSV path is unchanged — back-compat for fresh checkouts. 4 tests cover present/absent paths.
- **#23 APL subtype (partial)**: LAML now tiles the APL (M3) subtype — PML + RARA + FLT3 biomarkers, tretinoin (ATRA) + arsenic trioxide approved targets. The subtype filter isolates APL rows from the broader-AML FLT3 / IDH / menin panels. 5 tests. Sarcoma-subtype half of #23 already shipped via #142 (Tranche B); CLL half remains open — it's non-TCGA-indexed so needs a separate baseline.

## Test plan

- [x] \`pytest\` full suite — 462 passed, 1 skipped
- [x] \`python -m pirlygenes.tcga_decompose --cancer-types PRAD,BRCA --max-samples-per-type 2\` smoke-run produced plausible tumor TPM (KLK3 median ~11K for PRAD, ERBB2 ~151 for BRCA)
- [x] \`pan_cancer_expression()\` with and without the deconv CSV — 85 cols (pre-merge) unchanged when CSV absent, \`tcga_<CODE>\` cols added when present

## Notes

- The offline batch producing the bundled \`data/tcga-deconvolved-expression.csv\` is running in the background locally and will be dropped in as a follow-up commit — the wiring here works on the absent-CSV path, so this PR is shippable without blocking on the 1.5-hour decomposition run.
- Closes #18, #19, #20, #17 already — they were shipped earlier and were closed as part of this audit pass.
- Addresses #21, #22; partially addresses #23 (APL half).