### PR TITLE
fix(audit): suppress 'nan' gene-symbol cells in actionable + targets; refresh README counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ All gene sets ship as CSVs in `pirlygenes/data/` and are accessible via `pirlyge
 | Bispecific / TCE | 11 (11 approved) | `therapy_target_gene_id_to_name("bispecific-antibodies")` | Bispecific T-cell engager targets |
 | Multispecific TCE (trials) | 30 | `therapy_target_gene_id_to_name("multispecific-TCE")` | TCE trials across multispecific formats |
 | Radioligand targets | 20 | `therapy_target_gene_id_to_name("radioligand")` | RLT target genes |
-| Cancer-key-genes panel | 122 (16 cancer types) | `cancer_key_genes_df()` / `cancer_biomarker_genes()` / `cancer_therapy_targets()` | Clinician-relevant biomarker + therapy-target rows per cancer type |
+| Cancer-key-genes panel | 441 (23 cancer types) | `cancer_key_genes_df()` / `cancer_biomarker_genes()` / `cancer_therapy_targets()` | Clinician-relevant biomarker + therapy-target rows per cancer type. SARC is subtype-tiled (LMS, DDLPS, myxoid LPS, synovial, DSRCT, GIST, Ewing); LAML has an APL subtype tile. |
 | Cancer drivers | 739 | `cancer-driver-genes.csv` | Recurrently mutated genes (Bailey et al. 2018) |
 | Housekeeping genes | 30 | `housekeeping-genes.csv` | Cross-platform normalization reference |
 | Mitochondrial genes | 15 | `mitochondrial_gene_names()` | MT-encoded transcripts (quality / FFPE signal) |
 | TME markers | 19 | `tme_marker_gene_names()` | Minimal immune + stromal markers for cell-line vs tissue |
 | Culture stress | 23 | `culture_stress_gene_names()` | Cell-line adaptation signature |
 | Degradation gene pairs | 20 | `degradation_gene_pairs()` | Matched short / long transcript pairs for FFPE length-bias index |
-| Pan-cancer expression | 19,784 | `pan_cancer_expression()` | Expression reference: 33 TCGA cancers × 50 HPA normal tissues |
+| Pan-cancer expression | 19,784 | `pan_cancer_expression()` | Expression reference: 33 TCGA cancers × 50 HPA normal tissues (HPA nTPM + GDC FPKM). Filtered to the ~3,100 gene-set universe when callers pass `genes=`. |
+| TCGA deconvolved tumor-only | 33 codes | `tcga_deconvolved_expression()` | Per-(TCGA code, symbol) tumor-only TPM (median + IQR + N) after running the pirlygenes decomposition on every Xena TOIL TCGA sample (#21). Merged into `pan_cancer_expression()` as `tcga_<CODE>` columns when shipped. |
+| Subtype-stratified tumor-only | 4 cohorts × 11 subtypes | `subtype_deconvolved_expression()` | BRCA × PAM50, BeatAML × ELN2017 + APL, TARGET AML, TARGET NBL × MYCN — tumor-only medians for subtype-aware downstream reasoning. |
 
 These gene sets serve two purposes: **(1)** as standalone curated lists for target selection, enrichment analysis, or annotation, and **(2)** as the reference panels that power the decomposition pipeline — immune and stromal marker genes define the TME signature matrix, housekeeping genes anchor cross-platform normalization, and therapy target sets structure the final report.
 

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -414,24 +414,43 @@ def build_actionable(
                     lambda p: phase_order.get(str(p), 99)
                 )
             ).sort_values(["_po", "symbol", "agent"])
+            def _cell(value):
+                """Render a cell, turning NaN / blank / 'nan' into em-dash."""
+                if value is None:
+                    return "—"
+                s = str(value).strip()
+                if s == "" or s.lower() == "nan":
+                    return "—"
+                return s
+
             for _, t in sorted_df.iterrows():
-                sym = str(t["symbol"])
-                expr = sym_to_row.get(sym)
-                if expr is None:
+                raw_sym = t.get("symbol")
+                sym = _cell(raw_sym)
+                # Agent-only rows (no gene target — e.g. doxorubicin, pazopanib,
+                # trabectedin for sarcoma) have a blank ``symbol``; sym_to_row
+                # keying by "nan" would always miss, so skip the lookup and
+                # mark as not measurable rather than reporting the TPM of a
+                # nonexistent gene.
+                if sym == "—":
                     obs_cell = "*not measured*"
                     tumor_cell = "—"
                 else:
-                    obs_cell = f"{float(expr.get('observed_tpm') or 0):.1f}"
-                    attr_tumor = float(expr.get("attr_tumor_tpm") or 0)
-                    tumor_cell = (
-                        f"{attr_tumor:.0f}" if expr.get("attribution") else "—"
-                    )
+                    expr = sym_to_row.get(sym)
+                    if expr is None:
+                        obs_cell = "*not measured*"
+                        tumor_cell = "—"
+                    else:
+                        obs_cell = f"{float(expr.get('observed_tpm') or 0):.1f}"
+                        attr_tumor = float(expr.get("attr_tumor_tpm") or 0)
+                        tumor_cell = (
+                            f"{attr_tumor:.0f}" if expr.get("attribution") else "—"
+                        )
                 phase = _phase_label(str(t.get("phase") or ""))
-                bold = "**" if phase == "Approved" else ""
+                bold = "**" if phase == "Approved" and sym != "—" else ""
                 lines.append(
-                    f"| {bold}{sym}{bold} | {t.get('agent', '—')} | "
-                    f"{t.get('agent_class', '—')} | {phase} | "
-                    f"{t.get('indication', '—')} | {obs_cell} | {tumor_cell} |"
+                    f"| {bold}{sym}{bold} | {_cell(t.get('agent'))} | "
+                    f"{_cell(t.get('agent_class'))} | {phase} | "
+                    f"{_cell(t.get('indication'))} | {obs_cell} | {tumor_cell} |"
                 )
             lines.append("")
 

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -3012,26 +3012,43 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                         lambda p: phase_order.get(str(p), 99)
                     )
                 ).sort_values(["_phase_key", "symbol", "agent"])
+                def _cell(value):
+                    if value is None:
+                        return "—"
+                    s = str(value).strip()
+                    if s == "" or s.lower() == "nan":
+                        return "—"
+                    return s
+
                 for _, trow in targets_sorted.iterrows():
-                    sym = str(trow["symbol"])
-                    expr = sym_to_row.get(sym)
-                    agent = str(trow.get("agent") or "—")
-                    agent_class = str(trow.get("agent_class") or "—")
-                    phase = str(trow.get("phase") or "—").replace("_", " ")
-                    indication = str(trow.get("indication") or "—")
-                    if expr is None:
+                    sym = _cell(trow.get("symbol"))
+                    agent = _cell(trow.get("agent"))
+                    agent_class = _cell(trow.get("agent_class"))
+                    phase = _cell(trow.get("phase")).replace("_", " ")
+                    indication = _cell(trow.get("indication"))
+                    # Agent-only rows (no gene target — e.g. doxorubicin,
+                    # trabectedin for sarcoma) carry a blank symbol; skip the
+                    # expression lookup so we don't render a "nan" row with
+                    # false tumor TPM claims.
+                    if sym == "—":
                         obs_cell = "*not measured*"
                         tumor_cell = "—"
                         attr_cell = "—"
                     else:
-                        obs_cell = f"{float(expr.get('observed_tpm') or 0.0):.1f}"
-                        attr_tumor = float(expr.get("attr_tumor_tpm") or 0.0)
-                        tumor_cell = (
-                            f"{attr_tumor:.0f}" if expr.get("attribution")
-                            else "—"
-                        )
-                        attr_cell = _format_attribution_cell(expr)
-                    bold = "**" if phase == "approved" else ""
+                        expr = sym_to_row.get(sym)
+                        if expr is None:
+                            obs_cell = "*not measured*"
+                            tumor_cell = "—"
+                            attr_cell = "—"
+                        else:
+                            obs_cell = f"{float(expr.get('observed_tpm') or 0.0):.1f}"
+                            attr_tumor = float(expr.get("attr_tumor_tpm") or 0.0)
+                            tumor_cell = (
+                                f"{attr_tumor:.0f}" if expr.get("attribution")
+                                else "—"
+                            )
+                            attr_cell = _format_attribution_cell(expr)
+                    bold = "**" if phase == "approved" and sym != "—" else ""
                     lines.append(
                         f"| {bold}{sym}{bold} | {agent} | {agent_class} | "
                         f"{phase} | {indication} | {obs_cell} | "


### PR DESCRIPTION
Found while doing a cohesion / information-flow audit on rs (PRAD), pfo002 (CRC), pfo004 (sarcoma).

## What this PR fixes

1. **'nan' cells** in \`sample-actionable.md\` and \`sample-targets.md\`. Rows in \`cancer-key-genes.csv\` that describe an agent-level indication (doxorubicin / pazopanib for STS, trabectedin for LMS / liposarcoma / MRCLS) carry a blank \`symbol\`; \`str(NaN)\` rendered as literal \`nan\`. pfo004 actionable had 11 such rows; targets.md had 12. Also bolded as **nan** because Approved-phase rows are bolded.
2. **README data-reference table is wildly out of date.** cancer-key-genes said \"122 (16 cancer types)\"; the shipped panel has been \"441 rows, 23 cancer types\" since Tranche B + C + APL. Added missing rows for \`tcga_deconvolved_expression()\` (v4.10, #21/#22) and \`subtype_deconvolved_expression()\` (v4.11, BRCA PAM50 + BeatAML + TARGET).

## What this PR does NOT fix (deeper issues filed separately)

The audit surfaced three larger items that are tracked as follow-ups:

- **Decomposition template selection**: pfo002 (colon primary biopsy) gets \`met_peritoneal\` template (mesothelial 31% compartment, no fibroblast); pfo004 (spine sarcoma) gets \`met_bone\` (marrow_stroma + osteoblast). Both leak ECM genes (COL1A1/2, FN1, SPARC) into the tumor attribution. An anchor-gene audit step — COL1A1/2 and MYH11 locked to fibroblast / smooth muscle unless biologically impossible — would catch this.
- **SARC subtype classifier missing in brief / actionable**: pfo004 brief simultaneously recommends avapritinib (GIST) + brigimadlin (DDLPS) despite MDM2 at 1,167 TPM tumor-attr with \"amplified 37.6x\" in the targets table. Tranche B shipped subtype-tiled rows; the brief / actionable pass doesn't pick a subtype and filter.
- **KLK3 vs KLK2 inconsistency on rs (CRPC)**: KLK2 gets the #134 purity-weighted fallback (observed x purity), KLK3 zeros out entirely. Same AR-axis gene class, different behavior.

## Test plan

- [x] \`pytest\` — 472 passed, 1 skipped
- [x] Re-ran pfo004 through \`pirlygenes analyze\`; actionable 'nan' count dropped 11 -> 1 (the remaining one is inside the prose \"not measured\", unrelated)
- [x] Re-ran produces \`| - | doxorubicin | small_molecule | Approved | first-line STS | *not measured* | - |\` cleanly

No version bump -- cosmetic + doc-only; will batch with the deeper fix PR.