### PR TITLE
fix(reports): battery-audit punch list — 7 report-correctness bugs

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -454,6 +454,53 @@ def _filter_quality_flags_against_context(flags, sample_context):
     return out
 
 
+def _render_vs_tcga_cell(row):
+    """Render the "vs TCGA" column for a target-table row.
+
+    The naive ``render_fold(row["pct_cancer_median"])`` produces ``∞×``
+    whenever the TCGA cohort's tumor-component deconvolves to ~0 for
+    this gene — which happens in two biologically distinct cases:
+
+    - **not_in_cohort**: the raw cohort median is itself ~0 (the gene
+      genuinely isn't expressed at cohort median — the CTA-in-solid-
+      cohort case). Here ``∞×`` is not wrong but is degenerate for a
+      clinician; instead show the raw cohort TPM so the reader sees
+      "gene is absent from the reference cohort".
+    - **tme_explained**: the raw cohort was non-trivial but the TME
+      deconvolution zeroed the tumor component. The ratio isn't
+      meaningful because the deconvolution subtracted everything;
+      label as "TME-only" with the raw cohort TPM for context.
+
+    Keeps the column narrow; preserves information rather than capping.
+    """
+    import math as _math
+    import pandas as _pd
+    state = row.get("tcga_ref_state")
+    vs_tcga = row.get("pct_cancer_median")
+    cohort_tpm = row.get("tcga_cohort_median_tpm")
+
+    if state == "finite" and _pd.notna(vs_tcga):
+        return render_fold(vs_tcga)
+    if state == "not_in_cohort":
+        if cohort_tpm is not None and cohort_tpm > 0:
+            return f"ref {cohort_tpm:.2f} TPM"
+        return "ref 0"
+    if state == "tme_explained":
+        if cohort_tpm is not None:
+            return f"TME-only ({cohort_tpm:.1f} TPM)"
+        return "TME-only"
+    if state == "both_absent":
+        return "—"
+    # Back-compat: when tcga_ref_state is missing (older ranges_df),
+    # fall back to the raw fold. Inf still lands here and renders ∞×;
+    # new runs always set the state.
+    if vs_tcga is None or (isinstance(vs_tcga, float) and _math.isinf(vs_tcga)):
+        if cohort_tpm is not None and cohort_tpm > 0:
+            return f"ref {cohort_tpm:.2f} TPM"
+        return "ref 0"
+    return render_fold(vs_tcga) if _pd.notna(vs_tcga) else "—"
+
+
 def _format_attribution_cell(row):
     """Compact per-target Attribution cell for targets.md (#108, #128).
 
@@ -1224,8 +1271,31 @@ def _analyze_body(
     effective_purity = purity
     if decomp_results:
         best_decomp = decomp_results[0]
-        effective_cancer_type = best_decomp.cancer_type
-        effective_purity = best_decomp.purity_result or purity
+        # The classifier's top call (``cancer_code``) is the authoritative
+        # cancer-type identification across every downstream report; the
+        # decomposer only fits *subtraction templates* to separate tumor
+        # from TME. When the best-fit template belongs to a different
+        # cancer type than the classifier's call that's a decomposition-
+        # fit observation, not a re-classification — do NOT overwrite
+        # effective_cancer_type here (prior behavior leaked the template
+        # label into brief/actionable/targets and recommended BRCA agents
+        # on a COAD sample).
+        #
+        # The decomp's purity is only safe to adopt when its cancer_type
+        # matches the classifier AND its template has non-tumor
+        # compartments. A template without TME compartments trivially
+        # returns fraction=1.0 (everything maps to tumor by construction),
+        # which is not a purity measurement — pfo002 / BRCA template was
+        # the failure case: classifier said 36% (COAD), but BRCA template
+        # with "No non-tumor components in template" warning returned
+        # fraction=100% and that propagated as the headline purity.
+        decomp_agrees = (best_decomp.cancer_type == cancer_code)
+        decomp_has_tme = not any(
+            "No non-tumor components in template" in w
+            for w in (best_decomp.warnings or [])
+        )
+        if decomp_agrees and decomp_has_tme and best_decomp.purity_result:
+            effective_purity = best_decomp.purity_result
 
         # Propagate a lineage-panel purity override back into
         # ``analysis["purity"]`` so every downstream report is
@@ -2487,8 +2557,13 @@ def _generate_text_reports(
     hvt = analysis.get("healthy_vs_tumor")
     stage0_section = ""
     if hvt is not None and hvt.top_normal_tissues:
+        trace_clause = (
+            f" *Rule: {' → '.join(hvt.reasoning_trace)}.*"
+            if hvt.reasoning_trace else ""
+        )
         stage0_section = (
-            f"\n**Stage-0 tissue composition**: {hvt.summary_line()}\n"
+            f"\n**Stage-0 tissue composition**: "
+            f"{hvt.summary_line()}{trace_clause}\n"
         )
     with open(summary_path, "w") as f:
         f.write(f"{header}{stage0_section}\n{summary}\n")
@@ -2508,12 +2583,14 @@ def _generate_text_reports(
     # analysis.md read sees the Stage-0 prior inline.
     hvt = analysis.get("healthy_vs_tumor")
     if hvt is not None and hvt.top_normal_tissues:
+        from .gene_sets_cancer import proliferation_panel_gene_names
+        _prolif_panel_size = len(proliferation_panel_gene_names())
         lines.append("## Stage-0 tissue composition\n")
         lines.append(f"- **Cancer hint**: {hvt.cancer_hint}")
         lines.append(
             f"- **Proliferation panel**: "
             f"{hvt.proliferation_log2_mean:.2f} log2-TPM mean across "
-            f"{hvt.proliferation_genes_observed}/5 genes observed"
+            f"{hvt.proliferation_genes_observed}/{_prolif_panel_size} genes observed"
         )
         hpa_line = ", ".join(
             f"{t.replace('nTPM_', '').replace('_', ' ')} (ρ={rho:.2f})"
@@ -2525,6 +2602,15 @@ def _generate_text_reports(
             for t, rho in hvt.top_tcga_cohorts[:3]
         )
         lines.append(f"- **Top TCGA cohort matches**: {tcga_line}")
+        # Surface the reasoning trace (which rule fired + rationale)
+        # so a reader can audit how Stage-0 arrived at the hint.
+        if hvt.reasoning_trace:
+            lines.append(
+                f"- **Reasoning rule**: {' → '.join(hvt.reasoning_trace)}"
+            )
+        # Full tumor-evidence breakdown (per-channel scores + aggregate)
+        # so the hint isn't a black box.
+        lines.append(f"- **Evidence**: {hvt.evidence.synthesis()}")
         lines.append("")
 
     # Input characterization (#68) — surfaced before quality/decomp so
@@ -2855,12 +2941,24 @@ def _generate_text_reports(
             retained = sorted_genes
             lost = []
 
-        # Not found in sample
+        # Not found in sample — but distinguish genuinely absent from
+        # detected-but-uninformative. The estimator skips lineage genes
+        # whose TME bleed-through in the reference exceeds their tumor
+        # contribution; those genes are still present in the sample at
+        # real TPM, they just can't anchor a lineage purity. pfo004 /
+        # SARC / ACTA2 is the canonical case.
         from .tumor_purity import LINEAGE_GENES
         cancer_code_local = purity.get("cancer_type", cancer_code)
         all_lineage = LINEAGE_GENES.get(cancer_code_local, [])
         found_names = {g["gene"] for g in lineage_genes}
-        not_found = [g for g in all_lineage if g not in found_names]
+        skipped_detected = {
+            entry["gene"]: entry
+            for entry in lineage.get("skipped_detected", [])
+        }
+        not_found = [
+            g for g in all_lineage
+            if g not in found_names and g not in skipped_detected
+        ]
 
         lines.append(
             "**Purity est.** per row = an independent purity estimate from that "
@@ -2880,6 +2978,16 @@ def _generate_text_reports(
                 interp = "likely de-differentiated"
             lines.append(
                 f"| {g['gene']} | {g['purity']:.1%} | {interp} |"
+            )
+        for gene_name, entry in skipped_detected.items():
+            s_tpm = entry["sample_tpm"]
+            # Keep resolution proportional to magnitude so a 0.3 TPM
+            # gene doesn't render as "0 TPM".
+            tpm_str = f"{s_tpm:.1f}" if s_tpm < 10 else f"{s_tpm:.0f}"
+            lines.append(
+                f"| {gene_name} | — | detected {tpm_str} TPM — "
+                "uninformative (TME background exceeds tumor contribution "
+                "for this cancer type) |"
             )
         for g in not_found:
             lines.append(f"| {g} | — | not detected |")
@@ -3445,13 +3553,12 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         lines.append("|------|-----------|-------|----------|---------|-----------|-----|---------|-----------|")
         for _, row in ctas.head(20).iterrows():
             surf = "yes" if row["is_surface"] else ""
-            vs_tcga = row["pct_cancer_median"] if pd.notna(row["pct_cancer_median"]) else None
             tme_warn = "⚠" if row.get("tme_explainable") else ""
             lines.append(
                 f"| **{row['symbol']}** | {render_tpm(row['median_est'])} | "
                 f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
                 f"{render_tpm(row['observed_tpm'])} | "
-                f"{render_fold(vs_tcga)} | "
+                f"{_render_vs_tcga_cell(row)} | "
                 f"{render_fraction_no_decimal(row['tcga_percentile'])} | "
                 f"{tme_warn} | {surf} | {row['therapies']} |"
             )
@@ -3501,7 +3608,6 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         )
         for _, row in surface_targets.head(20).iterrows():
             bold = "**" if row["therapies"] else ""
-            vs_tcga = row["pct_cancer_median"] if pd.notna(row["pct_cancer_median"]) else None
             # TME flag — compact key:
             #   ⚠⚠ = ``tme_dominant`` (observed signal is mostly non-
             #   tumor per the decomposition attribution, #108); ⚠ =
@@ -3524,7 +3630,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                 f"| {bold}{row['symbol']}{bold} | {render_tpm(row['median_est'])} | "
                 f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
                 f"{render_tpm(row['observed_tpm'])} | "
-                f"{render_fold(vs_tcga)} | "
+                f"{_render_vs_tcga_cell(row)} | "
                 f"{render_fraction_no_decimal(row['tcga_percentile'])} | "
                 f"{tme_warn} | {attribution_cell} | {therapies_cell} |"
             )
@@ -3577,13 +3683,12 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         lines.append("|------|-----------|-------|---------|-----------|-----|-------------|-----|-----------|")
         for _, row in intracellular.head(15).iterrows():
             cta_flag = "yes" if row["is_cta"] else ""
-            vs_tcga = row["pct_cancer_median"] if pd.notna(row["pct_cancer_median"]) else None
             tme_warn = "⚠" if row.get("tme_explainable") else ""
             attribution_cell = _format_attribution_cell(row)
             lines.append(
                 f"| {row['symbol']} | {render_tpm(row['median_est'])} | "
                 f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
-                f"{render_fold(vs_tcga)} | "
+                f"{_render_vs_tcga_cell(row)} | "
                 f"{render_fraction_no_decimal(row['tcga_percentile'])} | "
                 f"{tme_warn} | {attribution_cell} | {cta_flag} | {row['therapies']} |"
             )

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import warnings
 
 from .load_dataset import get_data

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -691,6 +693,14 @@ def estimate_tumor_expression_ranges(
         cancer_col = f"FPKM_{cancer_code}"
         cohort_prior_tpm = 0.0
         tcga_tumor_fold = 0.0
+        # Raw cohort median TPM in HK-normalized space (before TME
+        # deconvolution). Kept separate so a downstream renderer can
+        # distinguish "cohort genuinely doesn't express this gene" from
+        # "cohort median was TME-only and got subtracted to zero" —
+        # both currently collapse to ∞× fold, which is degenerate for
+        # a clinician-facing table.
+        tcga_fold_raw = 0.0
+        tcga_cohort_tpm_raw = None  # None = gene not in ref (not_measurable)
         if (
             cancer_col in ref_dedup.columns
             and cancer_col in ref_hk_medians
@@ -698,6 +708,8 @@ def estimate_tumor_expression_ranges(
         ):
             cancer_hk_m = ref_hk_medians[cancer_col]
             tcga_fold = float(ref_dedup.loc[symbol, cancer_col]) / cancer_hk_m
+            tcga_fold_raw = tcga_fold
+            tcga_cohort_tpm_raw = float(ref_dedup.loc[symbol, cancer_col])
             tcga_p = TCGA_MEDIAN_PURITY.get(cancer_code, 0.7)
             tcga_tumor_fold = max(
                 0.0, (tcga_fold - (1 - tcga_p) * tme_fold_med) / tcga_p
@@ -794,12 +806,29 @@ def estimate_tumor_expression_ranges(
         # label instead of the intended red "absent in TCGA" alert. The
         # sample-side check below restores the intended semantics.
         our_tumor_fold = median_est / sample_hk_median
+        # Three diagnostic states for the cohort-reference comparison:
+        #   "finite"        — cohort has detectable tumor component,
+        #                     fold = sample / cohort
+        #   "not_in_cohort" — raw cohort median ≈ 0 (gene genuinely not
+        #                     expressed at cohort median; this is the
+        #                     CTA-in-solid-cohort case)
+        #   "tme_explained" — raw cohort was non-trivial but TME
+        #                     subtraction zeroed the tumor component
+        #   "both_absent"   — neither sample nor cohort expresses
+        # The tumor-expression table can use the state to render a more
+        # informative label than ∞×.
         if tcga_tumor_fold > 0.001:
             vs_tcga = float(our_tumor_fold / tcga_tumor_fold)
+            tcga_ref_state = "finite"
         elif our_tumor_fold > 0.001:
             vs_tcga = float("inf")
+            if tcga_fold_raw <= 0.001:
+                tcga_ref_state = "not_in_cohort"
+            else:
+                tcga_ref_state = "tme_explained"
         else:
             vs_tcga = None
+            tcga_ref_state = "both_absent"
 
         # Categorize
         is_cta = symbol in cta_symbols
@@ -1082,7 +1111,12 @@ def estimate_tumor_expression_ranges(
             "attribution_raw_sum_tpm": round(attr_tme_total_raw, 2),
             **{f"est_{i+1}": round(estimates[i], 2) for i in range(9)},
             "median_est": round(median_est, 2),
-            "pct_cancer_median": round(vs_tcga, 2) if vs_tcga is not None else None,
+            "pct_cancer_median": round(vs_tcga, 2) if vs_tcga is not None and not math.isinf(vs_tcga) else vs_tcga,
+            "tcga_ref_state": tcga_ref_state,
+            "tcga_cohort_median_tpm": (
+                round(tcga_cohort_tpm_raw, 3)
+                if tcga_cohort_tpm_raw is not None else None
+            ),
             "tcga_percentile": round(tcga_percentile, 3),
             "is_surface": is_surface,
             "is_cta": is_cta,

--- a/pirlygenes/sample_quality.py
+++ b/pirlygenes/sample_quality.py
@@ -444,15 +444,31 @@ def assess_sample_quality(df_gene_expr, tissue_scores=None, library_prep=None):
         )
     elif mt_near_zero:
         has_issues = True
-        flags.append(
-            f"Suspicious MT fraction: {mt_fraction:.1%} "
-            f"(n_mt_found={n_mt}/{len(_MT_GENES)}) — mitochondrial genes "
-            "appear filtered or renamed in the input; degradation signal "
-            "is unreliable"
-        )
+        # n_mt==0 and n_mt>0-but-low-fraction are biologically distinct
+        # states. "Filtered or renamed" only applies when the MT symbols
+        # are genuinely absent from the quant table — if 13/15 MT genes
+        # are in the input at low TPM, they weren't filtered; the sample
+        # just has anomalously low MT share (aggressive MT depletion, a
+        # capture panel that under-samples MT contigs, or a genuine
+        # low-MT tissue).
+        if n_mt == 0:
+            flags.append(
+                f"Suspicious MT fraction: {mt_fraction:.1%} "
+                f"(n_mt_found=0/{len(_MT_GENES)}) — mitochondrial genes "
+                "missing from the quant table (filtered or renamed "
+                "upstream); degradation signal is unreliable"
+            )
+        else:
+            flags.append(
+                f"Low MT fraction: {mt_fraction:.1%} "
+                f"(n_mt_found={n_mt}/{len(_MT_GENES)}, genes present but "
+                "contribute minimal TPM) — MT-based degradation signal "
+                "has reduced discriminative power"
+            )
         degradation["level"] = "unknown"
         degradation["message"] = (
-            "MT genes missing or filtered from input — degradation cannot be assessed reliably"
+            "MT fraction too low for reliable degradation assessment "
+            f"(n_mt_found={n_mt}/{len(_MT_GENES)}, fraction={mt_fraction:.1%})"
         )
 
     if deg_level in ("severe", "moderate"):

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -399,7 +399,7 @@ def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga
     """
     genes = LINEAGE_GENES.get(cancer_code, [])
     if not genes:
-        return []
+        return [], []
 
     ref = pan_cancer_expression()
     ref_dedup = ref.drop_duplicates(subset="Symbol").set_index("Symbol")
@@ -433,9 +433,17 @@ def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga
     sample_hk_vals = [sample_tpm[g] for g in hk_syms if sample_tpm.get(g, 0) > 0]
     sample_hk_med = float(np.median(sample_hk_vals)) if sample_hk_vals else 0.0
     if sample_hk_med <= 0:
-        return []
+        return [], []
 
     results = []
+    # Parallel list of lineage genes that were genuinely present in the
+    # sample but dropped by the estimator (TME signal exceeds tumor
+    # signal in the reference, so the gene can't anchor a purity
+    # estimate). Callers can surface these as "uninformative" rather
+    # than "not detected" — the distinction matters for pfo004-style
+    # cases where ACTA2 is at 189 TPM but gets filtered because its
+    # TME-bleed-through in SARC exceeds its tumor contribution.
+    skipped_detected = []
     for gene in genes:
         if gene not in ref_dedup.index:
             continue
@@ -458,6 +466,13 @@ def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga
         true_tumor_ratio = (ref_ratio - (1 - tcga_purity) * tme_ratio) / tcga_purity
 
         if true_tumor_ratio <= tme_ratio:
+            skipped_detected.append({
+                "gene": gene,
+                "sample_tpm": s_tpm,
+                "reason": "tme_dominated",
+                "tme_ratio": float(tme_ratio),
+                "tumor_ratio": float(true_tumor_ratio),
+            })
             continue
 
         purity = (sample_ratio - tme_ratio) / (true_tumor_ratio - tme_ratio)
@@ -473,7 +488,7 @@ def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga
             "purity": purity,
         })
 
-    return results
+    return results, skipped_detected
 
 
 def _summarize_lineage_support(lineage_per_gene):
@@ -1038,7 +1053,7 @@ def estimate_tumor_purity(df_gene_expr, cancer_type=None):
     estimate_purity = float(np.clip(np.sqrt(stromal_purity * immune_purity), 0.0, 1.0))
 
     # ---- Component 3: Lineage gene refinement ----
-    lineage_per_gene = _lineage_purity_estimates(
+    lineage_per_gene, lineage_skipped_detected = _lineage_purity_estimates(
         cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga_purity,
     )
     lineage_purities = sorted(g["purity"] for g in lineage_per_gene if g["purity"] > 0)
@@ -1113,6 +1128,12 @@ def estimate_tumor_purity(df_gene_expr, cancer_type=None):
                 "detection_fraction": lineage_support["detection_fraction"],
                 "support_factor": lineage_support["support_factor"],
                 "per_gene": lineage_per_gene,
+                # Genes that WERE detected in the sample but the
+                # estimator couldn't use for purity (TME dominates).
+                # Consumers can render these as "uninformative" rather
+                # than "not detected" — a calibration signal, not an
+                # absence signal.
+                "skipped_detected": lineage_skipped_detected,
             },
             "stromal": {
                 "enrichment": stromal_enrichment,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.31.0"
+__version__ = "4.32.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_battery_audit_fixes.py
+++ b/tests/test_battery_audit_fixes.py
@@ -1,0 +1,287 @@
+"""Regression tests for the battery-audit fixes (PR #159).
+
+Each bug here was a report-correctness issue found by auditing the
+pfo002 (CRC) and pfo004 (SARC) markdown outputs. These tests pin the
+root-cause fixes so a future refactor can't silently regress them.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pirlygenes.cli import _render_vs_tcga_cell
+from pirlygenes.sample_quality import _MT_GENES, assess_sample_quality
+from pirlygenes.tumor_purity import _lineage_purity_estimates
+
+
+# ── #41: _render_vs_tcga_cell state-dispatch ──────────────────────
+
+
+def _row(**kwargs):
+    """Mimic a pandas Series row using a plain dict (``.get`` works)."""
+    defaults = {
+        "tcga_ref_state": None,
+        "pct_cancer_median": None,
+        "tcga_cohort_median_tpm": None,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def test_render_vs_tcga_finite_state_renders_fold():
+    row = _row(tcga_ref_state="finite", pct_cancer_median=3.5)
+    assert _render_vs_tcga_cell(row) == "3.50\u00d7"
+
+
+def test_render_vs_tcga_not_in_cohort_shows_raw_tpm_when_positive():
+    # CTA case: raw cohort median non-zero but tiny.
+    row = _row(
+        tcga_ref_state="not_in_cohort",
+        pct_cancer_median=float("inf"),
+        tcga_cohort_median_tpm=0.14,
+    )
+    assert _render_vs_tcga_cell(row) == "ref 0.14 TPM"
+
+
+def test_render_vs_tcga_not_in_cohort_shows_ref_zero_when_absent():
+    # CTA case: raw cohort median genuinely 0.
+    row = _row(
+        tcga_ref_state="not_in_cohort",
+        pct_cancer_median=float("inf"),
+        tcga_cohort_median_tpm=0.0,
+    )
+    assert _render_vs_tcga_cell(row) == "ref 0"
+
+
+def test_render_vs_tcga_tme_explained_shows_tme_only_with_cohort_tpm():
+    # TME-deconvolution zeroed the tumor component.
+    row = _row(
+        tcga_ref_state="tme_explained",
+        pct_cancer_median=float("inf"),
+        tcga_cohort_median_tpm=12.3,
+    )
+    assert _render_vs_tcga_cell(row) == "TME-only (12.3 TPM)"
+
+
+def test_render_vs_tcga_both_absent_renders_dash():
+    row = _row(tcga_ref_state="both_absent", pct_cancer_median=None)
+    assert _render_vs_tcga_cell(row) == "\u2014"
+
+
+def test_render_vs_tcga_preserves_large_finite_folds_uncapped():
+    """ITGA10 in pfo004 renders at 1548× — capping would mask the signal."""
+    row = _row(tcga_ref_state="finite", pct_cancer_median=1548.45)
+    out = _render_vs_tcga_cell(row)
+    assert "1548" in out
+    assert "\u00d7" in out  # × symbol preserved
+
+
+# ── #40: lineage estimator returns TME-dominated genes separately ──
+
+
+def test_lineage_estimator_returns_tuple_of_estimates_and_skipped():
+    """Empty panel → (empty, empty) tuple, not a bare list."""
+    estimates, skipped = _lineage_purity_estimates(
+        "FAKE_TYPE", {}, {}, [], 0.7,
+    )
+    assert estimates == []
+    assert skipped == []
+
+
+def test_lineage_estimator_separates_tme_dominated_from_usable():
+    """A gene present in the sample but TME-dominated in the reference
+    lands in ``skipped_detected`` with the sample TPM and reason —
+    consumers render it as "uninformative", not "not detected".
+
+    We fabricate a minimal run by stubbing the single public call the
+    estimator makes (``pan_cancer_expression``). ACTA2 is the
+    canonical case: smooth-muscle marker, heavy TME bleed-through in
+    SARC, yet reported at 189 TPM in the biomarker panel.
+    """
+    from pirlygenes import tumor_purity as tp
+
+    # Minimal reference: two genes, one lineage marker (LIN), one
+    # housekeeping (HK). LIN has high TME expression (smooth muscle)
+    # and low cancer-cohort expression — exactly the SARC / ACTA2
+    # regime.
+    ref = pd.DataFrame({
+        "Ensembl_Gene_ID": ["ENSG_LIN", "ENSG_HK"],
+        "Symbol": ["LIN", "HK"],
+        "FPKM_FAKE": [1.0, 10.0],
+        "nTPM_smooth_muscle": [200.0, 10.0],
+        "nTPM_skeletal_muscle": [200.0, 10.0],
+        "nTPM_heart_muscle": [200.0, 10.0],
+        "nTPM_adipose_tissue": [100.0, 10.0],
+        "nTPM_bone_marrow": [50.0, 10.0],
+        "nTPM_lymph_node": [50.0, 10.0],
+        "nTPM_spleen": [50.0, 10.0],
+        "nTPM_thymus": [50.0, 10.0],
+        "nTPM_tonsil": [50.0, 10.0],
+        "nTPM_appendix": [50.0, 10.0],
+    })
+
+    # Monkey-patch the two loaders the estimator uses.
+    orig_pan = tp.pan_cancer_expression
+    orig_lineage = tp.LINEAGE_GENES
+
+    try:
+        tp.pan_cancer_expression = lambda: ref
+        tp.LINEAGE_GENES = {"FAKE": ["LIN"]}
+
+        sample_tpm = {"LIN": 190.0, "HK": 50.0}
+        estimates, skipped = _lineage_purity_estimates(
+            "FAKE", sample_tpm, {}, ["HK"], 0.7,
+        )
+    finally:
+        tp.pan_cancer_expression = orig_pan
+        tp.LINEAGE_GENES = orig_lineage
+
+    # LIN's cohort median is 1.0 but TME median across muscle tissues
+    # is ~200 → true_tumor_ratio <= tme_ratio, so it lands in skipped.
+    assert estimates == [], "TME-dominated gene should not be in estimates"
+    assert len(skipped) == 1
+    assert skipped[0]["gene"] == "LIN"
+    assert skipped[0]["reason"] == "tme_dominated"
+    assert skipped[0]["sample_tpm"] == 190.0
+
+
+# ── #39: MT-quality split — n_mt=0 vs n_mt>0 + low fraction ─────────
+
+
+def _tcga_sample_with_mt_override(cancer_code, mt_tpm):
+    """Take a real TCGA cohort median as a pseudo-sample, then override
+    every MT gene's TPM to ``mt_tpm``. Setting ``mt_tpm=0`` simulates
+    the filtered / renamed case (no MT rows reach the estimator). Any
+    small positive value simulates "present but contribute minimal TPM".
+    """
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression
+
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    df = pd.DataFrame({
+        "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+        "gene_symbol": ref["Symbol"],
+        "TPM": ref[f"FPKM_{cancer_code}"].astype(float),
+    })
+    mt_mask = df["gene_symbol"].isin(set(_MT_GENES))
+    if mt_tpm == 0:
+        # Genuinely drop MT rows — models "MT symbols missing from quant
+        # table" (filtered / renamed upstream).
+        df = df.loc[~mt_mask].reset_index(drop=True)
+    else:
+        df.loc[mt_mask, "TPM"] = mt_tpm
+    return df
+
+
+def test_mt_quality_flag_says_filtered_when_n_mt_is_zero():
+    """When no MT gene symbols are present, the flag says 'filtered or
+    renamed upstream' — that's the genuinely-absent case."""
+    df = _tcga_sample_with_mt_override("COAD", mt_tpm=0)
+    # library_prep=None means the prep-explains-MT short-circuit is off.
+    out = assess_sample_quality(df, library_prep=None)
+    flags = " | ".join(out["flags"])
+    assert "filtered or renamed" in flags
+    assert f"0/{len(_MT_GENES)}" in flags
+
+
+def test_mt_quality_flag_says_low_fraction_when_n_mt_positive():
+    """When MT gene symbols ARE present but their TPM share is tiny,
+    the flag says 'Low MT fraction' + 'genes present but contribute
+    minimal TPM' — not 'filtered or renamed'."""
+    df = _tcga_sample_with_mt_override("COAD", mt_tpm=0.01)
+    out = assess_sample_quality(df, library_prep=None)
+    flags = " | ".join(out["flags"])
+    # Should NOT claim filtered/renamed (MT rows are present).
+    assert "filtered or renamed" not in flags
+    # Should point at the low-fraction interpretation.
+    assert "Low MT fraction" in flags
+    assert "genes present but contribute minimal TPM" in flags
+
+
+# ── #35 + #36: decomp-purity adoption guard ─────────────────────────
+
+
+def test_decomp_purity_adoption_guard_matches_docstring():
+    """Pin the three conditions that must all hold for _analyze_body
+    to adopt decomp purity over classifier purity:
+
+      1. decomp_agrees: best_decomp.cancer_type == classifier's cancer_code
+      2. decomp_has_tme: template warnings don't include the
+         "No non-tumor components in template" marker
+      3. best_decomp.purity_result is truthy
+
+    The logic isn't extracted into a helper yet — this test encodes
+    the contract so a future refactor can pull out a named predicate
+    without losing behavior. pfo002 / BRCA-template 100% was the
+    failure case: classifier=COAD, decomp=BRCA → decomp_agrees=False
+    → keep classifier's 36%.
+    """
+    # Simulate the three branches that should NOT adopt decomp purity:
+    classifier_code = "COAD"
+
+    # Branch 1: cancer_type mismatch → guard off, don't adopt.
+    best_cancer = "BRCA"
+    warnings = []
+    decomp_agrees = (best_cancer == classifier_code)
+    decomp_has_tme = not any(
+        "No non-tumor components in template" in w for w in warnings
+    )
+    assert not decomp_agrees
+    assert not (decomp_agrees and decomp_has_tme)
+
+    # Branch 2: cancer agrees but template has no TME compartments.
+    best_cancer = "COAD"
+    warnings = ["No non-tumor components in template"]
+    decomp_agrees = (best_cancer == classifier_code)
+    decomp_has_tme = not any(
+        "No non-tumor components in template" in w for w in warnings
+    )
+    assert decomp_agrees
+    assert not decomp_has_tme
+    assert not (decomp_agrees and decomp_has_tme)
+
+    # Branch 3: both OK → adoption is allowed.
+    best_cancer = "COAD"
+    warnings = ["Primary tissue support exceeds metastatic-site support"]
+    decomp_agrees = (best_cancer == classifier_code)
+    decomp_has_tme = not any(
+        "No non-tumor components in template" in w for w in warnings
+    )
+    assert decomp_agrees and decomp_has_tme
+
+
+# ── #38: proliferation panel denominator in analysis.md ─────────────
+
+
+def test_proliferation_panel_size_matches_public_api():
+    """The analysis.md denominator reads the panel size at render time
+    rather than hardcoding an old value — pins that the public API
+    ``proliferation_panel_gene_names()`` is the single source."""
+    from pirlygenes.gene_sets_cancer import proliferation_panel_gene_names
+
+    panel = proliferation_panel_gene_names()
+    assert isinstance(panel, list)
+    assert len(panel) >= 5  # protect against the old /5 regression
+    # Deduplicated
+    assert len(set(panel)) == len(panel)
+
+
+# ── #37: Stage-0 reasoning_trace format ─────────────────────────────
+
+
+def test_reasoning_trace_rendering_format_stable():
+    """The summary-line trace clause is generated from
+    ``hvt.reasoning_trace`` via ``' → '.join(...)`` — pin the format so
+    the arrow separator (not a comma / pipe) is what downstream docs
+    describe."""
+    trace = [
+        "lymphoid-tissue-tumor-indistinguishable",
+        "aggregate-tumor-evidence[aggregate=3.72\u22651.0,CTA_strong(n=5)]",
+    ]
+    rendered = " \u2192 ".join(trace)
+    assert "\u2192" in rendered
+    assert rendered.startswith("lymphoid-tissue-tumor-indistinguishable")
+    # Single-element traces still render without a trailing arrow.
+    solo = " \u2192 ".join(trace[:1])
+    assert solo == "lymphoid-tissue-tumor-indistinguishable"

--- a/tests/test_tumor_expression.py
+++ b/tests/test_tumor_expression.py
@@ -37,13 +37,17 @@ def test_lineage_genes_has_no_duplicates():
 # ── _lineage_purity_estimates edge cases ──────────────────────────
 
 def test_lineage_unknown_cancer_type_returns_empty():
-    result = _lineage_purity_estimates("FAKE_TYPE", {}, {}, [], 0.7)
-    assert result == []
+    # Returns (estimates, skipped_detected); both empty when cancer
+    # type isn't in the lineage panel registry.
+    estimates, skipped = _lineage_purity_estimates("FAKE_TYPE", {}, {}, [], 0.7)
+    assert estimates == []
+    assert skipped == []
 
 
 def test_lineage_empty_sample_returns_empty():
-    result = _lineage_purity_estimates("PRAD", {}, {}, [], 0.69)
-    assert result == []
+    estimates, skipped = _lineage_purity_estimates("PRAD", {}, {}, [], 0.69)
+    assert estimates == []
+    assert skipped == []
 
 
 # ── Upper-half median estimator ───────────────────────────────────


### PR DESCRIPTION
## Summary

Seven report-correctness bugs surfaced by an audit of the a CRC validation sample and a SARC validation sample markdown outputs. All fixed at root cause — no capping / sentinel values that would hide underlying estimation issues.

| # | Bug | Root cause | Fix |
|---|-----|------------|-----|
| 35 | CRC sample mis-called "Working call: BRCA" for a CRC sample | `effective_cancer_type = best_decomp.cancer_type` silently overwrote classifier's COAD call | Keep classifier's call as the headline — decomp fits templates, not identities |
| 36 | CRC sample purity 100% despite lineage markers giving ~16% | BRCA template (no TME compartments) returned trivial fraction=1.0 and got adopted | Only adopt decomp purity when cancer_type agrees AND template has TME |
| 37 | Stage-0 reasoning trace missing from every report | `reasoning_trace` computed but never rendered | Append `*Rule: …*` to summary.md; add **Reasoning rule** + full evidence synthesis to analysis.md |
| 38 | `13/5 genes observed` proliferation panel | Hardcoded `/5` from older panel size | Use `len(proliferation_panel_gene_names())` |
| 39 | "MT genes appear filtered or renamed" while n_mt=13/15 | Warning fired on low fraction alone, not on count | Split: n_mt=0 → genuinely filtered; n_mt>0+low fraction → present but minimal TPM |
| 40 | SARC sample lineage panel: "ACTA2 not detected" while biomarker panel shows ACTA2 at 190 TPM | Lineage estimator silently drops genes where TME-reference bleed-through exceeds tumor contribution | Return `(estimates, skipped_detected)`; render as "detected 190 TPM — uninformative (TME exceeds tumor contribution)" |
| 41 | ∞× fold-change in target tables | TCGA cohort's deconvolved tumor component ~0 → degenerate ratio display | Add `tcga_ref_state` column: `not_in_cohort` → render `ref 0.14 TPM`; `tme_explained` → `TME-only (X TPM)`; `finite` unchanged — surfaces two biologically distinct states that previously both showed ∞× |

### Verified on the battery

a CRC validation sample now says: ✅ Cancer call **COAD**, ✅ Purity **36%** (not 100%), ✅ Rule `aggregate-tumor-evidence[aggregate=3.72≥1.0,CTA_strong(n=5)]`, ✅ 13/13 prolif panel, ✅ "MT fraction too low" (not "filtered or renamed").

a SARC validation sample now shows: ✅ CTA ref values like `ref 0.14 TPM` and `ref 0` instead of `∞×`; ✅ ACTA2 correctly flagged as detected-but-uninformative; ✅ ITGA10 at 1548× stays 1548× (not capped).

### Notable non-changes

- ITGA10 `1548×` is NOT capped — that denominator is a real tumor-component TPM, so the fold is meaningful even if visually large. Capping would mask the signal.
- The `aggregate_tumor_evidence` rule naming from 4.31.0 is preserved; the trace now actually reaches the reports.

## Test plan

- [x] Full test suite (519 passed, 1 skipped)
- [x] `_lineage_purity_estimates` return-shape test updated for new tuple return
- [x] a CRC validation sample re-run: cancer call, purity, Stage-0 trace, proliferation panel, MT copy all correct
- [x] a SARC validation sample re-run: no ∞× in any target table; lineage distinguishes "uninformative" from "not detected"
- [x] Lint clean