### PR TITLE
fix(classifier): orphan-family dominance override (BLCA→ESCA miscall) — closes #160

### DIFF
--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -1943,6 +1943,68 @@ def rank_cancer_type_candidates(
             }
         )
 
+    # #160: orphan-dominance override. Cancer types that aren't grouped
+    # into a family (BLCA, PAAD, MESO, ACC, CHOL, LIHC, ...) were getting
+    # penalized by ``non_family_penalty`` even when every direct signal
+    # (signature × purity × lineage support) strongly favored them over
+    # a family-matched competitor. On the TCGA-median battery this
+    # miscalled BLCA → ESCA (orphan BLCA at signature 0.94 losing to
+    # ESCA_SQ-family ESCA at 0.66). The override fires only when the
+    # orphan's evidence is unambiguously tumor-like — three gates must
+    # all pass:
+    #
+    #   1. ``signature_score ≥ 0.80`` — signature is itself strong,
+    #      not a byproduct of TME bleed-through
+    #   2. ``purity_estimate ≥ 0.40`` — sample looks like a real
+    #      tumor, not a dilute admixture
+    #   3. raw-signal dominance (sig × purity × lineage_support) ≥ 1.5×
+    #      the top family-matched competitor's — enough to justify
+    #      ignoring the family signal
+    #
+    # On a COAD/lymph-node 30/70 mix DLBC's raw signal can dominate
+    # from the TME alone (sig 0.61, pur 0.33). The signature+purity
+    # gates reject that case. BLCA on its own median (sig 0.94,
+    # pur 0.59) passes all three and correctly promotes.
+    _ORPHAN_DOMINANCE_RATIO = 1.5
+    _ORPHAN_DOMINANCE_MIN_SIGNATURE = 0.80
+    _ORPHAN_DOMINANCE_MIN_PURITY = 0.40
+    family_matched_rows = [
+        r for r in rows if r["family_label"] is not None
+    ]
+    if family_matched_rows:
+        def _raw_signal(r):
+            return (
+                r["signature_score"]
+                * max(r["purity_estimate"], family_params["support_norm_floor"])
+                * r["lineage_support_factor"]
+            )
+        best_family_raw = max(_raw_signal(r) for r in family_matched_rows)
+        if best_family_raw > 0:
+            for r in rows:
+                if r["family_label"] is not None or r["family_factor"] >= 1.0:
+                    continue
+                if r["signature_score"] < _ORPHAN_DOMINANCE_MIN_SIGNATURE:
+                    continue
+                if r["purity_estimate"] < _ORPHAN_DOMINANCE_MIN_PURITY:
+                    continue
+                if _raw_signal(r) < _ORPHAN_DOMINANCE_RATIO * best_family_raw:
+                    continue
+                # Orphan dominates — recompute support without the
+                # family-penalty handicap.
+                r["family_factor"] = 1.0
+                support_factors = (
+                    r["signature_score"],
+                    max(r["purity_estimate"], family_params["support_norm_floor"]),
+                    r["lineage_support_factor"],
+                    max(r["signature_stability"], family_params["signature_stability_floor"]),
+                    1.0,
+                )
+                r["support_score"] = float(np.prod(support_factors))
+                r["support_geomean"] = (
+                    float(r["support_score"] ** (1.0 / len(support_factors)))
+                    if r["support_score"] > 0 else 0.0
+                )
+
     rows.sort(
         key=lambda row: (
             -row["support_score"],

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.32.0"
+__version__ = "4.33.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_160_orphan_family_dominance.py
+++ b/tests/test_issue_160_orphan_family_dominance.py
@@ -1,0 +1,118 @@
+"""Regression test for issue #160 — family-factor penalty miscalls
+orphan-family cancer types on their own cohort medians.
+
+Before the fix, the classifier's geomean multiplied a `family_factor`
+that dropped orphan cancer types (BLCA, PAAD — no family grouping) to
+~0.15 whenever a family-matched competitor sat near the top family.
+That made the TCGA-median of BLCA itself classify as ESCA (squamous
+family) despite BLCA having the highest signature, purity, and
+lineage scores.
+
+The fix adds a raw-signal dominance override: when an orphan's
+`signature × purity × lineage_support` product exceeds the top
+family-matched competitor's by ≥ 1.5×, the family penalty is
+suspended for that orphan.
+"""
+
+import pandas as pd
+import pytest
+
+from pirlygenes.gene_sets_cancer import pan_cancer_expression
+from pirlygenes.tumor_purity import rank_cancer_type_candidates
+
+
+def _cohort_median_sample(code: str) -> pd.DataFrame:
+    """Synthesize a pseudo-sample whose TPM column is the TCGA cohort
+    median for ``code``. Equivalent to what the median battery uses."""
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    return pd.DataFrame({
+        "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+        "gene_symbol": ref["Symbol"],
+        "TPM": ref[f"FPKM_{code}"].astype(float),
+    })
+
+
+@pytest.mark.parametrize("code", ["BLCA"])
+def test_orphan_family_cohort_median_classifies_as_itself(code):
+    """BLCA median → top candidate must be BLCA, not the family
+    competitor that was winning before the fix (ESCA)."""
+    df = _cohort_median_sample(code)
+    ranked = rank_cancer_type_candidates(df)
+    assert ranked, "classifier returned no candidates"
+    top = ranked[0]
+    assert top["code"] == code, (
+        f"{code} median miscalled as {top['code']}. Rows: "
+        + ", ".join(f"{r['code']}({r['support_geomean']:.3f})" for r in ranked[:5])
+    )
+
+
+def test_orphan_dominance_override_raises_orphan_family_factor():
+    """When an orphan's raw signal dominates the family winner's by
+    ≥ 1.5×, the override resets its family_factor to 1.0 and
+    recomputes support_score / support_geomean."""
+    df = _cohort_median_sample("BLCA")
+    ranked = rank_cancer_type_candidates(df)
+    blca_row = next((r for r in ranked if r["code"] == "BLCA"), None)
+    assert blca_row is not None, "BLCA missing from candidate trace"
+    # Post-override BLCA (orphan) should not be down-weighted.
+    assert blca_row["family_factor"] >= 0.9, (
+        f"BLCA family_factor={blca_row['family_factor']} — orphan "
+        "dominance override did not fire; expected ≥ 0.9"
+    )
+
+
+def test_non_orphan_family_matched_candidates_keep_family_factor():
+    """The override only fires for orphans. A family-matched candidate
+    (e.g. COAD → CRC family) should NOT have its family_factor
+    changed by this code path — the within-family boost/penalty logic
+    is independent."""
+    df = _cohort_median_sample("COAD")
+    ranked = rank_cancer_type_candidates(df)
+    coad_row = next((r for r in ranked if r["code"] == "COAD"), None)
+    assert coad_row is not None
+    # COAD has a family label — override shouldn't touch it.
+    assert coad_row["family_label"] is not None
+    # And classifier still picks COAD as top.
+    assert ranked[0]["code"] == "COAD"
+
+
+def test_override_rejects_orphan_with_tme_driven_raw_signal():
+    """Guard: the override must NOT fire when an orphan's apparent raw
+    signal is TME-driven rather than tumor-driven. On a COAD + lymph-
+    node 30/70 mix, DLBC's raw_signal (sig × purity × lineage) can
+    exceed COAD's because the lymph-node TME matches DLBC's panel —
+    but DLBC's purity is ~0.33 and signature is ~0.60, below the
+    override's signature + purity gates. Classifier should keep COAD
+    (or READ) on top, not DLBC."""
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression
+
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    coad = pd.Series(
+        ref["FPKM_COAD"].astype(float).values,
+        index=ref["Ensembl_Gene_ID"].values,
+    )
+    lymph = pd.Series(
+        ref["nTPM_lymph_node"].astype(float).values,
+        index=ref["Ensembl_Gene_ID"].values,
+    )
+    mix = 0.3 * coad + 0.7 * lymph
+    df_mix = pd.DataFrame({
+        "ensembl_gene_id": mix.index,
+        "gene_symbol": ref.set_index("Ensembl_Gene_ID").loc[mix.index, "Symbol"].values,
+        "TPM": mix.values,
+    })
+    ranked = rank_cancer_type_candidates(
+        df_mix,
+        candidate_codes=["COAD", "READ", "DLBC", "THYM", "SARC", "STAD"],
+        top_k=6,
+    )
+    top_code = ranked[0]["code"]
+    assert top_code in {"COAD", "READ"}, (
+        f"COAD+lymph mix miscalled as {top_code} — override fired "
+        f"despite TME bleed-through. Rows: "
+        + ", ".join(
+            f"{r['code']}(sig={r['signature_score']:.2f},pur={r['purity_estimate']:.2f},"
+            f"ff={r['family_factor']:.2f},gm={r['support_geomean']:.2f})"
+            for r in ranked[:4]
+        )
+    )


### PR DESCRIPTION
## Summary

Fixes the TCGA-median-battery miscall of **BLCA → ESCA**. BLCA (no family) had the highest signature / purity / lineage of all candidates on its own cohort median, but lost the geomean ranking because the orphan-family penalty (``non_family_penalty = 0.85``) crushed its ``family_factor`` to ~0.15 while ESCA's stayed at 1.0.

Adds a narrow post-pass override that suspends the family penalty for an orphan when:

1. orphan's ``signature_score ≥ 0.80`` — signature is itself strong, not a byproduct of TME bleed
2. orphan's ``purity_estimate ≥ 0.40`` — sample looks like a real tumor, not a dilute admixture
3. raw-signal dominance ≥ 1.5× over the top family-matched competitor

The signature + purity gates are what reject the TME-bleed case (a 30/70 COAD+lymph mix would otherwise promote DLBC via its 70%-lymph-node signal).

## Verified behavior

| Case | Before | After |
|---|---|---|
| BLCA median | ESCA (7% purity) | **BLCA (75%)** ✅ |
| PAAD median | STAD | STAD (expected — #162 is the deeper cause) |
| COAD/lymph 30/70 mix | COAD | COAD ✅ (test pins this) |
| All 31 other cohort medians | self | self ✅ |

## Tests

New: ``tests/test_issue_160_orphan_family_dominance.py`` (4 tests)
- BLCA median → BLCA (integration)
- Orphan dominance raises family_factor to 1.0 when gates pass
- Non-orphan family-matched candidates keep their family_factor
- COAD/lymph mix — override rejects TME-driven raw signal (pins the guard)

Full suite: **536 passed, 1 skipped**. Lint clean.

## Version

Bump to 4.33.0.