### PR TITLE
fix(confidence): degenerate-CI tier for deterministic inputs (closes #161)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -574,11 +574,21 @@ def _ci_confidence_tier(overall_lower, overall_upper):
 
     Reader-facing tags on the purity estimate so a 19–100% CI is
     visibly different from a 58–70% CI in the report.
+
+    A *zero-width* CI (``lower == upper == estimate``) is degenerate —
+    the estimator saw no per-gene variation, which happens on synthetic
+    / deterministic inputs (TCGA cohort medians, decomposition
+    templates, expected-expression probes). Surfacing that as "high
+    confidence" is misleading — the estimator couldn't produce
+    uncertainty, not because the answer is certain but because the
+    input has no spread to bound it with (#161).
     """
     try:
         span = float(overall_upper) - float(overall_lower)
     except (TypeError, ValueError):
         return "unknown"
+    if span <= 1e-9:
+        return "degenerate"
     if span < 0.15:
         return "high"
     if span < 0.35:
@@ -2003,7 +2013,13 @@ def _purity_ci_phrase(purity):
     hi = purity["overall_upper"]
     tier = _ci_confidence_tier(lo, hi)
     core = f"**{est:.0%}** (range {lo:.0%}–{hi:.0%})"
-    if tier == "low":
+    if tier == "degenerate":
+        core += (
+            " — **degenerate CI**: input had no per-gene variation so "
+            "uncertainty could not be estimated (typical of synthetic "
+            "/ cohort-median inputs)"
+        )
+    elif tier == "low":
         core += (
             " — **⚠ low-confidence**: the CI spans "
             f"{(hi - lo):.0%}, so per-gene tumor-expression estimates "
@@ -2883,12 +2899,15 @@ def _generate_text_reports(
         degradation_severity=deg_for_tier,
     )
     analysis["purity_confidence"] = purity_tier
-    tier_suffix = (
-        f" — **{purity_tier.tier} confidence** "
-        f"({purity_tier.inline_note})"
-        if purity_tier.tier in {"low", "moderate"} and purity_tier.reasons
-        else ""
-    )
+    if purity_tier.tier == "degenerate":
+        tier_suffix = f" — **degenerate CI**: {purity_tier.inline_note}"
+    elif purity_tier.tier in {"low", "moderate"} and purity_tier.reasons:
+        tier_suffix = (
+            f" — **{purity_tier.tier} confidence** "
+            f"({purity_tier.inline_note})"
+        )
+    else:
+        tier_suffix = ""
     lines.append(f"- **Overall estimate**: {purity['overall_estimate']:.0%} "
                   f"({purity['overall_lower']:.0%}\u2013{purity['overall_upper']:.0%})"
                   f"{tier_suffix}")

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -33,14 +33,18 @@ from typing import List
 
 @dataclass(frozen=True)
 class ConfidenceTier:
-    tier: str  # "high" | "moderate" | "low" | "unknown"
+    tier: str  # "high" | "moderate" | "low" | "degenerate" | "unknown"
     reasons: List[str] = field(default_factory=list)
 
     @property
     def badge(self) -> str:
-        return {"low": "⚠⚠", "moderate": "⚠", "high": "", "unknown": "?"}.get(
-            self.tier, ""
-        )
+        return {
+            "low": "⚠⚠",
+            "moderate": "⚠",
+            "high": "",
+            "degenerate": "—",
+            "unknown": "?",
+        }.get(self.tier, "")
 
     @property
     def inline_note(self) -> str:
@@ -77,6 +81,21 @@ def compute_purity_confidence(
 
     tier = "high"
     span = upper - lower
+    if span <= 1e-9:
+        # Zero-width CI means the estimator saw no per-gene variation
+        # (synthetic / cohort-median / deterministic input). Surfacing
+        # that as "high confidence" is misleading — the estimator
+        # couldn't produce uncertainty, not because the answer is
+        # certain but because the input has no spread to bound it.
+        # #161: tier this as ``degenerate`` so renderers show a
+        # specific "deterministic input — CI not estimated" message.
+        return ConfidenceTier(
+            tier="degenerate",
+            reasons=[
+                "deterministic input (no per-gene variation) — purity "
+                "CI not estimated"
+            ],
+        )
     if span >= 0.35:
         tier = "low"
         reasons.append(f"wide purity CI ({lower:.0%}–{upper:.0%})")

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.33.0"
+__version__ = "4.34.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_161_degenerate_ci.py
+++ b/tests/test_issue_161_degenerate_ci.py
@@ -1,0 +1,81 @@
+"""Regression test for issue #161 — a zero-width purity CI must be
+labeled as "degenerate" rather than "high confidence".
+
+Deterministic inputs (TCGA cohort medians, decomposition templates,
+synthetic expected-expression probes) have no per-gene variance, so
+the purity estimator returns ``lower == upper == estimate``. Calling
+that ``high confidence`` misleads the reader — it is not "very
+certain", it is "the estimator had no spread to bound it with".
+"""
+
+import pytest
+
+from pirlygenes.cli import _ci_confidence_tier
+from pirlygenes.confidence import ConfidenceTier, compute_purity_confidence
+
+
+# ── _ci_confidence_tier ─────────────────────────────────────────────
+
+
+def test_zero_width_ci_returns_degenerate_tier():
+    assert _ci_confidence_tier(0.79, 0.79) == "degenerate"
+
+
+def test_tiny_positive_span_still_high_tier():
+    # A genuinely-tight CI (≤ 1pp but not exactly zero) is still "high",
+    # not "degenerate" — the estimator gave a real bound.
+    assert _ci_confidence_tier(0.68, 0.69) == "high"
+
+
+def test_typical_ci_spans_map_to_expected_tiers():
+    # 10pp — high
+    assert _ci_confidence_tier(0.65, 0.75) == "high"
+    # 20pp — moderate
+    assert _ci_confidence_tier(0.55, 0.75) == "moderate"
+    # 40pp — low
+    assert _ci_confidence_tier(0.30, 0.70) == "low"
+
+
+def test_invalid_inputs_return_unknown():
+    assert _ci_confidence_tier(None, None) == "unknown"
+    assert _ci_confidence_tier("not-a-number", 0.5) == "unknown"
+
+
+# ── compute_purity_confidence ───────────────────────────────────────
+
+
+def _purity_dict(estimate, lower, upper):
+    return {
+        "overall_estimate": estimate,
+        "overall_lower": lower,
+        "overall_upper": upper,
+    }
+
+
+def test_degenerate_purity_returns_degenerate_tier():
+    tier = compute_purity_confidence(_purity_dict(0.79, 0.79, 0.79))
+    assert tier.tier == "degenerate"
+    # Reason string mentions the key phrase "deterministic input"
+    assert any("deterministic" in r.lower() for r in tier.reasons)
+
+
+def test_degenerate_purity_badge_is_dash():
+    tier = ConfidenceTier(tier="degenerate", reasons=["test"])
+    assert tier.badge == "\u2014"  # em-dash
+
+
+def test_non_zero_span_keeps_high_tier():
+    tier = compute_purity_confidence(_purity_dict(0.69, 0.65, 0.73))
+    assert tier.tier == "high"
+    # "high" tier with no reasons returns empty render
+    assert tier.render() == ""
+
+
+def test_degenerate_tier_render_formats_reasons():
+    tier = ConfidenceTier(
+        tier="degenerate",
+        reasons=["deterministic input — purity CI not estimated"],
+    )
+    rendered = tier.render()
+    assert "degenerate" in rendered
+    assert "deterministic" in rendered


### PR DESCRIPTION
## Summary

Every correctly-classified cohort in the TCGA-median battery reported a **single-point CI** tagged as ``high confidence``:

    ACC:  79% (79%–79%) — high confidence
    BRCA: 73% (73%–73%) — high confidence
    COAD: 59% (59%–59%) — high confidence
    (…31 more)

A zero-width CI doesn't mean "very certain" — it means the estimator saw no per-gene variance and couldn't bound uncertainty. That's typical of synthetic / cohort-median / decomposition-template inputs.

## Fix

Introduces a ``degenerate`` tier in both confidence paths and threads it through the purity renderers:

- ``_ci_confidence_tier(lo, hi)`` — span ≤ 1e-9 → ``"degenerate"``
- ``compute_purity_confidence`` — returns ``ConfidenceTier(tier="degenerate", reasons=["deterministic input — purity CI not estimated"])``
- Report sections (``## Tumor Purity``, ``_purity_ci_phrase``, brief) render ``"— **degenerate CI**: …"`` instead of silent ``"high confidence"``

## Verified

PRAD median run now shows:

    **Overall estimate**: 69% (69%–69%) — **degenerate CI**: deterministic input (no per-gene variation) — purity CI not estimated
    **Purity:** 69% (CI 69%–69%, degenerate confidence).

Real-sample CIs (e.g. a CRC validation sample 17%–67%) still tier as ``low`` / ``moderate`` / ``high`` as before.

## Tests

8 new tests in ``tests/test_issue_161_degenerate_ci.py`` cover the tier boundary (zero vs 1pp vs 10pp vs 20pp vs 40pp), the reason strings, the render output, and the badge map.

Full suite: **540 passed**, 1 skipped. Lint clean.

## Dependency

Independent of #163 (#160 orphan-family fix). Version bump to 4.34.0 assumes this lands after #163 merges.