### PR TITLE
fix(classifier): lineage-panel specificity filter — PAAD→STAD miscall (closes #162)

### DIFF
--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -385,6 +385,94 @@ def _sample_hk_median(sample_tpm):
 LINEAGE_GENES = lineage_genes_by_cancer_type()
 
 
+# #162: cross-cohort lineage-panel specificity. When a lineage panel
+# gene is expressed at comparable levels in multiple TCGA cohorts
+# (e.g. MUC5AC in both STAD and PAAD, KRT19 across all GI epithelia),
+# running cohort X's panel on a sample from cohort Y inflates Y's
+# lineage purity for X — on the cohort-median battery STAD's lineage
+# computed to 0.913 on a PAAD median, which combined with the GASTRIC
+# family factor flipped the classifier to STAD. Filter each cohort's
+# panel to the genes whose *home* expression dominates the max non-
+# home cohort expression by the specificity threshold.
+_LINEAGE_SPECIFICITY_MIN = 0.5  # home / (home + max_other) ≥ 0.5
+_LINEAGE_SPECIFICITY_IGNORE_BELOW = 1.0  # don't filter near-zero refs
+_LINEAGE_MIN_GENES_AFTER_FILTER = 2  # don't prune a panel below this
+_LINEAGE_SPECIFIC_CACHE: dict = {}
+
+
+def _cancer_specific_lineage_genes(cancer_code: str) -> list:
+    """Return the subset of the cancer type's lineage panel that is
+    specific to its home cohort.
+
+    A gene is considered specific when its FPKM in ``cancer_code``'s
+    cohort exceeds every other cohort's FPKM such that
+    ``home / (home + max_other) ≥ _LINEAGE_SPECIFICITY_MIN``. Genes
+    with near-zero home expression (below
+    ``_LINEAGE_SPECIFICITY_IGNORE_BELOW``) are kept regardless — those
+    are ambient-level genes not driving cross-cohort crosstalk.
+
+    The filter guarantees at least ``_LINEAGE_MIN_GENES_AFTER_FILTER``
+    genes remain; when specificity-filtering would drop too many, the
+    original panel is returned (the cohort's panel is too promiscuous
+    to filter safely and the lineage estimator's own ``tme_ratio`` check
+    remains the safety net).
+    """
+    if cancer_code in _LINEAGE_SPECIFIC_CACHE:
+        return _LINEAGE_SPECIFIC_CACHE[cancer_code]
+    panel = LINEAGE_GENES.get(cancer_code, [])
+    if not panel:
+        _LINEAGE_SPECIFIC_CACHE[cancer_code] = []
+        return []
+    ref = pan_cancer_expression().drop_duplicates(subset="Symbol")
+    ref = ref.set_index("Symbol")
+    home_col = f"FPKM_{cancer_code}"
+    other_cols = [
+        c for c in ref.columns
+        if c.startswith("FPKM_") and c != home_col
+    ]
+    if home_col not in ref.columns or not other_cols:
+        _LINEAGE_SPECIFIC_CACHE[cancer_code] = list(panel)
+        return list(panel)
+    # Compute per-gene specificity score; keep the ones above the
+    # threshold. For genes below the threshold, retain the top-N most-
+    # specific so a heavily-shared panel (STAD's 3-of-4 GI-epithelium
+    # markers) still yields enough signal for the purity estimator.
+    scored = []
+    specific = []
+    for gene in panel:
+        if gene not in ref.index:
+            continue
+        home_val = float(ref.loc[gene, home_col] or 0.0)
+        other_vals = ref.loc[gene, other_cols].astype(float)
+        max_other = float(other_vals.max())
+        # Near-zero expression everywhere → filter doesn't apply.
+        if home_val + max_other < _LINEAGE_SPECIFICITY_IGNORE_BELOW:
+            specific.append(gene)
+            scored.append((gene, 1.0))
+            continue
+        denom = home_val + max_other
+        if denom <= 0:
+            scored.append((gene, 0.0))
+            continue
+        specificity = home_val / denom
+        scored.append((gene, specificity))
+        if specificity >= _LINEAGE_SPECIFICITY_MIN:
+            specific.append(gene)
+    if len(specific) < _LINEAGE_MIN_GENES_AFTER_FILTER and scored:
+        # Not enough specific genes to anchor a purity estimate. Fill
+        # in by keeping the top-N most-specific genes from the full
+        # panel, even if they fall below the threshold — safer than
+        # reverting to the full panel (which defeats the filter).
+        scored_sorted = sorted(scored, key=lambda pair: pair[1], reverse=True)
+        fill = [g for g, _ in scored_sorted if g not in specific]
+        for g in fill:
+            if len(specific) >= _LINEAGE_MIN_GENES_AFTER_FILTER:
+                break
+            specific.append(g)
+    _LINEAGE_SPECIFIC_CACHE[cancer_code] = specific
+    return specific
+
+
 def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga_purity):
     """Estimate purity from cancer-type lineage genes using HK-normalized ratios.
 
@@ -397,7 +485,11 @@ def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga
 
     Returns list of dicts with per-gene purity estimates.
     """
-    genes = LINEAGE_GENES.get(cancer_code, [])
+    # #162: filter the panel to genes that are specific to this cohort
+    # relative to other TCGA cohorts — avoids the STAD/PAAD-style
+    # crosstalk where shared GI-epithelium markers inflate the wrong
+    # cancer type's lineage purity.
+    genes = _cancer_specific_lineage_genes(cancer_code)
     if not genes:
         return [], []
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.34.0"
+__version__ = "4.35.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_162_lineage_specificity.py
+++ b/tests/test_issue_162_lineage_specificity.py
@@ -1,0 +1,136 @@
+"""Regression test for issue #162 — cross-cohort lineage-panel overlap.
+
+STAD's curated lineage panel (``MUC5AC, MUC6, CDX2, CLDN18``) shares
+two genes (MUC5AC, MUC6) that are *higher* in the PAAD cohort median
+than in STAD's own. Running STAD's panel on a PAAD sample inflated
+STAD's lineage purity to 0.913, which — combined with the GASTRIC
+family factor — flipped the classifier to STAD on the PAAD cohort
+median.
+
+The fix adds a per-cohort specificity filter
+(``_cancer_specific_lineage_genes``) that keeps only genes whose home-
+cohort expression dominates the max other-cohort expression
+(``home / (home + max_other) ≥ 0.5``). When too few genes pass, the
+top-N by specificity are retained so the purity estimator still has
+an anchor.
+"""
+
+import pandas as pd
+import pytest
+
+from pirlygenes.gene_sets_cancer import pan_cancer_expression
+from pirlygenes.tumor_purity import (
+    LINEAGE_GENES,
+    _cancer_specific_lineage_genes,
+    _LINEAGE_SPECIFIC_CACHE,
+    rank_cancer_type_candidates,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_specificity_cache():
+    """Clear the module-level cache so each test sees fresh results."""
+    _LINEAGE_SPECIFIC_CACHE.clear()
+    yield
+    _LINEAGE_SPECIFIC_CACHE.clear()
+
+
+# ── _cancer_specific_lineage_genes contract ────────────────────────
+
+
+def test_stad_panel_drops_genes_higher_in_other_cohorts():
+    """MUC6 (higher in PAAD than STAD) and CDX2 (highest in COAD) are
+    not STAD-specific — they should be dropped from STAD's filtered
+    panel."""
+    specific = _cancer_specific_lineage_genes("STAD")
+    assert "MUC6" not in specific, (
+        "MUC6 (PAAD > STAD) should be dropped from STAD's panel"
+    )
+    assert "CDX2" not in specific, (
+        "CDX2 (COAD > STAD) should be dropped from STAD's panel"
+    )
+
+
+def test_coad_panel_drops_genes_shared_with_other_gi():
+    """CDX2 is a CRC lineage marker but the expression is very close
+    across COAD/READ (same family) — filter keeps the rest."""
+    specific = _cancer_specific_lineage_genes("COAD")
+    # Retain at least the minimum-genes floor
+    assert len(specific) >= 2
+
+
+def test_filter_always_returns_at_least_minimum_genes():
+    """Every cohort with a lineage panel keeps ≥ 2 genes (the
+    estimator needs at least that to anchor a stable purity)."""
+    for code in LINEAGE_GENES:
+        specific = _cancer_specific_lineage_genes(code)
+        if LINEAGE_GENES[code]:
+            assert len(specific) >= 2, (
+                f"{code}: filter returned < 2 genes: {specific}"
+            )
+
+
+def test_filter_returns_subset_of_original_panel():
+    """The specificity filter never adds genes — only drops /
+    re-orders."""
+    for code in LINEAGE_GENES:
+        full = set(LINEAGE_GENES[code])
+        specific = set(_cancer_specific_lineage_genes(code))
+        assert specific <= full, (
+            f"{code}: filter added genes not in the original panel: "
+            f"{specific - full}"
+        )
+
+
+def test_filter_result_cached_across_calls():
+    """The cache short-circuits repeated calls — important because
+    the filter reads the full FPKM matrix."""
+    _cancer_specific_lineage_genes("STAD")
+    assert "STAD" in _LINEAGE_SPECIFIC_CACHE
+
+
+# ── End-to-end: PAAD median should classify as PAAD ─────────────────
+
+
+def _cohort_median_sample(code: str) -> pd.DataFrame:
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    return pd.DataFrame({
+        "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+        "gene_symbol": ref["Symbol"],
+        "TPM": ref[f"FPKM_{code}"].astype(float),
+    })
+
+
+def test_paad_cohort_median_classifies_as_paad():
+    """The canonical failure the specificity filter fixes — before
+    the fix STAD's lineage on PAAD median was 0.913 and won the
+    ranking via the GASTRIC family boost."""
+    df = _cohort_median_sample("PAAD")
+    ranked = rank_cancer_type_candidates(df)
+    assert ranked[0]["code"] == "PAAD", (
+        f"PAAD median miscalled as {ranked[0]['code']}. Top 5: "
+        + ", ".join(
+            f"{r['code']}(gm={r['support_geomean']:.2f},lin_s={r['lineage_support_factor']:.2f})"
+            for r in ranked[:5]
+        )
+    )
+
+
+def test_stad_lineage_purity_on_paad_drops_after_filter():
+    """On the PAAD cohort median, STAD's lineage purity should be
+    materially lower than PAAD's lineage purity — before the filter
+    STAD's was 0.913 vs PAAD's 0.420."""
+    df = _cohort_median_sample("PAAD")
+    ranked = rank_cancer_type_candidates(df)
+    stad_row = next((r for r in ranked if r["code"] == "STAD"), None)
+    paad_row = next((r for r in ranked if r["code"] == "PAAD"), None)
+    assert stad_row is not None and paad_row is not None
+    stad_lin = stad_row.get("lineage_purity") or 0.0
+    paad_lin = paad_row.get("lineage_purity") or 0.0
+    # PAAD's own lineage on its own median should be at least as high
+    # as STAD's on the same sample.
+    assert paad_lin >= stad_lin, (
+        f"PAAD lineage {paad_lin:.2f} < STAD lineage {stad_lin:.2f} "
+        "on PAAD median — specificity filter did not fix the "
+        "cross-cohort overlap"
+    )


### PR DESCRIPTION
## Summary

On the TCGA-median battery, STAD's lineage purity computed to **0.913** on a PAAD cohort-median sample — high enough that, combined with the GASTRIC family boost, it flipped the classifier to STAD even though PAAD had the highest direct signature score.

Root cause: STAD's curated lineage panel (``MUC5AC, MUC6, CDX2, CLDN18``) shares three of four genes with GI neighbors — MUC5AC/MUC6 are actually *higher* in PAAD than STAD, and CDX2 peaks in COAD. The lineage estimator was fundamentally reading a panel that pointed at GI-epithelium as a whole, not at STAD specifically.

## Fix

Adds a per-cohort specificity filter in ``tumor_purity.py``. Each gene is kept only when ``home_cohort_FPKM / (home + max_other_cohort_FPKM) >= 0.5``. Genes below threshold are kept only to meet a min-genes-per-panel floor (2).

| Cohort | Before | Kept | Dropped |
|---|---|---|---|
| STAD | MUC5AC, MUC6, CDX2, CLDN18 | CLDN18, MUC5AC | MUC6 (PAAD>STAD), CDX2 (COAD>STAD) |
| PAAD | PDX1, PTF1A, KRT19, MUC1 | PDX1, PTF1A | KRT19, MUC1 (pan-GI) |
| BLCA | UPK1A, UPK2, UPK3A, KRT20, GATA3, PPARG | UPK1A, UPK2, PPARG | UPK3A, KRT20, GATA3 |
| COAD | CDX2, MUC2, VIL1, CDH17 | MUC2, CDH17 | CDX2, VIL1 |

## Verified

- **PAAD median → PAAD** (was STAD) ✓
- **BLCA median → BLCA** (already fixed by #160) ✓
- All other 31 cohorts classify as themselves ✓
- STAD lineage purity on PAAD median now ≤ PAAD's own (was 0.913 vs 0.420)

## Tests

7 new tests in ``tests/test_issue_162_lineage_specificity.py``. Full suite: **543 passed**.

## Dependency

Stacked on #163 (#160). Version bumps to 4.35.0 — assumes #164 (#161) lands as 4.34.0 first.