### PR TITLE
fix(classifier): lineage filter retains rare subtype markers (closes #167)

### DIFF
--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -395,7 +395,14 @@ LINEAGE_GENES = lineage_genes_by_cancer_type()
 # panel to the genes whose *home* expression dominates the max non-
 # home cohort expression by the specificity threshold.
 _LINEAGE_SPECIFICITY_MIN = 0.5  # home / (home + max_other) ≥ 0.5
-_LINEAGE_SPECIFICITY_IGNORE_BELOW = 1.0  # don't filter near-zero refs
+# The filter only fires when the competing cohort's expression is above
+# this absolute floor — below it, the competitor isn't really "expressing"
+# the gene at levels that would create crosstalk. Pinned to 5 TPM after
+# the pfo004→THYM regression (#167): the original 1 TPM threshold was
+# dropping rare subtype markers like MYOD1 (TCGA_SARC median ≈ 0,
+# TCGA_UCS median 1.5) even though neither cohort materially expresses
+# the gene at median.
+_LINEAGE_COMPETITOR_FLOOR = 5.0
 _LINEAGE_MIN_GENES_AFTER_FILTER = 2  # don't prune a panel below this
 _LINEAGE_SPECIFIC_CACHE: dict = {}
 
@@ -445,8 +452,12 @@ def _cancer_specific_lineage_genes(cancer_code: str) -> list:
         home_val = float(ref.loc[gene, home_col] or 0.0)
         other_vals = ref.loc[gene, other_cols].astype(float)
         max_other = float(other_vals.max())
-        # Near-zero expression everywhere → filter doesn't apply.
-        if home_val + max_other < _LINEAGE_SPECIFICITY_IGNORE_BELOW:
+        # Competitor below the floor → no crosstalk risk; keep the
+        # gene. This preserves rare / subtype-specific markers whose
+        # cohort median is low in every cohort (MYOD1 / MYOG in SARC
+        # are the canonical case — only rhabdomyosarcoma subtypes
+        # express them, so the pan-cohort median is near zero).
+        if max_other < _LINEAGE_COMPETITOR_FLOOR:
             specific.append(gene)
             scored.append((gene, 1.0))
             continue

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.35.1"
+__version__ = "4.35.2"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_162_lineage_specificity.py
+++ b/tests/test_issue_162_lineage_specificity.py
@@ -59,6 +59,42 @@ def test_coad_panel_drops_genes_shared_with_other_gi():
     assert len(specific) >= 2
 
 
+def test_sarc_panel_retains_rare_subtype_markers_below_floor():
+    """#167 regression: MYOD1 and MYOG are rhabdomyosarcoma / muscle-
+    lineage markers whose cohort median is near-zero in every TCGA
+    cohort (including SARC — the cohort includes many non-muscle
+    sarcomas, pulling the median to 0). The filter must NOT drop them
+    as "non-specific" just because home_val=0; when the max competitor
+    is below the competitor floor (5 TPM), the gene is kept regardless.
+
+    On pfo004 (real sarcoma) MYOD1 is the only lineage marker that
+    yields a usable purity estimate — dropping it collapses SARC's
+    lineage concordance and lets THYM (with 0 concordance) win the
+    classifier.
+    """
+    specific = _cancer_specific_lineage_genes("SARC")
+    assert "MYOD1" in specific, (
+        "MYOD1 must be retained in SARC's panel — max-other ≈ 1.5 TPM "
+        "is below the 5 TPM competitor floor, so no crosstalk risk"
+    )
+    assert "MYOG" in specific, (
+        "MYOG must be retained in SARC's panel for the same reason"
+    )
+
+
+def test_sarc_panel_drops_tme_shared_smooth_muscle_markers():
+    """DES and ACTA2 are expressed at higher levels in PRAD's smooth-
+    muscle stroma than in TCGA SARC median, so they're genuinely not
+    SARC-specific and SHOULD be dropped from SARC's panel."""
+    specific = _cancer_specific_lineage_genes("SARC")
+    assert "DES" not in specific, (
+        "DES (PRAD=391 > SARC=56) should be dropped from SARC's panel"
+    )
+    assert "ACTA2" not in specific, (
+        "ACTA2 (PRAD=241 > SARC=189) should be dropped from SARC's panel"
+    )
+
+
 def test_filter_always_returns_at_least_minimum_genes():
     """Every cohort with a lineage panel keeps ≥ 2 genes (the
     estimator needs at least that to anchor a stable purity)."""


### PR DESCRIPTION
## Summary

Regression from PR #165 (#162 cross-cohort lineage-panel specificity). The filter was dropping rare subtype markers whose home-cohort median is near-zero, because a tiny non-zero value in any other cohort flipped the specificity ratio below 0.5 even though the competitor isn't really expressing the gene.

Canonical failure: **a real SARC validation sample → THYM** at 4.35.0. MYOD1 (rhabdomyosarcoma marker) has:
- TCGA_SARC median: 0.0 (the cohort includes many non-muscle sarcomas)
- TCGA_UCS median: 1.5
- specificity = 0 / 1.5 = 0 → filter dropped it

But on real sarcoma samples MYOD1 IS expressed at usable levels. Dropping it collapsed SARC's lineage concordance from 1.000 → None and THYM (with 0 concordance) won the geomean.

## Fix

Gate the specificity ratio on an absolute floor: ``max_other < 5 TPM`` → keep the gene regardless of ratio. Below the floor the competitor isn't really expressing the gene at crosstalk-risk levels.

## Verified

| Cohort | Before #167 | After #167 |
|---|---|---|
| SARC keeps | MYOD1 ❌, MYOG ❌ | **MYOD1 ✓, MYOG ✓** |
| SARC drops | DES, ACTA2 (still correct) | DES, ACTA2 (still correct) |
| SARC sample classifies as | THYM ❌ | **SARC ✓** |
| 33/33 TCGA medians | all correct | all correct (regression intact) |
| STAD / PAAD filter | same as before | same — MUC6/CDX2/KRT19/MUC1 still dropped |

## Tests

2 new regression tests in ``tests/test_issue_162_lineage_specificity.py``:
- ``test_sarc_panel_retains_rare_subtype_markers_below_floor``: MYOD1, MYOG in SARC's panel
- ``test_sarc_panel_drops_tme_shared_smooth_muscle_markers``: DES (PRAD=391 > SARC=56), ACTA2 still dropped

Full suite: **586 passed**, 1 skipped. Lint clean. Battery 33/33.

## Version

Bump to 4.35.2.