### PR TITLE
fix(confidence): surface contested-call uncertainty (closes #169)

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -285,8 +285,19 @@ def build_brief(
             lines.append(banner)
             lines.append("")
 
-    # Cancer call
-    lines.append(f"**Cancer call:** {cancer_code} ({cancer_name}).")
+    # Cancer call — annotated with #169 contested-call confidence when
+    # orthogonal signals (lineage concordance, runner-up gap, Stage-0
+    # top-ρ cohort) disagree with the classifier's pick.
+    from .confidence import compute_call_confidence
+    call_tier = compute_call_confidence(analysis)
+    if call_tier.tier in {"low", "moderate"} and call_tier.reasons:
+        suffix = (
+            f" — **{call_tier.tier} confidence** "
+            f"({call_tier.inline_note})"
+        )
+    else:
+        suffix = ""
+    lines.append(f"**Cancer call:** {cancer_code} ({cancer_name}).{suffix}")
 
     # Purity
     overall = purity.get("overall_estimate")
@@ -417,7 +428,18 @@ def build_actionable(
 
     # Cancer call + disease state
     lines.append("## Cancer call and disease state\n")
-    lines.append(f"Working call: **{cancer_code}** ({cancer_name}).")
+    from .confidence import compute_call_confidence
+    call_tier = compute_call_confidence(analysis)
+    if call_tier.tier in {"low", "moderate"} and call_tier.reasons:
+        call_suffix = (
+            f" — **{call_tier.tier} confidence** "
+            f"({call_tier.inline_note})"
+        )
+    else:
+        call_suffix = ""
+    lines.append(
+        f"Working call: **{cancer_code}** ({cancer_name}).{call_suffix}"
+    )
     # Stage-0 tissue-composition banner (if non-tumor-consistent) so
     # an actionable reader sees the Stage-0 caveat attached to the
     # working call, not buried in the summary. Same evidence-gated

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -135,6 +135,103 @@ def compute_purity_confidence(
     return ConfidenceTier(tier=tier, reasons=reasons)
 
 
+def compute_call_confidence(analysis) -> ConfidenceTier:
+    """Tier the cancer-type call itself based on orthogonal-signal contradictions.
+
+    The classifier's top candidate is its best guess, but that guess
+    can be fragile when orthogonal signals disagree. pirlygenes
+    computes several such signals that never feed back into the
+    confidence tier:
+
+    - ``lineage_concordance`` — how well the sample's lineage-gene
+      pattern matches the candidate's expected pattern. Near-zero
+      concordance means the classifier picked a candidate whose
+      lineage genes aren't expressed in the sample.
+    - Stage-0 top-ρ TCGA cohort vs the classifier's pick. When Stage
+      0 ranks cohort A first by correlation but the classifier picks
+      cohort B, that's a mismatch worth surfacing.
+    - Geomean gap to the runner-up. Top geomean 0.431 vs second 0.429
+      is a tied call, not a clean win.
+
+    This tier is independent of ``compute_purity_confidence`` — a
+    clean purity CI does not rescue a contested cancer-type call, and
+    a wide purity CI does not condemn an uncontested call.
+
+    Returns a ``ConfidenceTier`` with tier ∈ {high, moderate, low}
+    and reader-facing reason strings. ``low`` is the new tier for
+    "contested call" — reserved for cases where the call would be
+    materially different if any of the orthogonal signals were the
+    tiebreaker.
+
+    Issue #169 motivated this: pfo004 (real sarcoma) classified as
+    THYM with concordance=0.000 at 4.35.0, and the report emitted a
+    clean "Cancer call: THYM" with no caveat.
+    """
+    reasons: List[str] = []
+    tier = "high"
+
+    candidate_trace = analysis.get("candidate_trace") or []
+    if not candidate_trace:
+        return ConfidenceTier(tier="unknown", reasons=["no candidate trace"])
+
+    top = candidate_trace[0]
+    top_code = top.get("code")
+
+    # 1. Lineage concordance near zero — classifier picked a candidate
+    # whose lineage genes aren't expressed.
+    concordance = top.get("lineage_concordance")
+    if concordance is not None:
+        try:
+            concordance = float(concordance)
+        except (TypeError, ValueError):
+            concordance = None
+    if concordance is not None and concordance < 0.2:
+        tier = "low"
+        reasons.append(
+            f"lineage-pattern concordance is {concordance:.2f} "
+            f"(near zero) — sample does not match the expected "
+            f"{top_code} lineage-gene pattern"
+        )
+
+    # 2. Geomean gap to the runner-up. Within ~10% of the runner-up is
+    # a tied call.
+    if len(candidate_trace) >= 2:
+        second = candidate_trace[1]
+        top_gm = float(top.get("support_geomean") or 0.0)
+        second_gm = float(second.get("support_geomean") or 0.0)
+        if second_gm > 0 and (top_gm / second_gm) < 1.1:
+            gap_pct = (top_gm / second_gm - 1.0) * 100 if second_gm else 0
+            second_code = second.get("code")
+            if tier == "high":
+                tier = "moderate"
+            reasons.append(
+                f"top candidate {top_code} beats runner-up {second_code} "
+                f"by only {gap_pct:.0f}% on geomean ({top_gm:.3f} vs "
+                f"{second_gm:.3f}) — call is ambiguous"
+            )
+
+    # 3. Stage-0 top-ρ TCGA cohort disagrees with the classifier's
+    # pick. Sample-level correlation is the coarsest signal and can
+    # be more reliable than the classifier's geomean when the panel
+    # evidence is weak.
+    hvt = analysis.get("healthy_vs_tumor")
+    stage0_top_code = None
+    if hvt is not None:
+        tcga = getattr(hvt, "top_tcga_cohorts", None) or []
+        if tcga:
+            name, _rho = tcga[0]
+            stage0_top_code = name.replace("FPKM_", "") if isinstance(name, str) else None
+    if stage0_top_code and top_code and stage0_top_code != top_code:
+        if tier == "high":
+            tier = "moderate"
+        reasons.append(
+            f"Stage-0 correlation favored {stage0_top_code} but the "
+            f"classifier picked {top_code}"
+        )
+
+    return ConfidenceTier(tier=tier, reasons=reasons)
+
+
 def compute_target_confidence(
     row,
     purity_tier: ConfidenceTier,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.35.2"
+__version__ = "4.36.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_169_call_confidence.py
+++ b/tests/test_issue_169_call_confidence.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #169 — cancer-type call confidence.
+
+The classifier's top candidate is its best guess, but that guess can
+be fragile when orthogonal signals disagree. ``compute_call_confidence``
+downgrades the tier to ``low`` / ``moderate`` and surfaces reader-
+facing reasons when:
+
+1. Top candidate's lineage concordance < 0.2 (near zero)
+2. Geomean gap to runner-up < 1.1× (tied call)
+3. Stage-0 top-ρ TCGA cohort disagrees with the classifier's pick
+
+Canonical failure the tier catches: pfo004 at 4.35.0 → THYM with
+concordance 0.000 and a 0.002 geomean margin over SARC.
+"""
+
+from pirlygenes.confidence import compute_call_confidence
+
+
+def _candidate(code, **overrides):
+    base = {
+        "code": code,
+        "signature_score": 0.6,
+        "support_geomean": 0.5,
+        "lineage_concordance": 0.8,
+        "family_label": None,
+        "purity_estimate": 0.5,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_clean_call_returns_high_tier():
+    """A top candidate with strong concordance and a big lead returns
+    ``high`` confidence with no reasons."""
+    analysis = {
+        "candidate_trace": [
+            _candidate("PRAD", support_geomean=0.70, lineage_concordance=0.95),
+            _candidate("BRCA", support_geomean=0.30, lineage_concordance=0.20),
+        ],
+    }
+    tier = compute_call_confidence(analysis)
+    assert tier.tier == "high"
+    assert tier.reasons == []
+
+
+def test_zero_concordance_top_call_is_low_confidence():
+    """The pfo004 → THYM regression: top candidate's lineage genes
+    aren't expressed in the sample (concordance 0.0). That's a
+    contested call, not a clean win."""
+    analysis = {
+        "candidate_trace": [
+            _candidate("THYM", support_geomean=0.43, lineage_concordance=0.0),
+            _candidate("SARC", support_geomean=0.42, lineage_concordance=1.0),
+        ],
+    }
+    tier = compute_call_confidence(analysis)
+    assert tier.tier == "low"
+    # Reason should mention the concordance value
+    assert any("concordance" in r.lower() for r in tier.reasons)
+    assert any("0.00" in r for r in tier.reasons)
+
+
+def test_tied_geomean_downgrades_to_moderate():
+    """Geomean gap of < 10% is a tied call — downgrade to moderate."""
+    analysis = {
+        "candidate_trace": [
+            _candidate("A", support_geomean=0.50, lineage_concordance=0.8),
+            _candidate("B", support_geomean=0.48, lineage_concordance=0.8),
+        ],
+    }
+    tier = compute_call_confidence(analysis)
+    assert tier.tier == "moderate"
+    assert any("ambiguous" in r.lower() for r in tier.reasons)
+
+
+def test_stage0_mismatch_downgrades_to_moderate():
+    """Stage-0 correlation favors a cohort the classifier didn't pick
+    — surface the mismatch."""
+    class _HVT:
+        top_tcga_cohorts = [("FPKM_SARC", 0.77)]
+    analysis = {
+        "candidate_trace": [
+            _candidate("THYM", support_geomean=0.43, lineage_concordance=0.8),
+            _candidate("BRCA", support_geomean=0.30, lineage_concordance=0.6),
+        ],
+        "healthy_vs_tumor": _HVT(),
+    }
+    tier = compute_call_confidence(analysis)
+    assert tier.tier == "moderate"
+    assert any("Stage-0" in r and "SARC" in r for r in tier.reasons)
+
+
+def test_multiple_contradictions_all_surface_at_low_tier():
+    """Zero concordance + Stage-0 mismatch + tied geomean → tier stays
+    ``low`` and all three reasons appear."""
+    class _HVT:
+        top_tcga_cohorts = [("FPKM_SARC", 0.77)]
+    analysis = {
+        "candidate_trace": [
+            _candidate("THYM", support_geomean=0.431, lineage_concordance=0.0),
+            _candidate("SARC", support_geomean=0.429, lineage_concordance=1.0),
+        ],
+        "healthy_vs_tumor": _HVT(),
+    }
+    tier = compute_call_confidence(analysis)
+    assert tier.tier == "low"
+    assert len(tier.reasons) == 3
+
+
+def test_missing_candidate_trace_returns_unknown():
+    tier = compute_call_confidence({})
+    assert tier.tier == "unknown"
+    tier = compute_call_confidence({"candidate_trace": []})
+    assert tier.tier == "unknown"
+
+
+def test_stage0_match_does_not_downgrade():
+    """Stage-0 agreeing with the classifier keeps the tier high."""
+    class _HVT:
+        top_tcga_cohorts = [("FPKM_PRAD", 0.82)]
+    analysis = {
+        "candidate_trace": [
+            _candidate("PRAD", support_geomean=0.70, lineage_concordance=0.95),
+            _candidate("BRCA", support_geomean=0.30, lineage_concordance=0.20),
+        ],
+        "healthy_vs_tumor": _HVT(),
+    }
+    tier = compute_call_confidence(analysis)
+    assert tier.tier == "high"


### PR DESCRIPTION
## Summary

Classification is never 100% certain. The pipeline already computes every orthogonal signal needed to flag a contested call — concordance, Stage-0 ρ, runner-up gap — but none of them feed back into the confidence tier. On a SARC validation sample at 4.35.0 this produced a silent miscall:

    Cancer call: THYM (Thymoma).  [geomean 0.431, concordance 0.000]

Zero concordance = the classifier picked a candidate whose lineage genes aren't expressed in the sample. That should never be presented as a clean win.

## Fix

Adds ``compute_call_confidence(analysis)`` in ``pirlygenes/confidence.py`` that consumes three orthogonal signals:

1. **Lineage concordance < 0.2** → tier becomes ``low``. Top candidate's lineage-gene pattern doesn't match.
2. **Geomean gap to runner-up < 1.1×** → tier becomes ``moderate``. Tied call, not a clean win.
3. **Stage-0 top-ρ TCGA ≠ classifier's pick** → tier becomes ``moderate``. Coarsest correlation disagrees.

Multiple contradictions stack (reasons accumulate; tier stays at the lowest).

Brief + actionable now append the confidence suffix to the cancer-call line:

    Cancer call: THYM (Thymoma). — **low confidence**
    (lineage-pattern concordance is 0.00 (near zero) — sample does not match the expected THYM lineage-gene pattern;
     top candidate THYM beats runner-up SARC by only 0% on geomean (0.431 vs 0.429) — call is ambiguous;
     Stage-0 correlation favored SARC but the classifier picked THYM)

## Independence

This tier is separate from ``compute_purity_confidence`` — a clean CI doesn't rescue a contested call, and a wide CI doesn't condemn an uncontested one.

## Tests

7 new tests in ``tests/test_issue_169_call_confidence.py``:
- Clean call (high signals + big gap) → ``high``
- Zero concordance → ``low``
- Tied geomean → ``moderate``
- Stage-0 mismatch → ``moderate``
- Multiple contradictions → ``low`` with all reasons surfaced
- Missing candidate trace → ``unknown``
- Stage-0 match does not downgrade

Full suite: **593 passed**. Lint clean.

## Version

Bump to 4.36.0.