### PR TITLE
chore: scrub internal validation-sample IDs from public artifacts

### DIFF
--- a/docs/stage0-reasoning.md
+++ b/docs/stage0-reasoning.md
@@ -92,8 +92,8 @@ first rule whose precondition matches fires and writes to the
 The ordering is deliberate: R1 (strong tumor evidence) fires before
 R2/R3 (structural ambiguity) because a sample with overwhelming
 CTA signal is definitively tumor even in a lineage-ambiguous
-correlation regime. pfo004 (SARC, 58 CTA hits at 5000+ TPM) is the
-canonical R1-wins-over-R3 case.
+correlation regime. A real SARC sample with ~58 CTA hits at very
+high TPM is the canonical strong-evidence-wins-over-ambiguity case.
 
 ## Banner suppression
 

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1295,10 +1295,11 @@ def _analyze_body(
         # matches the classifier AND its template has non-tumor
         # compartments. A template without TME compartments trivially
         # returns fraction=1.0 (everything maps to tumor by construction),
-        # which is not a purity measurement — pfo002 / BRCA template was
-        # the failure case: classifier said 36% (COAD), but BRCA template
-        # with "No non-tumor components in template" warning returned
-        # fraction=100% and that propagated as the headline purity.
+        # which is not a purity measurement — the canonical failure
+        # case is a CRC sample whose classifier said 36% (COAD) but
+        # whose best-fit decomposition template was BRCA / solid_primary
+        # with "No non-tumor components in template"; fraction=100%
+        # propagated as the headline purity.
         decomp_agrees = (best_decomp.cancer_type == cancer_code)
         decomp_has_tme = not any(
             "No non-tumor components in template" in w
@@ -2964,8 +2965,9 @@ def _generate_text_reports(
         # detected-but-uninformative. The estimator skips lineage genes
         # whose TME bleed-through in the reference exceeds their tumor
         # contribution; those genes are still present in the sample at
-        # real TPM, they just can't anchor a lineage purity. pfo004 /
-        # SARC / ACTA2 is the canonical case.
+        # real TPM, they just can't anchor a lineage purity. The
+        # canonical case is SARC-ACTA2: ACTA2 at ~190 TPM in the
+        # sample but TME-dominated at the TCGA SARC reference.
         from .tumor_purity import LINEAGE_GENES
         cancer_code_local = purity.get("cancer_type", cancer_code)
         all_lineage = LINEAGE_GENES.get(cancer_code_local, [])

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -163,9 +163,9 @@ def compute_call_confidence(analysis) -> ConfidenceTier:
     materially different if any of the orthogonal signals were the
     tiebreaker.
 
-    Issue #169 motivated this: pfo004 (real sarcoma) classified as
-    THYM with concordance=0.000 at 4.35.0, and the report emitted a
-    clean "Cancer call: THYM" with no caveat.
+    Issue #169 motivated this: a real sarcoma validation sample was
+    classified as THYM with concordance=0.000 at 4.35.0, and the
+    report emitted a clean "Cancer call: THYM" with no caveat.
     """
     reasons: List[str] = []
     tier = "high"

--- a/pirlygenes/healthy_vs_tumor.py
+++ b/pirlygenes/healthy_vs_tumor.py
@@ -158,8 +158,9 @@ _TUMOR_UP_PANEL_STRONG_COUNT = 2
 # sample battery: healthy tissues (GTEx brain / smooth muscle / spleen)
 # show a few CTA hits at 1-5 TPM (PHF7, STKLD1, TEX14 — broadly
 # expressed CTAs with relaxed tumor specificity). Tumors with real
-# CTA re-expression (rs PRAD DAZ3=13, pfo002 CRC PIWIL1=8, pfo004
-# sarcoma PAGE5=1383) sit one or two orders of magnitude higher.
+# CTA re-expression (low-purity PRAD with DAZ3 ≈ 13 TPM, CRC with
+# PIWIL1 ≈ 8, sarcoma with PAGE5 ≈ 1383) sit one or two orders of
+# magnitude above the healthy-tissue noise floor.
 # Per-gene 3 TPM + count ≥ 4 avoids the healthy-tissue CTA noise
 # floor while preserving tumor detection at low purity.
 _CTA_PER_GENE_MIN_TPM = 3.0

--- a/pirlygenes/reasoning.py
+++ b/pirlygenes/reasoning.py
@@ -171,8 +171,8 @@ def tumor_marker_overrides_ambiguity(s, f) -> Optional[RuleOutcome]:
     """A strong tumor-specific marker — CTA, oncofetal, or type-specific
     — overrides the lymphoid/mesenchymal-ambiguity flag.
 
-    Canonical case: pfo004 (real SARC) with 58 CTA hits is definitively
-    tumor despite the mesenchymal correlation regime.
+    Canonical case: a real SARC sample with ~58 CTA hits at high TPM
+    is definitively tumor despite the mesenchymal correlation regime.
     """
     if not (f.in_ambiguous_regime and f.any_tumor_marker_strong):
         return None
@@ -221,7 +221,8 @@ def aggregate_tumor_evidence(s, f) -> Optional[RuleOutcome]:
     categories (CTA, oncofetal, type-specific, proliferation, hypoxia,
     glycolysis) sums to ≥ 1.0, OR any single tumor-marker category is
     strong on its own → tumor-consistent. Catches the low-purity case
-    where multiple soft categories co-occur (rs PRAD)."""
+    where multiple soft categories co-occur (e.g. a ~16%-purity PRAD
+    sample with soft CTA + soft oncofetal + soft glycolysis)."""
     agg = s.evidence.aggregate_score
     if not (agg >= 1.0 or f.any_tumor_marker_strong):
         return None

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -398,7 +398,7 @@ _LINEAGE_SPECIFICITY_MIN = 0.5  # home / (home + max_other) ≥ 0.5
 # The filter only fires when the competing cohort's expression is above
 # this absolute floor — below it, the competitor isn't really "expressing"
 # the gene at levels that would create crosstalk. Pinned to 5 TPM after
-# the pfo004→THYM regression (#167): the original 1 TPM threshold was
+# the sarcoma→THYM regression (#167): the original 1 TPM threshold was
 # dropping rare subtype markers like MYOD1 (TCGA_SARC median ≈ 0,
 # TCGA_UCS median 1.5) even though neither cohort materially expresses
 # the gene at median.
@@ -543,8 +543,8 @@ def _lineage_purity_estimates(cancer_code, sample_tpm, ref_by_sym, hk_syms, tcga
     # sample but dropped by the estimator (TME signal exceeds tumor
     # signal in the reference, so the gene can't anchor a purity
     # estimate). Callers can surface these as "uninformative" rather
-    # than "not detected" — the distinction matters for pfo004-style
-    # cases where ACTA2 is at 189 TPM but gets filtered because its
+    # than "not detected" — the distinction matters for sarcoma-style
+    # cases where ACTA2 is at ~190 TPM but gets filtered because its
     # TME-bleed-through in SARC exceeds its tumor contribution.
     skipped_detected = []
     for gene in genes:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.37.0"
+__version__ = "4.37.1"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_battery_audit_fixes.py
+++ b/tests/test_battery_audit_fixes.py
@@ -1,8 +1,9 @@
 """Regression tests for the battery-audit fixes (PR #159).
 
 Each bug here was a report-correctness issue found by auditing the
-pfo002 (CRC) and pfo004 (SARC) markdown outputs. These tests pin the
-root-cause fixes so a future refactor can't silently regress them.
+markdown outputs for a CRC validation sample and a SARC validation
+sample. These tests pin the root-cause fixes so a future refactor
+can't silently regress them.
 """
 
 import math
@@ -71,7 +72,8 @@ def test_render_vs_tcga_both_absent_renders_dash():
 
 
 def test_render_vs_tcga_preserves_large_finite_folds_uncapped():
-    """ITGA10 in pfo004 renders at 1548× — capping would mask the signal."""
+    """ITGA10 in a SARC validation sample renders at 1548× — capping
+    would mask the signal."""
     row = _row(tcga_ref_state="finite", pct_cancer_median=1548.45)
     out = _render_vs_tcga_cell(row)
     assert "1548" in out
@@ -213,8 +215,8 @@ def test_decomp_purity_adoption_guard_matches_docstring():
 
     The logic isn't extracted into a helper yet — this test encodes
     the contract so a future refactor can pull out a named predicate
-    without losing behavior. pfo002 / BRCA-template 100% was the
-    failure case: classifier=COAD, decomp=BRCA → decomp_agrees=False
+    without losing behavior. The canonical failure was a CRC
+    validation sample where classifier=COAD, decomp=BRCA → decomp_agrees=False
     → keep classifier's 36%.
     """
     # Simulate the three branches that should NOT adopt decomp purity:

--- a/tests/test_issue_162_lineage_specificity.py
+++ b/tests/test_issue_162_lineage_specificity.py
@@ -67,10 +67,10 @@ def test_sarc_panel_retains_rare_subtype_markers_below_floor():
     as "non-specific" just because home_val=0; when the max competitor
     is below the competitor floor (5 TPM), the gene is kept regardless.
 
-    On pfo004 (real sarcoma) MYOD1 is the only lineage marker that
-    yields a usable purity estimate — dropping it collapses SARC's
-    lineage concordance and lets THYM (with 0 concordance) win the
-    classifier.
+    On a real sarcoma validation sample, MYOD1 is the only lineage
+    marker that yields a usable purity estimate — dropping it
+    collapses SARC's lineage concordance and lets THYM (with 0
+    concordance) win the classifier.
     """
     specific = _cancer_specific_lineage_genes("SARC")
     assert "MYOD1" in specific, (

--- a/tests/test_issue_169_call_confidence.py
+++ b/tests/test_issue_169_call_confidence.py
@@ -9,8 +9,9 @@ facing reasons when:
 2. Geomean gap to runner-up < 1.1× (tied call)
 3. Stage-0 top-ρ TCGA cohort disagrees with the classifier's pick
 
-Canonical failure the tier catches: pfo004 at 4.35.0 → THYM with
-concordance 0.000 and a 0.002 geomean margin over SARC.
+Canonical failure the tier catches: a real sarcoma validation
+sample at 4.35.0 → THYM with concordance 0.000 and a 0.002 geomean
+margin over SARC.
 """
 
 from pirlygenes.confidence import compute_call_confidence
@@ -44,7 +45,7 @@ def test_clean_call_returns_high_tier():
 
 
 def test_zero_concordance_top_call_is_low_confidence():
-    """The pfo004 → THYM regression: top candidate's lineage genes
+    """The SARC → THYM regression: top candidate's lineage genes
     aren't expressed in the sample (concordance 0.0). That's a
     contested call, not a clean win."""
     analysis = {


### PR DESCRIPTION
## Summary

Internal clinical validation samples had been referenced by ID in comments, docstrings, and tests across the package. Those IDs are private and must not ship on PyPI or appear in the public GitHub repo.

This PR replaces every reference with anonymized clinical-phenotype descriptions, preserving the technical substance without the ID. No behavioral change; 627/627 tests pass.

## Scrubbed files

- `pirlygenes/healthy_vs_tumor.py`
- `pirlygenes/tumor_purity.py`
- `pirlygenes/cli.py`
- `pirlygenes/confidence.py`
- `pirlygenes/reasoning.py`
- `docs/stage0-reasoning.md`
- `tests/test_battery_audit_fixes.py`
- `tests/test_issue_162_lineage_specificity.py`
- `tests/test_issue_169_call_confidence.py`

## Going forward

A memory guideline is now in place so sample IDs don't appear in committed text, commit messages, PR bodies, or issue bodies.

## Historical note

Earlier commits and merged PR / issue bodies still contain the IDs. Rewriting history would require force-pushing and isn't practical since the information is already public. Going forward is the actionable scope; this PR stops the bleed.

## Version

Bump to 4.37.1 (patch — descriptions only).