### PR TITLE
chore: raise perf-fence ceiling to 120s (flake under coverage)

### DIFF
--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.38.0"
+__version__ = "4.38.1"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_perf_regression.py
+++ b/tests/test_perf_regression.py
@@ -38,11 +38,11 @@ import pytest
 
 N_TRANSCRIPTS = 5_000
 # Ceiling is set to catch *catastrophic* regressions (10×+), not micro
-# drift. A single-process local run lands at ~2s; xdist + noisy CI can
-# push this materially higher without indicating a real regression.
-# Keep enough slack that routine parallel-suite runs don't flake, and
-# a 10× regression to ~20s still fires.
-TIME_CEILING_S = 45.0
+# drift. A single-process local run lands at ~2s; xdist + coverage +
+# noisy CI can push this materially higher without indicating a real
+# regression. Keep enough slack that routine parallel-suite runs don't
+# flake, and a 50× regression to ~100s still fires.
+TIME_CEILING_S = 120.0
 
 
 def _make_fake_quant(path: Path, n: int = N_TRANSCRIPTS, seed: int = 42) -> None:


### PR DESCRIPTION
## Summary

``tests/test_perf_regression.py::test_load_expression_data_perf_fence`` was flaking on ``deploy.sh`` (which runs pytest with ``--cov``) on 10-way xdist. Single-process local runs land at ~2s; coverage + xdist pushes closer to 50–60s. The 45s ceiling was too tight.

120s still catches 50×+ regressions with enough slack to stop flaking under load.

## Version
Bump to 4.38.1 (patch — infra only).