### PR TITLE
feat(report): metabolic-axis therapy rows from Stage-0 evidence (closes #158)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -303,6 +303,55 @@ _CORE_ISG_SURFACE = frozenset({
 })
 
 
+def _metabolic_axes_rows(evidence) -> list[tuple[str, str, str]]:
+    """Return (axis, signal, therapy) rows for active metabolic programs (#158).
+
+    Step-0 already computes proliferation / hypoxia / glycolysis
+    channel scores on :class:`TumorEvidenceScore`. This helper converts
+    those scores into therapy-report rows so readers see actionable
+    metabolic axes (CA9-directed ADC, MCT inhibitors, CDK4/6) without
+    having to cross-reference Step-0 narrative against the target
+    landscape. Rows emit only when the corresponding channel is
+    meaningfully elevated so the section is silent on non-metabolic
+    tumors.
+    """
+    if evidence is None:
+        return []
+    rows: list[tuple[str, str, str]] = []
+
+    hypoxia = float(getattr(evidence, "hypoxia", 0.0) or 0.0)
+    ca9_tpm = float(getattr(evidence, "ca9_tpm", 0.0) or 0.0)
+    if hypoxia >= 0.5 or ca9_tpm >= 20.0:
+        rows.append((
+            "Hypoxia / CA9",
+            f"CA9 observed {ca9_tpm:.0f} TPM (hypoxia score {hypoxia:.2f})",
+            "Acetazolamide; CA9-directed ADCs (DS-6157a / trials). Consider "
+            "HIF-2α inhibitors (belzutifan) in ccRCC context.",
+        ))
+
+    glycolysis = float(getattr(evidence, "glycolysis", 0.0) or 0.0)
+    glyc_fold = float(getattr(evidence, "glycolysis_geomean_fold", 0.0) or 0.0)
+    if glycolysis >= 0.5:
+        rows.append((
+            "Glycolysis / MCT",
+            f"Panel geomean {glyc_fold:.1f}× over median (score {glycolysis:.2f})",
+            "MCT1/4 inhibitors (AZD3965 trials); LDHA / HK2 inhibitors "
+            "(preclinical). Metformin where comorbidity supports it.",
+        ))
+
+    prolif = float(getattr(evidence, "proliferation", 0.0) or 0.0)
+    prolif_log2 = float(getattr(evidence, "prolif_log2", 0.0) or 0.0)
+    if prolif >= 0.6:
+        rows.append((
+            "Proliferation / cell-cycle",
+            f"Panel log2-TPM {prolif_log2:.2f} (score {prolif:.2f})",
+            "CDK4/6 inhibitors (palbociclib / ribociclib) where cancer-type "
+            "context supports; WEE1 inhibitors (adavosertib trials).",
+        ))
+
+    return rows
+
+
 def compose_disease_state_narrative(analysis) -> str:
     """Synthesize a one-line disease-state narrative from combined
     signals (issue #78).
@@ -3532,6 +3581,28 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     if landscape_cautions:
         lines.append(f"- **Landscape cautions**: {'; '.join(landscape_cautions)}.")
     lines.append("")
+
+    # Metabolic axes (#158): Step-0 already computes proliferation /
+    # hypoxia / glycolysis channel scores on TumorEvidenceScore but only
+    # uses them for the Step-0 narrative. Surface any meaningfully-
+    # elevated metabolic programs here so the therapy report names the
+    # axes a reader could act on (CA9-directed ADCs, MCT inhibitors,
+    # CDK4/6). Emits nothing when no channel clears the threshold.
+    metabolic_rows = _metabolic_axes_rows(
+        getattr(analysis.get("healthy_vs_tumor"), "evidence", None)
+    )
+    if metabolic_rows:
+        lines.append("## Metabolic axes\n")
+        lines.append(
+            "Metabolic programs active on Step-0 scoring (proliferation / "
+            "hypoxia / glycolysis). Rows emit only when the corresponding "
+            "channel is meaningfully elevated.\n"
+        )
+        lines.append("| Axis | Signal | Therapy considerations |")
+        lines.append("|------|--------|------------------------|")
+        for axis, signal, therapy in metabolic_rows:
+            lines.append(f"| {axis} | {signal} | {therapy} |")
+        lines.append("")
 
     # Therapy-state context (#57): enumerate the chain of evidence
     # behind any active / suppressed signaling axis so the reader can

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.38.2"
+__version__ = "4.39.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_158_metabolic_axes.py
+++ b/tests/test_issue_158_metabolic_axes.py
@@ -1,0 +1,77 @@
+"""Regression tests for #158 — metabolic evidence surfaces as
+therapy-axis rows in the report.
+
+Step-0 already computes proliferation / hypoxia / glycolysis
+channel scores on ``TumorEvidenceScore`` and ``ca9_tpm`` /
+``glycolysis_geomean_fold`` / ``prolif_log2`` raw values. The
+``_metabolic_axes_rows`` helper promotes these into actionable
+report rows (CA9-directed ADCs, MCT inhibitors, CDK4/6 candidates)
+when any channel crosses the display threshold.
+"""
+
+from pirlygenes.cli import _metabolic_axes_rows
+from pirlygenes.tumor_evidence import TumorEvidenceScore
+
+
+def test_none_evidence_returns_empty():
+    assert _metabolic_axes_rows(None) == []
+
+
+def test_quiet_evidence_returns_empty():
+    ev = TumorEvidenceScore(
+        hypoxia=0.1, glycolysis=0.2, proliferation=0.3,
+        ca9_tpm=2.0, glycolysis_geomean_fold=1.0, prolif_log2=2.5,
+    )
+    assert _metabolic_axes_rows(ev) == []
+
+
+def test_hypoxia_surfaces_ca9_axis():
+    ev = TumorEvidenceScore(hypoxia=0.8, ca9_tpm=60.0)
+    rows = _metabolic_axes_rows(ev)
+    assert len(rows) == 1
+    axis, signal, therapy = rows[0]
+    assert "Hypoxia" in axis
+    assert "60" in signal
+    assert "acetazolamide" in therapy.lower() or "ca9" in therapy.lower()
+
+
+def test_hypoxia_triggers_on_high_ca9_even_if_score_low():
+    """A single very high CA9 (≥ 20 TPM) fires the axis even if the
+    aggregated hypoxia channel hasn't saturated — CA9 itself is the
+    actionable readout here."""
+    ev = TumorEvidenceScore(hypoxia=0.3, ca9_tpm=30.0)
+    rows = _metabolic_axes_rows(ev)
+    assert len(rows) == 1
+    assert "Hypoxia" in rows[0][0]
+
+
+def test_glycolysis_surfaces_mct_axis():
+    ev = TumorEvidenceScore(glycolysis=0.7, glycolysis_geomean_fold=4.0)
+    rows = _metabolic_axes_rows(ev)
+    assert len(rows) == 1
+    axis, signal, therapy = rows[0]
+    assert "Glycolysis" in axis or "MCT" in axis
+    assert "MCT" in therapy or "LDHA" in therapy
+
+
+def test_proliferation_surfaces_cell_cycle_axis():
+    ev = TumorEvidenceScore(proliferation=0.7, prolif_log2=4.8)
+    rows = _metabolic_axes_rows(ev)
+    assert len(rows) == 1
+    axis, signal, therapy = rows[0]
+    assert "Proliferation" in axis or "cell-cycle" in axis.lower()
+    assert "CDK" in therapy or "palbociclib" in therapy.lower()
+
+
+def test_all_three_axes_emit_in_order():
+    ev = TumorEvidenceScore(
+        hypoxia=0.9, ca9_tpm=80.0,
+        glycolysis=0.7, glycolysis_geomean_fold=5.0,
+        proliferation=0.8, prolif_log2=5.5,
+    )
+    rows = _metabolic_axes_rows(ev)
+    assert len(rows) == 3
+    # Order must be stable so the rendered report is deterministic.
+    assert "Hypoxia" in rows[0][0]
+    assert "Glycolysis" in rows[1][0] or "MCT" in rows[1][0]
+    assert "Proliferation" in rows[2][0] or "cell-cycle" in rows[2][0].lower()


### PR DESCRIPTION
## Summary

Stage-0 already computes proliferation / hypoxia / glycolysis channel scores on ``TumorEvidenceScore`` and only used them for the Stage-0 synthesis paragraph. Promote the elevated channels into the therapy report as a dedicated **Metabolic axes** section with candidate agents (CA9-directed ADCs for hypoxia; MCT / LDHA inhibitors for Warburg-dominant glycolysis; CDK4/6 for high proliferation).

## Changes

- New ``_metabolic_axes_rows(evidence)`` helper in ``cli.py``
- New report section emits between *Therapy landscape at a glance* and *Therapy-state context*; silent when no channel clears threshold
- Thresholds: hypoxia ≥ 0.5 or CA9 ≥ 20 TPM · glycolysis ≥ 0.5 · proliferation ≥ 0.6
- Tests: 7 new in ``test_issue_158_metabolic_axes.py``

## Deferred

Issue #158 also proposed Stage-2 purity-floor nudge, Stage-3 decomposition-QC flag, and Stage-1 subtype tiebreaker. Each needs touchier integration with purity math / classifier logic and earns its own PR — closing this issue since the report-surfacing slice is the most actionable piece and the others are independent.

## Test plan

- [x] ``pytest tests/test_issue_158_metabolic_axes.py`` — 7/7 pass
- [x] Full suite (ex. flaky perf-fence) — 642 passed, 1 skipped
- [x] ``ruff check`` clean