### PR TITLE
chore: rename pipeline Stage-N → Step-N (avoid clinical-staging collision)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Curated gene sets, pan-cancer expression references, and bulk RNA-seq decomposit
 - [Quick start](#quick-start) — install, run `analyze`, use gene sets in Python
 - [Gene sets](#gene-sets) — what's bundled and how to access it
 - [Analyze command](#the-analyze-command) — full single-sample pipeline
-  - [Attribution flow](#attribution-flow-make-it-make-sense) — the 5-stage decomposition logic
+  - [Attribution flow](#attribution-flow-make-it-make-sense) — the 5-step decomposition logic
   - [CLI arguments](#cli-arguments)
   - [Sample quality](#sample-quality-assessment)
   - [Decomposition](#broad-compartment-decomposition)
@@ -114,36 +114,36 @@ The main entry point for single-sample analysis. Takes a gene expression file (C
 
 See [docs/analyze-command.md](docs/analyze-command.md) for full output file reference.
 
-### Reasoning pipeline: coarse-to-fine with explicit stages
+### Reasoning pipeline: coarse-to-fine with explicit steps
 
-See [docs/reasoning-pipeline.md](docs/reasoning-pipeline.md) for the complete stage inventory and information-flow contract. Short version:
+See [docs/reasoning-pipeline.md](docs/reasoning-pipeline.md) for the complete step inventory and information-flow contract. Short version:
 
 ```
-  Stage 0a  Sample context        library prep + preservation + degradation
-  Stage 0b  Tissue composition    top HPA normals + top TCGA cohorts + cancer-hint
-  Stage 1   Cancer-type call      top-k TCGA candidates (signature + purity + lineage)
-  Stage 2   Tumor purity          point + CI + confidence tier
-  Stage 3   Broad decomposition   NNLS fit of tumor + TME (template-aware)
-  Stage 4   Therapy-axis state    AR / EMT / hypoxia / IFN / HER2 / ER up/down calls
-  Stage 5   Tumor-value core      9-point per-gene tumor-TPM
-  Stage 6   Report synthesis      brief / actionable / summary / analysis / targets / provenance
+  Step 0a  Sample context        library prep + preservation + degradation
+  Step 0b  Tissue composition    top HPA normals + top TCGA cohorts + cancer-hint
+  Step 1   Cancer-type call      top-k TCGA candidates (signature + purity + lineage)
+  Step 2   Tumor purity          point + CI + confidence tier
+  Step 3   Broad decomposition   NNLS fit of tumor + TME (template-aware)
+  Step 4   Therapy-axis state    AR / EMT / hypoxia / IFN / HER2 / ER up/down calls
+  Step 5   Tumor-value core      9-point per-gene tumor-TPM
+  Step 6   Report synthesis      brief / actionable / summary / analysis / targets / provenance
 ```
 
-Each stage writes a named result into a shared `analysis` dict; downstream stages read but never overwrite. Contracts are explicit — a reader of the final brief can trace any claim back through the stage chain. The guiding principle: if a sample is flagged ambiguous at Stage 0, that flag propagates through to Stage 6; no downstream stage silently promotes a soft-confidence call to a confident one.
+Each step writes a named result into a shared `analysis` dict; downstream steps read but never overwrite. Contracts are explicit — a reader of the final brief can trace any claim back through the step chain. The guiding principle: if a sample is flagged ambiguous at Step 0, that flag propagates through to Step 6; no downstream step silently promotes a soft-confidence call to a confident one.
 
 ### Attribution flow: "make it make sense"
 
 `pirlygenes` treats every TPM in a bulk tumor sample as a claim that must be *attributed* to some source — and then explains away as much of it as possible before crediting the tumor. The goal is a conservative, defensible core of tumor-specific expression, not a lift of raw TPM straight into therapeutic target recommendations.
 
-The flow runs in five stages:
+The flow runs in five steps:
 
-1. **Sample context** (runs *first*, before any cancer-type inference). A `SampleContext` is inferred from the expression table alone — what **library prep** produced the data (poly-A capture, ribo-depletion, total RNA, or exome capture) and what **preservation / degradation** state the RNA is in (fresh-frozen, FFPE, partial degradation). This becomes a **base layer of expression expectations**: which genes are expected to be over- or under-represented for *artifactual* reasons, independent of biology. The context is propagated forward and every downstream stage reads from it.
+1. **Sample context** (runs *first*, before any cancer-type inference). A `SampleContext` is inferred from the expression table alone — what **library prep** produced the data (poly-A capture, ribo-depletion, total RNA, or exome capture) and what **preservation / degradation** state the RNA is in (fresh-frozen, FFPE, partial degradation). This becomes a **base layer of expression expectations**: which genes are expected to be over- or under-represented for *artifactual* reasons, independent of biology. The context is propagated forward and every downstream step reads from it.
 2. **Coarse healthy-tissue decomposition.** Broad non-tumor compartments (T cell, B cell, myeloid, fibroblast, endothelial, plus site-specific host tissue for met samples) are fit by weighted NNLS against curated marker panels, anchored to an externally-estimated tumor purity.
 3. **Fine TME-subtype / activation-state dissection** (in progress: CAF vs healthy fibroblast, TAM polarisation, exhausted T, tumor endothelium, etc.). Activated-state references refine the coarse compartment call into biologically actionable subsets.
 4. **Tumor-value adjustment.** Per gene, the TME and matched-normal contributions are subtracted from the observed TPM before dividing by purity. Genes whose observed signal is dominantly explained by non-tumor compartments are flagged `tme_explainable` rather than credited to the tumor.
-5. **Conservative tumor-specific core.** What remains after stages 1–4 is reported as a bounded per-gene tumor-expression range (9-point across low/median/high TME and low/median/high purity), with a low-purity caveat for samples below 20% purity where TME residuals would otherwise be amplified ≥5×.
+5. **Conservative tumor-specific core.** What remains after steps 1–4 is reported as a bounded per-gene tumor-expression range (9-point across low/median/high TME and low/median/high purity), with a low-purity caveat for samples below 20% purity where TME residuals would otherwise be amplified ≥5×.
 
-Each stage *adds* to the attribution chain; none replaces earlier stages. The `analyze` report (summary.md, analysis.md, targets.md) surfaces the chain so a reader can see *why* a number is what it is, not just the final value.
+Each step *adds* to the attribution chain; none replaces earlier steps. The `analyze` report (summary.md, analysis.md, targets.md) surfaces the chain so a reader can see *why* a number is what it is, not just the final value.
 
 Reports and figures are ordered high-level → specific: start with what data we're looking at and how it was prepared (QC), then the coarse cancer-type call and what else is in the sample, then the deeper per-gene / per-target detail.
 
@@ -263,7 +263,7 @@ Prefer the standalone decomposition figures when reviewing or sharing a case. Th
 
 | File | Description |
 |---|---|
-| `*-sample-context.png` | Stage 1 diagnostic: library prep + preservation inference with thresholds used for the call |
+| `*-sample-context.png` | Step 1 diagnostic: library prep + preservation inference with thresholds used for the call |
 | `*-degradation-index.png` | Gene-pair scatter: expected vs observed long/short ratios, diagonal = no degradation |
 | `*-sample-summary.png` | Quick overview: cancer type, purity, background signatures |
 | `*-decomposition-composition.png` | Standalone composition bar for the best hypothesis |

--- a/docs/reasoning-pipeline.md
+++ b/docs/reasoning-pipeline.md
@@ -1,37 +1,37 @@
-# Reasoning pipeline — stages and information flow
+# Reasoning pipeline — steps and information flow
 
-`pirlygenes analyze` runs a coarse-to-fine pipeline. Each stage
-produces a named result that downstream stages consume. This page
-documents the stages and the contract between them — what each stage
-writes, and what each stage reads from its predecessors.
+`pirlygenes analyze` runs a coarse-to-fine pipeline. Each step
+produces a named result that downstream steps consume. This page
+documents the steps and the contract between them — what each step
+writes, and what each step reads from its predecessors.
 
-The guiding principle: **no stage overrides an earlier stage's
-output**. Later stages refine the reading by adding orthogonal
-evidence; if a sample is flagged as ambiguous at Stage 0, that flag
+The guiding principle: **no step overrides an earlier step's
+output**. Later steps refine the reading by adding orthogonal
+evidence; if a sample is flagged as ambiguous at Step 0, that flag
 travels all the way to the brief. The reader sees the full chain.
 
-## Stage inventory (coarsest → finest)
+## Step inventory (coarsest → finest)
 
 ```
-  Stage 0   Sample context      library prep + preservation + degradation
-  Stage 0   Tissue composition  top HPA normals + top TCGA cohorts + cancer-hint
-  Stage 1   Cancer-type call    top-k TCGA candidates with signature + purity + lineage
-  Stage 2   Tumor purity        point + CI + confidence tier
-  Stage 3   Broad decomposition NNLS fit of tumor + TME compartments (template-aware)
-  Stage 4   Therapy-axis state  AR / EMT / hypoxia / IFN / HER2 / ER up/down calls
-  Stage 5   Tumor-value core    9-point per-gene tumor-attributed TPM with TME + purity ranges
-  Stage 6   Report synthesis    brief / actionable / summary / analysis / targets / provenance
+  Step 0   Sample context      library prep + preservation + degradation
+  Step 0   Tissue composition  top HPA normals + top TCGA cohorts + cancer-hint
+  Step 1   Cancer-type call    top-k TCGA candidates with signature + purity + lineage
+  Step 2   Tumor purity        point + CI + confidence tier
+  Step 3   Broad decomposition NNLS fit of tumor + TME compartments (template-aware)
+  Step 4   Therapy-axis state  AR / EMT / hypoxia / IFN / HER2 / ER up/down calls
+  Step 5   Tumor-value core    9-point per-gene tumor-attributed TPM with TME + purity ranges
+  Step 6   Report synthesis    brief / actionable / summary / analysis / targets / provenance
 ```
 
-Stages 0 run before Stage 1; the rest form a strictly ordered chain
-from Stage 1 onward. Each stage emits its result into the in-memory
-`analysis` dict under a known key, so Stage 6 (report synthesis) can
+Steps 0 run before Step 1; the rest form a strictly ordered chain
+from Step 1 onward. Each step emits its result into the in-memory
+`analysis` dict under a known key, so Step 6 (report synthesis) can
 read the full chain to surface every piece of evidence the clinician
 needs.
 
 ---
 
-## Stage 0a — Sample context
+## Step 0a — Sample context
 
 Module: `pirlygenes.sample_context`
 Entry: `infer_sample_context(df_expr) -> SampleContext`
@@ -48,15 +48,15 @@ Reads the expression table alone and infers:
 
 Writes: `analysis["sample_context"]`
 
-Consumed by: every downstream stage reads `sample_context` as a
-keyword argument. Stage 3 adjusts marker-panel weightings when prep
-is exome-capture (skip non-coding genes), Stage 5 widens 9-point
-ranges when degradation is severe, Stage 6 surfaces the prep-specific
+Consumed by: every downstream step reads `sample_context` as a
+keyword argument. Step 3 adjusts marker-panel weightings when prep
+is exome-capture (skip non-coding genes), Step 5 widens 9-point
+ranges when degradation is severe, Step 6 surfaces the prep-specific
 "mitochondrial and non-coding absence is expected by design" caveat.
 
 ---
 
-## Stage 0b — Tissue composition + cancer hint
+## Step 0b — Tissue composition + cancer hint
 
 Module: `pirlygenes.healthy_vs_tumor`
 Entry: `assess_tissue_composition(df_expr) -> TissueCompositionSignal`
@@ -78,7 +78,7 @@ Produces:
 
 Writes: `analysis["healthy_vs_tumor"]`
 
-Consumed by: Stage 6 (brief / summary banner). Explicitly does NOT
+Consumed by: Step 6 (brief / summary banner). Explicitly does NOT
 override the cancer call; it gives the reader a coarse "what kind of
 tissue + any hint of cancer" context so they can judge downstream
 confidence. Low-purity tumors and healthy tissue look similar here —
@@ -86,13 +86,13 @@ the gate surfaces that ambiguity rather than guessing.
 
 Known limitation: lymphoid-tissue-normal correlates almost identically
 with DLBC (the TCGA reference is itself >90% lymphoid tissue + the
-malignant clone). Stage 0b flags such cases as tumor-consistent /
-ambiguous rather than over-committing; Stage 3's lineage-marker
+malignant clone). Step 0b flags such cases as tumor-consistent /
+ambiguous rather than over-committing; Step 3's lineage-marker
 check is better positioned to distinguish.
 
 ---
 
-## Stage 1 — Cancer-type classification
+## Step 1 — Cancer-type classification
 
 Module: `pirlygenes.tumor_purity`
 Entry: `rank_cancer_type_candidates(df_expr, candidate_codes=None,
@@ -108,7 +108,7 @@ using five composable factors:
 5. **family-factor** — carries through to the final `geomean` score
 
 Reads: `sample_context` (library prep adjusts marker weights),
-`tissue_composition` (the Stage-0b top TCGA cohorts inform the
+`tissue_composition` (the Step-0b top TCGA cohorts inform the
 candidate-codes set when caller doesn't override).
 
 Writes: `analysis["cancer_candidates"]` — a list of
@@ -116,13 +116,13 @@ Writes: `analysis["cancer_candidates"]` — a list of
  normalized}` rows. Head of the list is the working call; rows 2-6
 are the alternatives surfaced in the *analysis.md* table.
 
-Consumed by: Stage 2 pulls the top candidate's `purity_result` as
-the starting point; Stage 3 runs decomposition per (cancer_type,
+Consumed by: Step 2 pulls the top candidate's `purity_result` as
+the starting point; Step 3 runs decomposition per (cancer_type,
 template) hypothesis across the top-k list.
 
 ---
 
-## Stage 2 — Tumor purity refinement
+## Step 2 — Tumor purity refinement
 
 Module: `pirlygenes.tumor_purity`
 Entry: `estimate_tumor_purity(df_expr, cancer_code, sample_context)
@@ -143,17 +143,17 @@ Produces:
   per-reason explanations (wide CI, low-purity regime, inconsistency
   across estimators)
 
-Reads: `sample_context`, top candidate from Stage 1.
+Reads: `sample_context`, top candidate from Step 1.
 
 Writes: `analysis["purity"]`, `analysis["purity_confidence"]`.
 
-Consumed by: Stage 3 uses purity as the external anchor for the NNLS
-fit; Stage 5 uses CI to widen 9-point ranges; Stage 6 surfaces tier
+Consumed by: Step 3 uses purity as the external anchor for the NNLS
+fit; Step 5 uses CI to widen 9-point ranges; Step 6 surfaces tier
 + reasons in the brief's purity line.
 
 ---
 
-## Stage 3 — Broad-compartment decomposition
+## Step 3 — Broad-compartment decomposition
 
 Module: `pirlygenes.decomposition`
 Entry: `decompose_sample(df_expr, cancer_types, templates=None,
@@ -170,23 +170,23 @@ For each (cancer_type, template) hypothesis in the top-k candidates:
 2. Select markers per compartment (HPA-derived specificity ranks,
    guarded against lineage-irrelevant auto-markers)
 3. Fit weighted NNLS under a soft sum-to-one constraint, with the
-   external purity from Stage 2 as anchor
+   external purity from Step 2 as anchor
 4. Attribute per gene: the TME + matched-normal contributions are
    subtracted from observed TPM to produce tumor-attributed TPM
 
-Reads: `sample_context`, `candidate_rows` (reuses Stage 1's ranking
+Reads: `sample_context`, `candidate_rows` (reuses Step 1's ranking
 to avoid re-running purity estimation per candidate — #85).
 
 Writes: `analysis["decomp_results"]` (list of candidates),
 `best_decomp = decomp_results[0]` — the winning hypothesis has
 `gene_attribution` DataFrame + `fractions` dict + `component_trace`.
 
-Consumed by: Stage 5 reads the gene_attribution for per-target tumor
-TPM; Stage 6 renders the component breakdown in provenance.md.
+Consumed by: Step 5 reads the gene_attribution for per-target tumor
+TPM; Step 6 renders the component breakdown in provenance.md.
 
 ---
 
-## Stage 4 — Therapy-response axis state
+## Step 4 — Therapy-response axis state
 
 Module: `pirlygenes.therapy_response`
 Entry: `score_therapy_signatures(sample_tpm_by_symbol, cancer_code)
@@ -203,14 +203,14 @@ TCGA cohort and emits a state call:
 
 Writes: `analysis["therapy_response_scores"]`.
 
-Consumed by: Stage 6 synthesises disease-state narrative from axis
+Consumed by: Step 6 synthesises disease-state narrative from axis
 states ("AR axis suppressed consistent with ADT exposure ...
 hypoxia active ... IFN-driven inflation of MHC-I / ISG surface
 targets").
 
 ---
 
-## Stage 5 — Tumor-value adjustment + 9-point expression ranges
+## Step 5 — Tumor-value adjustment + 9-point expression ranges
 
 Module: `pirlygenes.cli` (inside `analyze()` after decomposition)
 
@@ -230,12 +230,12 @@ levels. Attribution flags:
 Writes: `analysis["expression_ranges"]` — DataFrame with one row
 per target gene.
 
-Consumed by: Stage 6 renders targets.md deep tables + actionable
+Consumed by: Step 6 renders targets.md deep tables + actionable
 therapy landscape + brief top-3 candidates.
 
 ---
 
-## Stage 6 — Report synthesis
+## Step 6 — Report synthesis
 
 Modules: `pirlygenes.brief` (build_brief + build_actionable),
 `pirlygenes.cli` (summary.md, analysis.md, targets.md, provenance.md)
@@ -243,18 +243,18 @@ Modules: `pirlygenes.brief` (build_brief + build_actionable),
 Reads the entire `analysis` dict and produces six markdown
 artefacts:
 
-- `*-brief.md` — ≤40-line tumor-board handoff (Stage-0 banner,
+- `*-brief.md` — ≤40-line tumor-board handoff (Step-0 banner,
   cancer call, purity, disease state, top-3 therapies, caveats)
 - `*-actionable.md` — oncologist-facing review with therapy
   landscape + biomarker panel
-- `*-summary.md` — narrative summary (Stage-0 tissue composition
+- `*-summary.md` — narrative summary (Step-0 tissue composition
   line at top, then cancer call, therapy state, purity)
-- `*-analysis.md` — full pipeline detail (every stage's output)
+- `*-analysis.md` — full pipeline detail (every step's output)
 - `*-targets.md` — per-gene deep tables
-- `*-provenance.md` — stage-by-stage deduction chain
+- `*-provenance.md` — step-by-step deduction chain
 
-Each of these surfaces evidence from every prior stage so a reader
-can follow the reasoning from Stage 0 context down to the final
+Each of these surfaces evidence from every prior step so a reader
+can follow the reasoning from Step 0 context down to the final
 per-gene tumor-TPM call without losing intermediate evidence.
 
 ---
@@ -264,21 +264,21 @@ per-gene tumor-TPM call without losing intermediate evidence.
 ```
   df_expr
     │
-    ├─► Stage 0a: SampleContext ──────┐
+    ├─► Step 0a: SampleContext ──────┐
     │                                 │
-    ├─► Stage 0b: TissueComposition ──┤
+    ├─► Step 0b: TissueComposition ──┤
     │                                 ▼
-    └─► Stage 1: CancerCandidates ───► Stage 2: Purity ───► Stage 3: Decomp
+    └─► Step 1: CancerCandidates ───► Step 2: Purity ───► Step 3: Decomp
                                                                    │
-                                                                   ├─► Stage 4: TherapyAxes
+                                                                   ├─► Step 4: TherapyAxes
                                                                    │
-                                                                   └─► Stage 5: ExpressionRanges
+                                                                   └─► Step 5: ExpressionRanges
                                                                                    │
                                                                                    ▼
-                                                                           Stage 6: Reports
+                                                                           Step 6: Reports
 ```
 
-All stages write to the same `analysis` dict; Stage 6 is a pure reader.
-No stage mutates another stage's output. This means any stage's result
+All steps write to the same `analysis` dict; Step 6 is a pure reader.
+No step mutates another step's output. This means any step's result
 can be re-run independently (e.g. to debug a bad purity call) without
 corrupting upstream reasoning.

--- a/docs/step0-reasoning.md
+++ b/docs/step0-reasoning.md
@@ -1,6 +1,6 @@
-# Stage-0 reasoning: signals, rules, and evidence synthesis
+# Step-0 reasoning: signals, rules, and evidence synthesis
 
-The Stage-0 gate answers "what kind of tissue is this, and is there
+The Step-0 gate answers "what kind of tissue is this, and is there
 evidence of cancer?" as the coarsest step of the pirlygenes pipeline.
 This document enumerates every signal the gate reads, the ordered
 rule list that drives the `cancer_hint` decision, and the
@@ -59,7 +59,7 @@ channel alone or several soft channels co-occurring.
 
 ## Rule list
 
-Stage-0 picks a `cancer_hint` by running these rules in order. The
+Step-0 picks a `cancer_hint` by running these rules in order. The
 first rule whose precondition matches fires and writes to the
 `reasoning_trace` for audit.
 
@@ -98,8 +98,8 @@ high TPM is the canonical strong-evidence-wins-over-ambiguity case.
 ## Banner suppression
 
 Banners are displayed to the clinician in the brief / actionable.
-They can be suppressed when downstream evidence (Stage 1 signature +
-Stage 2 purity) corroborates the cancer call:
+They can be suppressed when downstream evidence (Step 1 signature +
+Step 2 purity) corroborates the cancer call:
 
 - **Healthy-dominant banner**: suppressed only under very strong
   corroboration (purity ≥ 0.5 AND signature ≥ 0.75).
@@ -127,4 +127,4 @@ All gene panels are exposed via `pirlygenes.gene_sets_cancer`:
 
 Consumers can reuse these panels for downstream scoring, signature
 calibration, or cross-cohort comparison — same definitions the
-Stage-0 gate uses.
+Step-0 gate uses.

--- a/pirlygenes/__init__.py
+++ b/pirlygenes/__init__.py
@@ -89,7 +89,7 @@ __all__ = [
     "cancer_family_panels_df",
     "cancer_family_panel",
     "cancer_family_panels",
-    # Sample context (stage 1 of unified attribution flow)
+    # Sample context (step 1 of unified attribution flow)
     "SampleContext",
     "infer_sample_context",
     "plot_sample_context",

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -43,7 +43,7 @@ def _phase_label(phase: str) -> str:
 def _top_candidate_signature_score(analysis) -> float | None:
     """Return the top-ranked cancer candidate's signature match score.
 
-    Used by the Stage-0 banner to suppress noise: a confident TCGA
+    Used by the Step-0 banner to suppress noise: a confident TCGA
     signature match is evidence of tumor and nudges the banner to
     stay silent on soft "composition-ambiguous" cases.
     """
@@ -270,11 +270,11 @@ def build_brief(
     )
     lines.append("")
 
-    # #149: Stage-0 healthy-vs-tumor banner. Above the cancer call so
+    # #149: Step-0 healthy-vs-tumor banner. Above the cancer call so
     # the reader sees the caveat before anchoring on the TCGA label.
     # Banner decision reads downstream tumor evidence (purity from
-    # Stage 2, signature score from Stage 1) so a confident cancer
-    # call doesn't trigger a spurious Stage-0 warning.
+    # Step 2, signature score from Step 1) so a confident cancer
+    # call doesn't trigger a spurious Step-0 warning.
     hvt = analysis.get("healthy_vs_tumor")
     if hvt is not None:
         banner = hvt.brief_banner(
@@ -286,7 +286,7 @@ def build_brief(
             lines.append("")
 
     # Cancer call — annotated with #169 contested-call confidence when
-    # orthogonal signals (lineage concordance, runner-up gap, Stage-0
+    # orthogonal signals (lineage concordance, runner-up gap, Step-0
     # top-ρ cohort) disagree with the classifier's pick.
     from .confidence import compute_call_confidence
     call_tier = compute_call_confidence(analysis)
@@ -470,8 +470,8 @@ def build_actionable(
     lines.append(
         f"Working call: **{cancer_code}** ({cancer_name}).{call_suffix}"
     )
-    # Stage-0 tissue-composition banner (if non-tumor-consistent) so
-    # an actionable reader sees the Stage-0 caveat attached to the
+    # Step-0 tissue-composition banner (if non-tumor-consistent) so
+    # an actionable reader sees the Step-0 caveat attached to the
     # working call, not buried in the summary. Same evidence-gated
     # logic as the brief — strong tumor signal suppresses the banner.
     hvt = analysis.get("healthy_vs_tumor")

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -428,7 +428,7 @@ def annotate_surface_targets_with_cross_signals(ranges_df, therapy_scores):
 
 
 def _filter_quality_flags_against_context(flags, sample_context):
-    """Drop / rewrite quality flags that the stage-1 SampleContext
+    """Drop / rewrite quality flags that the step-1 SampleContext
     already explains (issue #77).
 
     Specifically: the "Suspicious MT fraction" warning fires whenever
@@ -915,8 +915,8 @@ def _analyze_body(
     forced_labels = _parse_always_label_genes(label_genes)
     template_overrides = _parse_csv_tokens(decomposition_templates)
 
-    # Stage 1 of the unified attribution flow: infer SampleContext BEFORE
-    # cancer-type inference. Downstream stages (purity CIs, decomposition,
+    # Step 1 of the unified attribution flow: infer SampleContext BEFORE
+    # cancer-type inference. Downstream steps (purity CIs, decomposition,
     # tumor-value adjustment, reporting) read from it as the base layer
     # of expression expectations.
     print("[context] Inferring sample context (library prep + preservation)...")
@@ -925,7 +925,7 @@ def _analyze_body(
     for flag in sample_context.flags:
         print(f"[context] {flag}")
 
-    # #149: Stage-0 healthy-vs-tumor gate. Races the sample against
+    # #149: Step-0 healthy-vs-tumor gate. Races the sample against
     # the 50 HPA normal-tissue columns + 33 TCGA cancer columns in
     # pan_cancer_expression() and checks a proliferation-panel
     # (MKI67+TOP2A+CCNB1+BIRC5+AURKA) geomean. Fixes the GTEx-style
@@ -936,9 +936,9 @@ def _analyze_body(
     from .healthy_vs_tumor import assess_healthy_vs_tumor
     try:
         healthy_vs_tumor = assess_healthy_vs_tumor(df_expr)
-        print(f"[stage-0] {healthy_vs_tumor.verdict}")
+        print(f"[step-0] {healthy_vs_tumor.verdict}")
     except Exception as exc:  # noqa: BLE001
-        print(f"[stage-0] healthy-vs-tumor gate failed: {exc}")
+        print(f"[step-0] healthy-vs-tumor gate failed: {exc}")
         healthy_vs_tumor = None
 
     context_png = "%s-sample-context.png" % prefix if prefix else "sample-context.png"
@@ -1021,7 +1021,7 @@ def _analyze_body(
     analysis["sample_context"] = sample_context
     analysis["cancer_type_source"] = "user-specified" if cancer_type else "auto-detected"
 
-    # Stage 1 propagation: widen purity confidence intervals under
+    # Step 1 propagation: widen purity confidence intervals under
     # detected degradation (#26). A noisier sample has a noisier purity
     # estimate; we don't re-estimate, just scale the reported band and
     # attach a ``degradation_caveat`` so downstream consumers (reports,
@@ -1102,7 +1102,7 @@ def _analyze_body(
 
     # Sample quality assessment — run after analysis so tissue_scores
     # are available for tissue-matched degradation baselines.
-    # #77: pass the stage-1 library_prep so the assessor skips the
+    # #77: pass the step-1 library_prep so the assessor skips the
     # "Suspicious MT fraction" override (and doesn't clobber the
     # length-pair-derived degradation level) when MT being near-zero is
     # explained by the inferred prep.
@@ -1113,7 +1113,7 @@ def _analyze_body(
         if sample_context is not None else None,
     )
     analysis["quality"] = quality
-    # #77: filter quality flags against the stage-1 SampleContext — the
+    # #77: filter quality flags against the step-1 SampleContext — the
     # "Suspicious MT fraction" warning is a false alarm when the
     # library prep we already inferred (exome capture / poly-A) legitimately
     # strips MT. Same filtered list is used by the markdown reports,
@@ -1138,7 +1138,7 @@ def _analyze_body(
         print(f"[therapy-response] scoring skipped: {exc}")
         therapy_scores = {}
     analysis["therapy_response_scores"] = therapy_scores
-    # #149: make the Stage-0 healthy-vs-tumor call available to
+    # #149: make the Step-0 healthy-vs-tumor call available to
     # brief / actionable / summary renderers downstream.
     analysis["healthy_vs_tumor"] = healthy_vs_tumor
     for cls, score in therapy_scores.items():
@@ -2413,7 +2413,7 @@ def _generate_text_reports(
     # Disease-state synthesis (#78): one-line narrative up top.
     disease_state_paragraph = compose_disease_state_narrative(analysis)
 
-    # Stage 1: input & sample-QC framing.
+    # Step 1: input & sample-QC framing.
     sample_context = analysis.get("sample_context")
     context_paragraph = ""
     if sample_context is not None:
@@ -2451,10 +2451,10 @@ def _generate_text_reports(
         if flags_to_show:
             quality_paragraph = "**Quality note**: " + "; ".join(flags_to_show) + "."
 
-    # Stage 2: headline call (already built above as `intro`).
+    # Step 2: headline call (already built above as `intro`).
     headline = intro
 
-    # Stage 3: what else is in the sample — purity clause + background
+    # Step 3: what else is in the sample — purity clause + background
     # tissues (from _summary_mode_clause), MHC-I level, analysis mode.
     composition = (
         _summary_mode_clause(sample_mode, purity, top_tissues)
@@ -2493,7 +2493,7 @@ def _generate_text_reports(
             )
         therapy_paragraph = "\n".join(lines_ts)
 
-    # Stage 4: constraints / decomposition detail / ambiguity.
+    # Step 4: constraints / decomposition detail / ambiguity.
     detail_parts = []
     if therapy_paragraph:
         detail_parts.append(therapy_paragraph)
@@ -2567,23 +2567,23 @@ def _generate_text_reports(
     header = "# Sample Analysis Summary\n"
     if input_path:
         header += f"\n*Input*: `{input_path}`\n"
-    # #149: Prepend the Stage-0 tissue-composition + cancer-hint
+    # #149: Prepend the Step-0 tissue-composition + cancer-hint
     # reading so a reader sees the coarse "what kind of tissue is
     # this and is there any hint of cancer" context before the
     # downstream cancer-type call. Propagated forward from analyze().
     hvt = analysis.get("healthy_vs_tumor")
-    stage0_section = ""
+    step0_section = ""
     if hvt is not None and hvt.top_normal_tissues:
         trace_clause = (
             f" *Rule: {' → '.join(hvt.reasoning_trace)}.*"
             if hvt.reasoning_trace else ""
         )
-        stage0_section = (
-            f"\n**Stage-0 tissue composition**: "
+        step0_section = (
+            f"\n**Step-0 tissue composition**: "
             f"{hvt.summary_line()}{trace_clause}\n"
         )
     with open(summary_path, "w") as f:
-        f.write(f"{header}{stage0_section}\n{summary}\n")
+        f.write(f"{header}{step0_section}\n{summary}\n")
     print(f"[report] Saved {summary_path}")
 
     # --- Detailed report ---
@@ -2594,15 +2594,15 @@ def _generate_text_reports(
     if disease_state_paragraph:
         lines.append(f"**Disease state**: {disease_state_paragraph}\n")
 
-    # Stage-0 tissue composition (#149) — same signal that drives the
+    # Step-0 tissue composition (#149) — same signal that drives the
     # brief banner and the summary top-line, surfaced here with the
     # full top-3 tissues / top-3 cohorts so a reader doing a deep
-    # analysis.md read sees the Stage-0 prior inline.
+    # analysis.md read sees the Step-0 prior inline.
     hvt = analysis.get("healthy_vs_tumor")
     if hvt is not None and hvt.top_normal_tissues:
         from .gene_sets_cancer import proliferation_panel_gene_names
         _prolif_panel_size = len(proliferation_panel_gene_names())
-        lines.append("## Stage-0 tissue composition\n")
+        lines.append("## Step-0 tissue composition\n")
         lines.append(f"- **Cancer hint**: {hvt.cancer_hint}")
         lines.append(
             f"- **Proliferation panel**: "
@@ -2620,7 +2620,7 @@ def _generate_text_reports(
         )
         lines.append(f"- **Top TCGA cohort matches**: {tcga_line}")
         # Surface the reasoning trace (which rule fired + rationale)
-        # so a reader can audit how Stage-0 arrived at the hint.
+        # so a reader can audit how Step-0 arrived at the hint.
         if hvt.reasoning_trace:
             lines.append(
                 f"- **Reasoning rule**: {' → '.join(hvt.reasoning_trace)}"
@@ -2675,7 +2675,7 @@ def _generate_text_reports(
             )
         lines.append("")
 
-    # Sample quality — driven by the stage-1 SampleContext so the
+    # Sample quality — driven by the step-1 SampleContext so the
     # three report sections (summary / analysis / targets) agree
     # (#77). The raw sample_quality output is still used for its
     # tissue-matched baselines, but the top-level "is this sample
@@ -3176,7 +3176,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             "`median_est` > 30 TPM against `tme_fold_med` before acting.\n"
         )
 
-    # Sample-context caveat (stage 1 propagation): when the sample was
+    # Sample-context caveat (step 1 propagation): when the sample was
     # flagged as degraded / FFPE, every marker-selection step down the
     # pipeline is noisier and the target medians are correspondingly
     # less reliable.

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -147,7 +147,7 @@ def compute_call_confidence(analysis) -> ConfidenceTier:
       pattern matches the candidate's expected pattern. Near-zero
       concordance means the classifier picked a candidate whose
       lineage genes aren't expressed in the sample.
-    - Stage-0 top-ρ TCGA cohort vs the classifier's pick. When Stage
+    - Step-0 top-ρ TCGA cohort vs the classifier's pick. When Step
       0 ranks cohort A first by correlation but the classifier picks
       cohort B, that's a mismatch worth surfacing.
     - Geomean gap to the runner-up. Top geomean 0.431 vs second 0.429
@@ -210,22 +210,22 @@ def compute_call_confidence(analysis) -> ConfidenceTier:
                 f"{second_gm:.3f}) — call is ambiguous"
             )
 
-    # 3. Stage-0 top-ρ TCGA cohort disagrees with the classifier's
+    # 3. Step-0 top-ρ TCGA cohort disagrees with the classifier's
     # pick. Sample-level correlation is the coarsest signal and can
     # be more reliable than the classifier's geomean when the panel
     # evidence is weak.
     hvt = analysis.get("healthy_vs_tumor")
-    stage0_top_code = None
+    step0_top_code = None
     if hvt is not None:
         tcga = getattr(hvt, "top_tcga_cohorts", None) or []
         if tcga:
             name, _rho = tcga[0]
-            stage0_top_code = name.replace("FPKM_", "") if isinstance(name, str) else None
-    if stage0_top_code and top_code and stage0_top_code != top_code:
+            step0_top_code = name.replace("FPKM_", "") if isinstance(name, str) else None
+    if step0_top_code and top_code and step0_top_code != top_code:
         if tier == "high":
             tier = "moderate"
         reasons.append(
-            f"Stage-0 correlation favored {stage0_top_code} but the "
+            f"Step-0 correlation favored {step0_top_code} but the "
             f"classifier picked {top_code}"
         )
 

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -740,7 +740,7 @@ def subtype_deconvolved_expression():
         return None
 
 
-# ---------- Cancer-pathway panels (tumor-evidence Stage-0 signals) ----------
+# ---------- Cancer-pathway panels (tumor-evidence Step-0 signals) ----------
 #
 # Each panel is a coordinated-program set — genes that move together in
 # tumors vs normal tissue. Empirical median-fold-change numbers below
@@ -820,7 +820,7 @@ def proliferation_panel_gene_names():
 
     Empirically-selected from a pan-cancer sweep: each gene has
     median fold-change ≥ 3 across 20 epithelial cancer-tissue pairs.
-    Used as a Stage-0 tumor-evidence signal (healthy_vs_tumor) and
+    Used as a Step-0 tumor-evidence signal (healthy_vs_tumor) and
     available here for downstream scoring / calibration.
     """
     return list(_PROLIFERATION_PANEL_GENES)
@@ -830,7 +830,7 @@ def hypoxia_panel_gene_names():
     """Hypoxia-response panel — CA9, SLC2A1, LDHA, ENO1, PGK1.
 
     CA9 is the strongest single-gene marker (median fold 12x across
-    pan-cancer). Used as a Stage-0 tumor-evidence signal and for
+    pan-cancer). Used as a Step-0 tumor-evidence signal and for
     downstream hypoxia-score calculation.
     """
     return list(_HYPOXIA_PANEL_GENES)
@@ -904,7 +904,7 @@ def tumor_up_vs_matched_normal(cancer_code: str | None = None):
     and specific to ≤ 4 cancer codes (drops ubiquitous artefacts and
     Ig / TCR rearrangement genes).
 
-    Useful as cancer-type-specific tumor evidence — if Stage-1 says
+    Useful as cancer-type-specific tumor evidence — if Step-1 says
     the sample best matches PRAD, and one of the PRAD-specific tumor-
     up genes (OTOP1, ANKRD34C) is expressed, that is independent
     corroboration distinct from the correlation pass.

--- a/pirlygenes/healthy_vs_tumor.py
+++ b/pirlygenes/healthy_vs_tumor.py
@@ -4,11 +4,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-"""Stage-0 tissue-composition + cancer-hint gate (#149, refined).
+"""Step-0 tissue-composition + cancer-hint gate (#149, refined).
 
 Runs BEFORE cancer-type classification. Produces the coarsest
 possible reading of "what kind of tissue is this, and is there a
-hint of cancer?" and propagates the result forward so later stages
+hint of cancer?" and propagates the result forward so later steps
 can refine. Explicitly does NOT make a binary healthy-vs-cancer call
 on the first pass — healthy and low-purity-tumor look similar here
 and will be distinguished downstream once lineage markers, purity,
@@ -43,7 +43,7 @@ from .tumor_evidence import (
     TumorEvidenceScore,
     compute_tumor_evidence_score,
 )
-from .reasoning import DerivedFlags, compute_derived_flags, run_stage0_rules
+from .reasoning import DerivedFlags, compute_derived_flags, run_step0_rules
 
 
 _MIN_REFERENCE_GENES = 2000
@@ -148,7 +148,7 @@ _ONCOFETAL_PER_GENE_MIN_TPM = 3.0
 _ONCOFETAL_STRONG_COUNT = 2  # stricter than CTA since the panel is smaller
 
 # Cancer-type-specific tumor-up-vs-matched-normal panel. Built from
-# :func:`tumor_up_vs_matched_normal`. When Stage-0's top TCGA match
+# :func:`tumor_up_vs_matched_normal`. When Step-0's top TCGA match
 # aligns with a sample expressing several of that cohort's private
 # tumor-up markers, that's independent type-specific tumor evidence.
 _TUMOR_UP_PANEL_PER_GENE_MIN_TPM = 3.0
@@ -170,7 +170,7 @@ _CTA_STRONG_SUM_TPM = 30.0
 
 @dataclass
 class TissueCompositionSignal:
-    """Stage-0 coarse reading of tissue composition + cancer hint.
+    """Step-0 coarse reading of tissue composition + cancer hint.
 
     ``cancer_hint`` is one of:
 
@@ -196,7 +196,7 @@ class TissueCompositionSignal:
     # True when the top HPA / top TCGA pair is structurally
     # indistinguishable by bulk RNA (lymphoid normal vs heme-lymphoid
     # cancer). Downstream tumor-evidence gates should NOT suppress
-    # the Stage-0 banner in this case — the "purity" estimate on a
+    # the Step-0 banner in this case — the "purity" estimate on a
     # normal lymphoid sample is spurious anchor.
     structural_ambiguity: bool = False
     # CTA panel as positive tumor evidence (zero in non-reproductive
@@ -214,7 +214,7 @@ class TissueCompositionSignal:
     oncofetal_count_above_threshold: int = 0
     oncofetal_top_hits: list[tuple[str, float]] = field(default_factory=list)
     # Cancer-type-specific tumor-up-vs-matched-normal panel hits.
-    # Keyed on the top Stage-0 TCGA cohort — if that cohort has a
+    # Keyed on the top Step-0 TCGA cohort — if that cohort has a
     # specific tumor-up panel (PRAD: OTOP1/ANKRD34C; OV: CLDN6;
     # KIRC: CD70, GAGE1; STAD: CT45A9/DAZ1) and the sample expresses
     # hits from it, that's cancer-type-specific positive evidence.
@@ -231,7 +231,7 @@ class TissueCompositionSignal:
     reasoning_trace: list[str] = field(default_factory=list)
 
     def synthesis(self) -> str:
-        """Single-spot narrative of all Stage-0 evidence.
+        """Single-spot narrative of all Step-0 evidence.
 
         Enumerates the top tissue / top cohort / all tumor-evidence
         channels + aggregate + the rule trace that drove the
@@ -293,18 +293,18 @@ class TissueCompositionSignal:
     ) -> str | None:
         """Terse banner for the brief — shown for every non-tumor-consistent hint.
 
-        Propagates the Stage-0 coarse reading forward so a clinician
+        Propagates the Step-0 coarse reading forward so a clinician
         reading the brief sees the tissue context and the cancer-hint
         confidence up front rather than just the downstream TCGA label.
 
-        When ``purity`` (Stage 2) and/or ``signature_score`` (Stage 1)
+        When ``purity`` (Step 2) and/or ``signature_score`` (Step 1)
         are supplied, corroborating tumor evidence can suppress the
         banner: we don't want to shout "composition ambiguous" on a
         sample that has a solid lineage-matched TCGA cohort at moderate
         purity. The healthy-dominant banner has a higher bar to
         suppress than the possibly-tumor banner — it takes strong
         evidence (purity ≥ 0.5 AND signature ≥ 0.75) to override a
-        confident Stage-0 healthy call.
+        confident Step-0 healthy call.
         """
         if self.cancer_hint == "tumor-consistent":
             return None
@@ -337,7 +337,7 @@ class TissueCompositionSignal:
         cohort_rho = self.top_tcga_cohorts[0][1] if self.top_tcga_cohorts else 0.0
         if self.cancer_hint == "healthy-dominant":
             return (
-                f"**⚠ Stage-0 hint: healthy tissue dominant.** Sample profile "
+                f"**⚠ Step-0 hint: healthy tissue dominant.** Sample profile "
                 f"correlates with normal **{tissue_name}** (ρ={rho:.2f}) more "
                 f"than any TCGA cohort (best {cohort} ρ={cohort_rho:.2f}); "
                 f"proliferation panel quiet "
@@ -358,7 +358,7 @@ class TissueCompositionSignal:
             )
             if any(tag in tissue_lc for tag in lymphoid_tissues):
                 return (
-                    f"**Stage-0 hint: structural ambiguity (lymphoid).** Top "
+                    f"**Step-0 hint: structural ambiguity (lymphoid).** Top "
                     f"normal match is **{tissue_name}** (ρ={rho:.2f}); top "
                     f"TCGA match is {cohort} (ρ={cohort_rho:.2f}). Normal "
                     f"lymphoid tissue and lymphoid malignancy are indist-"
@@ -369,7 +369,7 @@ class TissueCompositionSignal:
                     f"is unreliable in this regime."
                 )
             return (
-                f"**Stage-0 hint: structural ambiguity (mesenchymal).** Top "
+                f"**Step-0 hint: structural ambiguity (mesenchymal).** Top "
                 f"normal match is **{tissue_name}** (ρ={rho:.2f}); top TCGA "
                 f"match is {cohort} (ρ={cohort_rho:.2f}). Well-differentiated "
                 f"sarcomas share a mesenchymal expression program with "
@@ -381,7 +381,7 @@ class TissueCompositionSignal:
                 f"below as the primary tumor-evidence channels."
             )
         return (
-            f"**Stage-0 hint: composition ambiguous.** Top normal-tissue match "
+            f"**Step-0 hint: composition ambiguous.** Top normal-tissue match "
             f"is **{tissue_name}** (ρ={rho:.2f}); top TCGA match is {cohort} "
             f"(ρ={cohort_rho:.2f}). Could be normal tissue or a low-purity "
             f"tumor — the downstream cancer call is soft-confidence pending "
@@ -518,8 +518,8 @@ def assess_tissue_composition(df_expr: pd.DataFrame) -> TissueCompositionSignal:
     """Race the sample against HPA-normal-tissue and TCGA-cohort columns.
 
     Returns the top-3 matches on each side + proliferation-panel
-    geomean + a coarse cancer-hint call. Intended as the first stage
-    in a coarse-to-fine pipeline: it gives downstream stages a
+    geomean + a coarse cancer-hint call. Intended as the first step
+    in a coarse-to-fine pipeline: it gives downstream steps a
     tissue-composition prior without committing to healthy / cancer.
     """
     sample_by_symbol = _extract_sample_tpm_by_symbol(df_expr)
@@ -645,7 +645,7 @@ def assess_tissue_composition(df_expr: pd.DataFrame) -> TissueCompositionSignal:
     # ---- Ordered rule-list reasoning ----
     # Build a lightweight signal carrier holding every field the
     # standalone rules need (rules are in pirlygenes.reasoning and
-    # are testable in isolation — see docs/stage0-reasoning.md).
+    # are testable in isolation — see docs/step0-reasoning.md).
     tmp = TissueCompositionSignal(
         top_normal_tissues=top_normal,
         top_tcga_cohorts=top_tcga,
@@ -664,7 +664,7 @@ def assess_tissue_composition(df_expr: pd.DataFrame) -> TissueCompositionSignal:
         type_specific_hits=type_specific_hits,
         evidence=evidence,
     )
-    # Derive the Stage-0 flags (lymphoid/mesenchymal ambiguity, strong/
+    # Derive the Step-0 flags (lymphoid/mesenchymal ambiguity, strong/
     # soft tumor-evidence booleans, correlation margin) from the signal
     # fields + the ambiguity booleans that were computed upstream from
     # the raw tissue correlations.
@@ -681,7 +681,7 @@ def assess_tissue_composition(df_expr: pd.DataFrame) -> TissueCompositionSignal:
         correlation_margin=base_flags.correlation_margin,
     )
 
-    outcome, reasoning_trace = run_stage0_rules(tmp, flags)
+    outcome, reasoning_trace = run_step0_rules(tmp, flags)
     cancer_hint = outcome.hint
     structural_ambiguity = outcome.structural
     if outcome.rationale:

--- a/pirlygenes/load_expression.py
+++ b/pirlygenes/load_expression.py
@@ -747,7 +747,7 @@ def load_expression_data(
         aggregate_gene_expression = False
 
     # Preserve the transcript-level frame (if present in the input) so
-    # downstream stages can use it for capture-bias-immune signals
+    # downstream steps can use it for capture-bias-immune signals
     # (isoform length bias, APA-3'UTR usage). Computed here *before*
     # aggregation / consolidation because those pandas groupby ops
     # strip ``df.attrs``; the retained frame is re-attached to the

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -3,7 +3,7 @@
 """Sample-provenance page — one synthesized 'what is this sample' doc (#106).
 
 The existing reports (summary, analysis, targets, brief, actionable)
-each surface different parts of the 5-stage attribution chain:
+each surface different parts of the 5-step attribution chain:
 
     library prep -> preservation -> coarse TME -> fine subtypes -> tumor core
 
@@ -30,9 +30,9 @@ def build_provenance_md(
     cancer_code: str,
     sample_id: Optional[str] = None,
 ) -> str:
-    """Render ``*-provenance.md`` — the 5-stage attribution chain.
+    """Render ``*-provenance.md`` — the 5-step attribution chain.
 
-    Each stage states its input and what it deducts from the naive
+    Each step states its input and what it deducts from the naive
     "all signal is tumor" interpretation so the reader can follow the
     chain from raw TPMs to a conservative tumor core.
     """
@@ -42,13 +42,13 @@ def build_provenance_md(
     header_id = f": {sample_id}" if sample_id else ""
     lines.append(f"# Sample provenance{header_id}\n")
     lines.append(
-        "<!-- What is in this sample, stage by stage. Each step "
+        "<!-- What is in this sample, step by step. Each step "
         "explains what it deducts before the next one. -->"
     )
     lines.append("")
 
-    # Stage 0b — tissue composition screen (#149). Runs before the
-    # lineage-aware stages so the reader sees "what kind of tissue is
+    # Step 0b — tissue composition screen (#149). Runs before the
+    # lineage-aware steps so the reader sees "what kind of tissue is
     # this, and is there any hint of cancer" in the first breath.
     hvt = analysis.get("healthy_vs_tumor")
     if hvt is not None and hvt.top_normal_tissues:
@@ -56,14 +56,14 @@ def build_provenance_md(
         lines.append(hvt.summary_line())
         if hvt.cancer_hint != "tumor-consistent":
             lines.append(
-                "\nThis Stage-0 signal propagates forward: the downstream "
+                "\nThis Step-0 signal propagates forward: the downstream "
                 "cancer call is treated as soft-confidence in the report "
                 "synthesis, and the per-gene expression ranges carry a "
                 "wider CI to reflect the ambiguity."
             )
         lines.append("")
 
-    # Stage 1 — library prep
+    # Step 1 — library prep
     lines.append("## 1. Library prep\n")
     if sample_context is not None:
         prep = getattr(sample_context, "library_prep", "unknown")
@@ -103,7 +103,7 @@ def build_provenance_md(
         lines.append("*Library prep could not be inferred from this input.*")
     lines.append("")
 
-    # Stage 2 — preservation / degradation
+    # Step 2 — preservation / degradation
     lines.append("## 2. Preservation\n")
     if sample_context is not None:
         pres = getattr(sample_context, "preservation", "unknown").replace("_", " ")
@@ -124,7 +124,7 @@ def build_provenance_md(
             )
     lines.append("")
 
-    # Stage 3 — coarse composition
+    # Step 3 — coarse composition
     lines.append("## 3. Coarse composition\n")
     best = decomp_results[0] if decomp_results else None
     if best is not None:
@@ -153,7 +153,7 @@ def build_provenance_md(
         lines.append("*No decomposition result available for this sample.*")
     lines.append("")
 
-    # Stage 4 — activated subtypes
+    # Step 4 — activated subtypes
     lines.append("## 4. Subtype refinements\n")
     if best is not None:
         trace = getattr(best, "component_trace", None)
@@ -185,7 +185,7 @@ def build_provenance_md(
             )
     lines.append("")
 
-    # Stage 5 — tumor core
+    # Step 5 — tumor core
     lines.append("## 5. Tumor-specific core\n")
     if ranges_df is not None and len(ranges_df):
         if "attribution" in ranges_df.columns:

--- a/pirlygenes/reasoning.py
+++ b/pirlygenes/reasoning.py
@@ -1,8 +1,8 @@
 # Licensed under the Apache License, Version 2.0
-"""Stage-by-stage reasoning framework.
+"""Step-by-step reasoning framework.
 
-Each pipeline stage emits a typed dataclass. An ``AnalysisState``
-composes all the stage outputs so far, and reasoning rules are
+Each pipeline step emits a typed dataclass. An ``AnalysisState``
+composes all the step outputs so far, and reasoning rules are
 standalone typed functions that take the state (plus the fields
 they specifically need) and return a ``RuleOutcome`` or ``None``.
 
@@ -12,14 +12,14 @@ Design intent:
   dependencies on upstream analysis dicts.
 - Rules are ordered as a list (data, not code) so ordering changes
   are configurational, not edits-to-decision-logic.
-- Stages accumulate: Stage-1 analysis reads Stage-0 signals + fresh
-  Stage-1 fields; Stage-2 reads Stage-0 + Stage-1 + Stage-2.
-- Every stage has the same ``cancer_hint / reasoning_trace`` contract
+- Steps accumulate: Step-1 analysis reads Step-0 signals + fresh
+  Step-1 fields; Step-2 reads Step-0 + Step-1 + Step-2.
+- Every step has the same ``cancer_hint / reasoning_trace`` contract
   so downstream code that only needs the hint doesn't care which
-  stage produced the call.
+  step produced the call.
 
-For now this module implements the Stage-0 rule set; Stage-1 through
-Stage-6 are planned follow-ups. The framework is ready to extend.
+For now this module implements the Step-0 rule set; Step-1 through
+Step-6 are planned follow-ups. The framework is ready to extend.
 """
 
 from __future__ import annotations
@@ -46,11 +46,11 @@ _TUMOR_UP_PANEL_STRONG_COUNT = 2
 
 @dataclass(frozen=True)
 class DerivedFlags:
-    """Precomputed boolean derivations used by Stage-0 reasoning rules.
+    """Precomputed boolean derivations used by Step-0 reasoning rules.
 
     Populated by :func:`compute_derived_flags` once from the
     :class:`TissueCompositionSignal` fields so rules don't re-derive
-    them. Typed, immutable, and part of the Stage-0 contract (unlike
+    them. Typed, immutable, and part of the Step-0 contract (unlike
     the earlier hack of attaching private attributes to the signal).
     """
 
@@ -104,7 +104,7 @@ class RuleOutcome:
 
 # Type alias: rules are pure functions of (signal, flags) returning
 # a RuleOutcome (fires) or None (defers to next rule).
-Stage0Rule = Callable[
+Step0Rule = Callable[
     ["TissueCompositionSignal", DerivedFlags], Optional[RuleOutcome]
 ]
 
@@ -123,7 +123,7 @@ def rule(name: str, *, structural: bool = False):
 
 
 def compute_derived_flags(signal) -> DerivedFlags:
-    """Pre-compute the Stage-0 derived booleans from raw signal fields.
+    """Pre-compute the Step-0 derived booleans from raw signal fields.
 
     Single source of truth for the evidence-channel thresholds — rules
     read from the returned flags rather than re-deriving. Structural-
@@ -157,7 +157,7 @@ def compute_derived_flags(signal) -> DerivedFlags:
     )
 
 
-# ---- Stage-0 rules ----
+# ---- Step-0 rules ----
 #
 # Each rule is a pure function of (signal, flags) → RuleOutcome | None.
 # The @rule decorator stamps a descriptive name + the structural flag
@@ -340,7 +340,7 @@ def _tumor_marker_reasons(s, f: DerivedFlags) -> list[str]:
 # Ordered rule list. Rules are applied in order; the first to fire
 # (return a non-None ``RuleOutcome``) wins and downstream rules are
 # skipped. Re-orderable without editing rule bodies.
-STAGE0_RULES: list[Stage0Rule] = [
+STEP0_RULES: list[Step0Rule] = [
     tumor_marker_overrides_ambiguity,
     lymphoid_tissue_ambiguity,
     mesenchymal_tissue_ambiguity,
@@ -353,22 +353,22 @@ STAGE0_RULES: list[Stage0Rule] = [
 ]
 
 
-def run_stage0_rules(
+def run_step0_rules(
     signal,
     flags: DerivedFlags | None = None,
-    rules: list[Stage0Rule] | None = None,
+    rules: list[Step0Rule] | None = None,
 ) -> tuple[RuleOutcome, list[str]]:
     """Apply rules in order. Return (first-fire outcome, trace).
 
-    ``flags`` holds the pre-computed Stage-0 derivations; when omitted
+    ``flags`` holds the pre-computed Step-0 derivations; when omitted
     it is computed from ``signal``. ``rules`` defaults to
-    :data:`STAGE0_RULES` but can be overridden for unit tests that
+    :data:`STEP0_RULES` but can be overridden for unit tests that
     want to reorder or subset the rule list.
     """
     if flags is None:
         flags = compute_derived_flags(signal)
     if rules is None:
-        rules = STAGE0_RULES
+        rules = STEP0_RULES
     for fn in rules:
         outcome = fn(signal, flags)
         if outcome is not None:
@@ -381,30 +381,30 @@ def run_stage0_rules(
     )
 
 
-# ---- Analysis state (composable; grows stage by stage) ----
+# ---- Analysis state (composable; grows step by step) ----
 
 @dataclass
 class AnalysisState:
-    """Accumulating typed container for stage outputs.
+    """Accumulating typed container for step outputs.
 
-    Rules and downstream analyses read whichever stage fields they
-    need. ``stage0`` is the Stage-0 tissue-composition signal;
-    ``stage1``..``stage6`` will be populated as the pipeline runs
-    (Stage-1 cancer candidates, Stage-2 purity, Stage-3 decomposition,
-    etc.). A stage that hasn't run yet is ``None`` — rules that
+    Rules and downstream analyses read whichever step fields they
+    need. ``step0`` is the Step-0 tissue-composition signal;
+    ``step1``..``step6`` will be populated as the pipeline runs
+    (Step-1 cancer candidates, Step-2 purity, Step-3 decomposition,
+    etc.). A step that hasn't run yet is ``None`` — rules that
     depend on it must check before reading.
 
-    For now only stage0 is typed through; the other slots are kept
+    For now only step0 is typed through; the other slots are kept
     as the raw ``analysis`` dict pirlygenes already threads through
     the pipeline. Future PRs can replace each slot with a typed
-    dataclass as the corresponding stage is refactored.
+    dataclass as the corresponding step is refactored.
     """
 
-    stage0: object | None = None  # TissueCompositionSignal
+    step0: object | None = None  # TissueCompositionSignal
     # Future slots — left as Any so pre-refactor pipeline still works:
-    stage1_candidates: list | None = None
-    stage2_purity: dict | None = None
-    stage3_decomp: object | None = None
-    stage4_therapy_axes: dict | None = None
-    stage5_expression_ranges: object | None = None
+    step1_candidates: list | None = None
+    step2_purity: dict | None = None
+    step3_decomp: object | None = None
+    step4_therapy_axes: dict | None = None
+    step5_expression_ranges: object | None = None
     reasoning_trace: list[str] = field(default_factory=list)

--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -12,7 +12,7 @@
 
 """Sample-context inference — library prep, preservation, degradation.
 
-First stage of the unified attribution flow (see README "Attribution
+First step of the unified attribution flow (see README "Attribution
 flow"). Runs before cancer-type inference and produces a ``SampleContext``
 that every downstream step consumes as a **base-layer of expression
 expectations**: which genes are expected to be over- or under-represented
@@ -715,7 +715,7 @@ def _refine_preservation_with_orthogonal_signals(
 def infer_sample_context(df_gene_expr) -> SampleContext:
     """Infer a ``SampleContext`` from a TPM expression table.
 
-    This is the FIRST stage of the unified attribution flow — it runs
+    This is the FIRST step of the unified attribution flow — it runs
     before cancer-type inference, decomposition, and any downstream
     analysis that might be biased by FFPE / library-prep artifacts.
 
@@ -833,7 +833,7 @@ def infer_sample_context(df_gene_expr) -> SampleContext:
             "needed for a definitive FFPE call."
         )
 
-    # Append refinement-stage flags last so they read in narrative order.
+    # Append refinement-step flags last so they read in narrative order.
     flags.extend(refined_flags)
 
     return SampleContext(

--- a/pirlygenes/therapy_response.py
+++ b/pirlygenes/therapy_response.py
@@ -30,11 +30,11 @@ scoring module surfaces that chain explicitly, so readers see
 
 rather than having to reconstruct it from per-gene TPM tables.
 
-Five-stage attribution flow placement: this is a **stage 3/4** layer.
-Stage 1 (SampleContext) covers library prep / preservation; stage 2
-handles coarse TME decomposition; stage 3 refines TME subtype / state;
-stage 4 adjusts tumor values before claiming. Therapy-response adds
-to stage 4 by explaining *why* a tumor gene is high or low independent
+Five-step attribution flow placement: this is a **step 3/4** layer.
+Step 1 (SampleContext) covers library prep / preservation; step 2
+handles coarse TME decomposition; step 3 refines TME subtype / state;
+step 4 adjusts tumor values before claiming. Therapy-response adds
+to step 4 by explaining *why* a tumor gene is high or low independent
 of TME mis-attribution.
 """
 

--- a/pirlygenes/tumor_evidence.py
+++ b/pirlygenes/tumor_evidence.py
@@ -1,7 +1,7 @@
 # Licensed under the Apache License, Version 2.0
 """Unified tumor-evidence scoring (#149 synthesis).
 
-Every tumor-evidence channel Stage-0 computes — CTA re-expression,
+Every tumor-evidence channel Step-0 computes — CTA re-expression,
 oncofetal reactivation, coordinated proliferation, Warburg /
 glycolysis, hypoxia, cancer-type-specific tumor-up hits, DDR
 activation — each produces a normalised 0..1 score. Scores are

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.38.1"
+__version__ = "4.38.2"
 
 version_string = f"v{__version__}"
 

--- a/reports/cross-modality-target-report-2026-04.md
+++ b/reports/cross-modality-target-report-2026-04.md
@@ -104,7 +104,7 @@ targeting TCE, opening a new category for mutation-specific pMHC therapies.
 ## Methodology
 
 Targets were scored by: (1) number of distinct modalities with active programs,
-and (2) sum of development-stage scores per modality (Approved=5, Phase 3=3,
+and (2) sum of development-step scores per modality (Approved=5, Phase 3=3,
 Phase 2=2, Phase 1=1, Preclinical=0.5). Data sourced from pirlygenes curated
 datasets covering ADC-approved, ADC-trials, bispecific-antibodies-approved,
 multispecific-tcell-engager-trials, CAR-T-approved, TCR-T-approved, and

--- a/tests/test_battery_audit_fixes.py
+++ b/tests/test_battery_audit_fixes.py
@@ -269,7 +269,7 @@ def test_proliferation_panel_size_matches_public_api():
     assert len(set(panel)) == len(panel)
 
 
-# ── #37: Stage-0 reasoning_trace format ─────────────────────────────
+# ── #37: Step-0 reasoning_trace format ─────────────────────────────
 
 
 def test_reasoning_trace_rendering_format_stable():

--- a/tests/test_healthy_vs_tumor.py
+++ b/tests/test_healthy_vs_tumor.py
@@ -1,4 +1,4 @@
-"""Tests for the Stage-0 tissue-composition + cancer-hint gate (#149).
+"""Tests for the Step-0 tissue-composition + cancer-hint gate (#149).
 
 Uses the shipped HPA nTPM + TCGA FPKM reference to construct synthetic
 samples (pure-tissue + pure-tumor) and asserts the top-3 matches and
@@ -51,7 +51,7 @@ def test_brain_sample_routes_to_healthy_dominant_with_brain_tissues_on_top():
     """A synthetic brain sample with quiet proliferation must produce
     a healthy-dominant hint AND the top HPA match must be a brain
     tissue (cerebral_cortex / spinal_cord / cerebellum). This is the
-    coarse-to-fine signal that downstream stages read."""
+    coarse-to-fine signal that downstream steps read."""
     from pirlygenes.healthy_vs_tumor import _ONCOFETAL_STRICT
     ref = _ref()
     sample = ref["nTPM_cerebral_cortex"].astype(float).to_dict()

--- a/tests/test_issue_169_call_confidence.py
+++ b/tests/test_issue_169_call_confidence.py
@@ -7,7 +7,7 @@ facing reasons when:
 
 1. Top candidate's lineage concordance < 0.2 (near zero)
 2. Geomean gap to runner-up < 1.1× (tied call)
-3. Stage-0 top-ρ TCGA cohort disagrees with the classifier's pick
+3. Step-0 top-ρ TCGA cohort disagrees with the classifier's pick
 
 Canonical failure the tier catches: a real sarcoma validation
 sample at 4.35.0 → THYM with concordance 0.000 and a 0.002 geomean
@@ -74,8 +74,8 @@ def test_tied_geomean_downgrades_to_moderate():
     assert any("ambiguous" in r.lower() for r in tier.reasons)
 
 
-def test_stage0_mismatch_downgrades_to_moderate():
-    """Stage-0 correlation favors a cohort the classifier didn't pick
+def test_step0_mismatch_downgrades_to_moderate():
+    """Step-0 correlation favors a cohort the classifier didn't pick
     — surface the mismatch."""
     class _HVT:
         top_tcga_cohorts = [("FPKM_SARC", 0.77)]
@@ -88,11 +88,11 @@ def test_stage0_mismatch_downgrades_to_moderate():
     }
     tier = compute_call_confidence(analysis)
     assert tier.tier == "moderate"
-    assert any("Stage-0" in r and "SARC" in r for r in tier.reasons)
+    assert any("Step-0" in r and "SARC" in r for r in tier.reasons)
 
 
 def test_multiple_contradictions_all_surface_at_low_tier():
-    """Zero concordance + Stage-0 mismatch + tied geomean → tier stays
+    """Zero concordance + Step-0 mismatch + tied geomean → tier stays
     ``low`` and all three reasons appear."""
     class _HVT:
         top_tcga_cohorts = [("FPKM_SARC", 0.77)]
@@ -115,8 +115,8 @@ def test_missing_candidate_trace_returns_unknown():
     assert tier.tier == "unknown"
 
 
-def test_stage0_match_does_not_downgrade():
-    """Stage-0 agreeing with the classifier keeps the tier high."""
+def test_step0_match_does_not_downgrade():
+    """Step-0 agreeing with the classifier keeps the tier high."""
     class _HVT:
         top_tcga_cohorts = [("FPKM_PRAD", 0.82)]
     analysis = {

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -47,7 +47,7 @@ def _ranges_df():
     ])
 
 
-def test_provenance_md_walks_the_five_stages():
+def test_provenance_md_walks_the_five_steps():
     analysis = {
         "sample_context": _Ctx(),
         "purity": {"overall_estimate": 0.28, "overall_lower": 0.19, "overall_upper": 0.40},
@@ -56,11 +56,11 @@ def test_provenance_md_walks_the_five_stages():
         analysis, _ranges_df(), [_Decomp()],
         cancer_code="PRAD", sample_id="sample_X",
     )
-    # Each numbered stage must appear.
+    # Each numbered step must appear.
     for heading in ["1. Library prep", "2. Preservation",
                     "3. Coarse composition", "4. Subtype refinements",
                     "5. Tumor-specific core"]:
-        assert heading in md, f"missing stage heading: {heading}"
+        assert heading in md, f"missing step heading: {heading}"
     assert "exome capture" in md
     assert "FOLH1" in md or "tumor-core" in md.lower()
 

--- a/tests/test_reasoning_rules.py
+++ b/tests/test_reasoning_rules.py
@@ -1,4 +1,4 @@
-"""Tests for the Stage-0 reasoning rules as standalone pure functions.
+"""Tests for the Step-0 reasoning rules as standalone pure functions.
 
 Each rule in :mod:`pirlygenes.reasoning` takes a
 ``TissueCompositionSignal`` and a pre-computed :class:`DerivedFlags`,
@@ -19,7 +19,7 @@ from pirlygenes.reasoning import (
     high_proliferation_panel,
     lymphoid_tissue_ambiguity,
     mesenchymal_tissue_ambiguity,
-    run_stage0_rules,
+    run_step0_rules,
     tcga_dominant_correlation,
     tumor_marker_overrides_ambiguity,
     weak_healthy_lean,
@@ -212,27 +212,27 @@ def test_tcga_dominant_correlation_is_unconditional_default():
 
 # ---------- Rule runner ----------
 
-def test_run_stage0_rules_picks_first_match():
+def test_run_step0_rules_picks_first_match():
     """Rule runner returns the first rule that fires — ordering matters."""
     s = _make_signal(cta_count_above_1_tpm=10)
     f = _flags(s, lymphoid_ambiguity=True)
-    outcome, trace = run_stage0_rules(s, f)
+    outcome, trace = run_step0_rules(s, f)
     # tumor_marker_overrides_ambiguity is first and matches.
     assert outcome.rule_name == "tumor-marker-overrides-ambiguity"
     assert outcome.hint == "tumor-consistent"
 
 
-def test_run_stage0_rules_falls_to_default_when_nothing_else_matches():
+def test_run_step0_rules_falls_to_default_when_nothing_else_matches():
     """Rule runner reaches the TCGA-dominant default when no earlier
     rule fires."""
     s = _make_signal()  # no tumor evidence, no ambiguity, no healthy margin
     f = _flags(s)
-    outcome, trace = run_stage0_rules(s, f)
+    outcome, trace = run_step0_rules(s, f)
     assert outcome.rule_name == "tcga-dominant-correlation"
     assert outcome.hint == "tumor-consistent"
 
 
-def test_run_stage0_rules_accepts_custom_rule_order():
+def test_run_step0_rules_accepts_custom_rule_order():
     """Custom rule order is honored."""
     s = _make_signal(cta_count_above_1_tpm=10)
     f = _flags(s, lymphoid_ambiguity=True)
@@ -243,13 +243,13 @@ def test_run_stage0_rules_accepts_custom_rule_order():
         tumor_marker_overrides_ambiguity,
         tcga_dominant_correlation,
     ]
-    outcome, trace = run_stage0_rules(s, f, rules=custom_order)
+    outcome, trace = run_step0_rules(s, f, rules=custom_order)
     assert outcome.rule_name == "lymphoid-tissue-tumor-indistinguishable"
 
 
-def test_run_stage0_rules_auto_computes_flags_when_omitted():
+def test_run_step0_rules_auto_computes_flags_when_omitted():
     """When ``flags`` is omitted the runner pre-computes them."""
     s = _make_signal(cta_count_above_1_tpm=10)
-    outcome, trace = run_stage0_rules(s)
+    outcome, trace = run_step0_rules(s)
     assert outcome.hint == "tumor-consistent"
     assert outcome.rule_name == "aggregate-tumor-evidence"


### PR DESCRIPTION
## Summary

The analysis pipeline called its phases "Stage-0 / Stage-1 / ..." with no deeper meaning beyond "successive analysis steps." In report output next to oncology content, a header like **"Stage 4 therapy axes"** collides with clinical tumor staging (Stage IV = advanced-stage cancer) and reads ambiguously to a clinician.

Rename throughout — no behavior change, 635 tests pass.

## Changes

- Report headers and user-facing strings: ``Stage-0`` → ``Step-0``, ``Stage 1`` → ``Step 1``
- Code identifiers: ``stage0`` / ``stage1_candidates`` / ``stage2_purity`` / … / ``stage5_expression_ranges``, ``STAGE0_RULES``, ``Stage0Rule``, ``run_stage0_rules`` → ``step*`` equivalents
- Doc filename: ``docs/stage0-reasoning.md`` → ``docs/step0-reasoning.md``
- Module docstrings / comments referencing pipeline phases

## Scope carve-outs

- Historical commit / PR / issue references not rewritten — only live source uses the new terminology going forward
- ``cancer-key-genes.csv`` line using "late-stage trials" unchanged (different meaning: phase of drug development)

## Version
Bump to 4.38.2 (patch — rename only).

## Test plan

- [x] Full suite (ex. flaky perf-fence) — 635 passed, 1 skipped
- [x] ``ruff check`` clean
- [x] Spot-checked ``docs/reasoning-pipeline.md`` + ``README.md`` rendered