### PR TITLE
feat(decomp): SARC subtype-aware matched-normal routing (closes #51)

### DIFF
--- a/pirlygenes/decomposition/engine.py
+++ b/pirlygenes/decomposition/engine.py
@@ -21,10 +21,10 @@ from .signature import build_signature_matrix, get_component_markers
 from .templates import (
     EPITHELIAL_MATCHED_NORMAL_TISSUE,
     TEMPLATES,
-    epithelial_matched_normal_component,
     get_template_components,
     get_template_extra_components,
     get_template_host_tissues,
+    matched_normal_component,
 )
 from ..gene_sets_cancer import (
     housekeeping_gene_ids,
@@ -621,10 +621,17 @@ def _fit_one_hypothesis(
     cancer_type = candidate_row["code"]
     purity_result = candidate_row["purity_result"]
 
-    components = get_template_components(template_name, cancer_type)
+    # Mixture-cohort subtype (#171) — when the classifier tagged a
+    # winning subtype (e.g. SARC parent with winning SARC_LMS), use it
+    # to route matched-normal selection (#51). Falls back silently to
+    # parent-code lookup for non-mixture cohorts.
+    winning_subtype = candidate_row.get("winning_subtype")
+    components = get_template_components(
+        template_name, cancer_type, winning_subtype=winning_subtype,
+    )
     comp_names = [comp for comp in components if comp != "tumor"]
     matched_normal_name = (
-        epithelial_matched_normal_component(cancer_type)
+        matched_normal_component(cancer_type, winning_subtype=winning_subtype)
         if template_name == "solid_primary"
         else None
     )

--- a/pirlygenes/decomposition/templates.py
+++ b/pirlygenes/decomposition/templates.py
@@ -151,20 +151,22 @@ _PRIMARY_HOST_TISSUES = {
     "READ": ["rectum", "colon", "appendix"],
 }
 
-# Epithelial primaries with a defensible matched-normal parent tissue.
-# Enables an optional `matched_normal_<tissue>` compartment in solid_primary
-# that lets admixed benign parent tissue (e.g. admixed benign prostate gland
-# in a PRAD resection, adjacent normal mucosa in a COAD biopsy) be absorbed
-# as non-tumor signal rather than attributed to tumor cells by the
-# purity-adjusted deconvolution.
+# Cancer codes with a defensible matched-normal parent tissue — enables an
+# optional ``matched_normal_<tissue>`` compartment in solid_primary so that
+# admixed benign parent tissue (adjacent benign prostate in a PRAD resection,
+# adjacent mucosa in a COAD biopsy, uterine smooth muscle in a LMS) is
+# absorbed as non-tumor signal rather than attributed to tumor cells.
 #
-# Scope: epithelial cancers only. Mesenchymal / glial / melanocytic / heme
-# cancers are excluded because they lack a single stable benign analog at
-# the bulk-reference level; see issue #51 for a subtype-aware SARC plan.
-# TGCT is excluded because germ-cell origin is sui generis. MESO is
-# excluded because its parent mesothelium is a thin serosal layer not
-# captured well by bulk references.
-EPITHELIAL_MATCHED_NORMAL_TISSUE = {
+# Scope note: mesenchymal / glial / melanocytic / heme cancers lack a single
+# stable benign analog at the **parent** level. For SARC the analog depends
+# on subtype (LMS → smooth muscle; liposarcoma → adipose; MPNST → Schwann),
+# so the parent SARC code is deliberately absent and the classifier's
+# ``winning_subtype`` (#171) routes per-subtype. UPS / MFS / UPS-like /
+# synovial sarcoma / angiosarcoma have no defensible benign counterpart and
+# stay on the unassigned path. TGCT germ-cell origin and MESO serosal
+# mesothelium are also excluded for reference-quality reasons.
+MATCHED_NORMAL_TISSUE = {
+    # Epithelial primaries
     "BLCA": "urinary_bladder",
     "BRCA": "breast",
     "CESC": "cervix",
@@ -185,21 +187,52 @@ EPITHELIAL_MATCHED_NORMAL_TISSUE = {
     "STAD": "stomach",
     "THCA": "thyroid_gland",
     "UCEC": "endometrium",
+    # SARC subtypes (issue #51, enabled by mixture-cohort winning_subtype
+    # from #171). LMS → smooth muscle; all liposarcoma flavors → mature
+    # adipose. MPNST → Schwann would require a non-HPA reference and is
+    # deferred. UPS / MFS / synovial / angiosarcoma stay unassigned.
+    "SARC_LMS": "smooth_muscle",
+    "SARC_DDLPS": "adipose_tissue",
+    "SARC_WDLPS": "adipose_tissue",
+    "SARC_MYXLPS": "adipose_tissue",
+    "SARC_LPS_UNSPEC": "adipose_tissue",
+}
+
+# Backwards-compatibility alias kept so external importers that used
+# ``EPITHELIAL_MATCHED_NORMAL_TISSUE`` keep working. Reads the merged map
+# and filters out the sarcoma subtypes at access time; prefer the new name.
+EPITHELIAL_MATCHED_NORMAL_TISSUE = {
+    code: tissue for code, tissue in MATCHED_NORMAL_TISSUE.items()
+    if not code.startswith("SARC_")
 }
 
 
-def epithelial_matched_normal_component(cancer_type):
-    """Return matched-normal component name for an epithelial primary, or None.
+def matched_normal_component(cancer_type, winning_subtype=None):
+    """Return matched-normal component name, or ``None`` when unavailable.
 
-    Returns e.g. ``"matched_normal_prostate"`` for PRAD, or None for cancer
-    types that are not in :data:`EPITHELIAL_MATCHED_NORMAL_TISSUE`.
+    ``winning_subtype`` is the mixture-cohort classifier's per-subtype
+    call (#171). When set, it takes precedence over the parent code so
+    a SARC parent with ``winning_subtype=SARC_LMS`` picks up
+    ``matched_normal_smooth_muscle`` instead of falling to the unassigned
+    default.
     """
-    if cancer_type is None:
+    code = winning_subtype or cancer_type
+    if code is None:
         return None
-    tissue = EPITHELIAL_MATCHED_NORMAL_TISSUE.get(cancer_type)
+    tissue = MATCHED_NORMAL_TISSUE.get(code)
     if tissue is None:
         return None
     return f"matched_normal_{tissue}"
+
+
+def epithelial_matched_normal_component(cancer_type):
+    """Deprecated alias for :func:`matched_normal_component`.
+
+    Kept so external importers keep working. Does not consult the
+    mixture-cohort ``winning_subtype`` — callers that need the SARC
+    subtype-aware path should use :func:`matched_normal_component`.
+    """
+    return matched_normal_component(cancer_type)
 
 _TEMPLATE_HOST_TISSUES = {
     # Retroperitoneal/deep soft tissue biopsies can look like a mix of muscle
@@ -223,15 +256,20 @@ TUMOR_ORIGIN_TYPE = {
 }
 
 
-def get_template_components(template_name, cancer_type=None):
+def get_template_components(template_name, cancer_type=None, winning_subtype=None):
     """Get the full component list for a template + cancer type.
 
-    For ``template_name == "solid_primary"`` and ``cancer_type`` in
-    :data:`EPITHELIAL_MATCHED_NORMAL_TISSUE`, a ``matched_normal_<tissue>``
-    component is appended so admixed benign parent tissue can be absorbed
-    as non-tumor signal rather than attributed to tumor cells (issue #50).
-    Non-epithelial solid primaries (SARC, heme, etc.) get no matched-normal
-    compartment — see issue #51 for the subtype-aware SARC plan.
+    For ``template_name == "solid_primary"`` and a cancer code with a
+    defensible benign parent tissue in :data:`MATCHED_NORMAL_TISSUE`, a
+    ``matched_normal_<tissue>`` component is appended so admixed benign
+    parent tissue is absorbed as non-tumor signal rather than attributed
+    to tumor cells (issue #50).
+
+    ``winning_subtype`` is the mixture-cohort classifier's per-subtype
+    hypothesis (#171). When set it takes precedence over ``cancer_type``
+    for matched-normal lookup — the SARC subtype-aware path (#51)
+    routes SARC_LMS → smooth muscle, liposarcoma flavors → adipose,
+    etc., while leaving UPS / MFS / synovial / angiosarcoma unassigned.
 
     Returns
     -------
@@ -241,7 +279,9 @@ def get_template_components(template_name, cancer_type=None):
     tmpl = TEMPLATES[template_name]
     components = ["tumor"] + list(tmpl["components"])
     if template_name == "solid_primary":
-        matched = epithelial_matched_normal_component(cancer_type)
+        matched = matched_normal_component(
+            cancer_type, winning_subtype=winning_subtype,
+        )
         if matched is not None:
             components.append(matched)
     return components

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.39.0"
+__version__ = "4.40.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_51_sarc_matched_normal.py
+++ b/tests/test_issue_51_sarc_matched_normal.py
@@ -1,0 +1,101 @@
+"""Regression tests for #51 — SARC subtype-aware matched-normal.
+
+The epithelial matched-normal mechanism (#50) gives every epithelial
+primary an optional ``matched_normal_<tissue>`` compartment so admixed
+benign parent tissue is absorbed as non-tumor signal. SARC parent is
+deliberately absent from that map because it's a mixture of lineage-
+distinct subtypes with different benign analogs (LMS → smooth muscle;
+liposarcoma → adipose; MPNST → Schwann).
+
+With the mixture-cohort classifier (#171) producing ``winning_subtype``
+on the SARC parent row, the decomposition engine now routes
+matched-normal selection per subtype.
+
+UPS / MFS / synovial / angiosarcoma have no defensible benign
+counterpart and stay on the unassigned path.
+"""
+
+from pirlygenes.decomposition.templates import (
+    MATCHED_NORMAL_TISSUE,
+    epithelial_matched_normal_component,
+    get_template_components,
+    matched_normal_component,
+)
+
+
+def test_sarc_parent_without_subtype_has_no_matched_normal():
+    """Without ``winning_subtype``, the SARC parent code alone must not
+    pull any matched-normal component — the mixture parent has no single
+    defensible benign analog."""
+    assert matched_normal_component("SARC") is None
+
+
+def test_sarc_lms_subtype_picks_smooth_muscle():
+    assert matched_normal_component(
+        "SARC", winning_subtype="SARC_LMS",
+    ) == "matched_normal_smooth_muscle"
+
+
+def test_sarc_liposarcoma_subtypes_pick_adipose():
+    for code in ("SARC_DDLPS", "SARC_WDLPS", "SARC_MYXLPS", "SARC_LPS_UNSPEC"):
+        assert matched_normal_component(
+            "SARC", winning_subtype=code,
+        ) == "matched_normal_adipose_tissue", code
+
+
+def test_sarc_unassigned_subtypes_have_no_matched_normal():
+    """UPS / MFS / synovial / angiosarcoma / MPNST have no defensible
+    benign reference in HPA and must stay on the unassigned path."""
+    for code in ("SARC_UPS", "SARC_MYXFIB", "SARC_SYN", "SARC_ANGIO", "SARC_MPNST"):
+        assert matched_normal_component(
+            "SARC", winning_subtype=code,
+        ) is None, code
+
+
+def test_epithelial_primaries_unaffected_by_subtype_override():
+    """An epithelial primary keeps its existing matched-normal
+    regardless of winning_subtype (which wouldn't be set for
+    non-mixture parents anyway, but defend the invariant)."""
+    assert matched_normal_component("PRAD") == "matched_normal_prostate"
+    assert matched_normal_component(
+        "PRAD", winning_subtype=None,
+    ) == "matched_normal_prostate"
+
+
+def test_get_template_components_wires_subtype_through():
+    """``get_template_components`` must route the winning_subtype to
+    matched_normal lookup so the engine picks the correct compartment
+    for NNLS fitting."""
+    comps_parent = get_template_components("solid_primary", "SARC")
+    assert not any(c.startswith("matched_normal_") for c in comps_parent), (
+        f"SARC parent without subtype should not add matched-normal: {comps_parent}"
+    )
+    comps_lms = get_template_components(
+        "solid_primary", "SARC", winning_subtype="SARC_LMS",
+    )
+    assert "matched_normal_smooth_muscle" in comps_lms
+    comps_lps = get_template_components(
+        "solid_primary", "SARC", winning_subtype="SARC_LPS_UNSPEC",
+    )
+    assert "matched_normal_adipose_tissue" in comps_lps
+
+
+def test_deprecated_epithelial_alias_still_works():
+    """Outside importers kept ``epithelial_matched_normal_component``
+    — the alias must keep returning the parent-code result and must not
+    consult winning_subtype (SARC-subtype routing is only via the new
+    name)."""
+    assert epithelial_matched_normal_component("PRAD") == "matched_normal_prostate"
+    assert epithelial_matched_normal_component("SARC") is None
+    assert epithelial_matched_normal_component("SARC_LMS") == "matched_normal_smooth_muscle"
+
+
+def test_matched_normal_map_contains_expected_codes():
+    """Registry invariant: epithelial primaries + the four defensible
+    SARC subtypes must be present."""
+    for code in ("BRCA", "PRAD", "COAD", "LUAD"):
+        assert code in MATCHED_NORMAL_TISSUE
+    for code in ("SARC_LMS", "SARC_DDLPS", "SARC_WDLPS", "SARC_MYXLPS", "SARC_LPS_UNSPEC"):
+        assert code in MATCHED_NORMAL_TISSUE
+    # Parent SARC must remain absent so the mixture-cohort path owns it.
+    assert "SARC" not in MATCHED_NORMAL_TISSUE


### PR DESCRIPTION
## Summary

TCGA-SARC's parent code was deliberately absent from the matched-normal map because the biological analog depends on subtype: LMS → smooth muscle, liposarcoma → adipose, MPNST → Schwann. With the mixture-cohort classifier (#171) now producing ``winning_subtype`` on the SARC parent row, the decomposition engine routes matched-normal per subtype.

## Changes

- ``MATCHED_NORMAL_TISSUE`` unified map adds ``SARC_LMS`` → smooth_muscle; ``SARC_DDLPS`` / ``SARC_WDLPS`` / ``SARC_MYXLPS`` / ``SARC_LPS_UNSPEC`` → adipose_tissue
- New public ``matched_normal_component(cancer_type, winning_subtype=None)`` — prefers subtype when set
- ``epithelial_matched_normal_component`` kept as a deprecated alias so external importers keep working
- ``get_template_components`` threads winning_subtype through; ``solid_primary`` gains ``matched_normal_<tissue>`` only when defensible
- Engine reads winning_subtype from candidate_row and passes to template resolution

## Carve-outs

- UPS / MFS / UPS-like / synovial / angiosarcoma / MPNST stay on the unassigned path — no defensible HPA benign reference (MPNST would need Schwann-cell reference not in HPA bulk; deferred)
- Mis-subtyped behavior not explicitly tested beyond "unassigned → no matched-normal"; downstream #131 flags surface over-prediction naturally

## Test plan

- [x] 8 new tests in ``test_issue_51_sarc_matched_normal.py`` — all pass
- [x] Full suite — 650 passed, 1 skipped
- [x] Verified on a real SARC_LPS_UNSPEC sample: decomposition now fits ``matched_normal_adipose_tissue``; matched-normal-over-predicted flag fires on HMGA2 / CDKN2A (expected for 12q-amp liposarcoma)
- [x] ``ruff check`` clean

## Version
Bump to 4.40.0 (minor — new feature).