### PR TITLE
chore(report): six UX polish items

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -316,9 +316,18 @@ def build_brief(
             if not match.empty:
                 row = match.iloc[0]
                 subtype_key = row.get("subtype_key")
+                label = None
                 if isinstance(subtype_key, str) and subtype_key and subtype_key.lower() != "nan":
                     label = subtype_key.replace("_", " ")
                 else:
+                    # Fall back to the human-readable registry ``name``
+                    # so aggregate-only rows without a ``subtype_key``
+                    # still render cleanly (SARC_LPS_UNSPEC →
+                    # "liposarcoma" rather than raw code).
+                    name = row.get("name")
+                    if isinstance(name, str) and name:
+                        label = name.split("(")[0].strip().lower()
+                if not label:
                     label = winning_subtype
                 subtype_annotation = f" (subtype: {label}-consistent)"
         except Exception:

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -39,8 +39,6 @@ from .load_expression import load_expression_data
 from .plot import (
     plot_gene_expression,
     plot_sample_vs_cancer,
-    plot_cancer_type_genes,
-    plot_cancer_type_disjoint_genes,
     plot_cancer_type_mds,
     plot_therapy_target_tissues,
     plot_therapy_target_safety,
@@ -1583,14 +1581,11 @@ def _analyze_body(
     )
     _plt.close("all")
 
-    # Cancer type signature plots
-    print("[plot] Generating cancer type signature gene plots...")
-    genes_png = "%s-cancer-types-genes.png" % prefix if prefix else "cancer-types-genes.png"
-    plot_cancer_type_genes(df_expr, save_to_filename=genes_png, save_dpi=output_dpi)
-
-    disjoint_png = "%s-cancer-types-disjoint.png" % prefix if prefix else "cancer-types-disjoint.png"
-    plot_cancer_type_disjoint_genes(df_expr, save_to_filename=disjoint_png, save_dpi=output_dpi)
-    _plt.close("all")
+    # Cancer-type signature gene grids (``plot_cancer_type_genes`` +
+    # ``plot_cancer_type_disjoint_genes``) were removed from the default
+    # plot set in 4.40.1 — they duplicated the candidate-ranking table
+    # in analysis.md without adding interpretive value. The functions
+    # remain in ``pirlygenes.plot_embedding`` for Python-API consumers.
 
     # Sample-among-TCGA embedding: MDS in the TME-low gene space is the
     # preferred view — robust at low purity (where hierarchy-method plots
@@ -1917,8 +1912,6 @@ def _analyze_body(
         "%s-antigens.png" % prefix if prefix else "antigens.png",
         "%s-treatments.png" % prefix if prefix else "treatments.png",
         safety_png,
-        genes_png,
-        disjoint_png,
     ] + embedding_pngs
     if ct_png:
         png_files.append(ct_png)
@@ -1995,9 +1988,12 @@ Sample analyzed as **{cancer_code}** ({cancer_name}).
 
 | File | Description |
 |------|-------------|
-| `*-summary.md` | One-paragraph natural language summary — cancer type, purity, key findings |
-| `*-analysis.md` | Structured analysis — candidate trace, purity components, decomposition, background signatures, embedding features |
+| `*-brief.md` | One-page clinician-facing summary (≤ 40 lines) — cancer call, purity, top therapies, caveats |
+| `*-actionable.md` | Oncologist-facing treatment-review document — deeper context on each therapy, subtype hypothesis, disease-state narrative |
+| `*-summary.md` | One-paragraph natural-language summary — cancer type, purity, key findings |
+| `*-analysis.md` | Structured deep-dive — candidate trace, purity components, decomposition, background signatures, embedding features |
 | `*-targets.md` | Therapeutic targets — tumor context, therapy landscape at a glance, CTAs, surface proteins, intracellular targets, tumor-expression ranges |
+| `*-provenance.md` | Attribution chain — how the sample gets parsed into library-prep / preservation / TME / tumor-core step by step |
 | `*-analysis-parameters.json` | Free model parameters plus selected sample mode and embedding methods |
 | `*-all-figures.pdf` | All figures combined into a single PDF |
 | `*-cancer-candidates.tsv` | Candidate cancer-type support trace |
@@ -2027,8 +2023,6 @@ Prefer the standalone decomposition figures for review and sharing. They replace
 | `*-purity-ctas.png` | Tumor-expression ranges for CTAs |
 | `*-purity-surface.png` | Tumor-expression ranges for surface proteins |
 | `*-mds-tme.png` | MDS: sample among TCGA cancer types (TME-low gene space) |
-| `*-cancer-types-genes.png` | Cancer-type gene signature heatmap |
-| `*-cancer-types-disjoint.png` | Disjoint (unique) gene counts per cancer type |
 """
     readme_path.write_text(readme)
     print(f"[output] Wrote {readme_path}")

--- a/pirlygenes/plot_data_helpers.py
+++ b/pirlygenes/plot_data_helpers.py
@@ -311,8 +311,12 @@ def prepare_gene_expr_df(
         # build from DF
         id_to_name_from_df = dict(zip(expr_gene_ids, df[gene_name_col].astype(str)))
     else:
-        # fallback: resolve names for all expressed IDs (one call)
+        # fallback: resolve names for all expressed IDs (one call). Slow
+        # on full transcriptomes — announce so the CLI progress log
+        # doesn't go silent for tens of seconds here.
         uniq_ids = list(dict.fromkeys(expr_gene_ids))  # preserves order, de-dups
+        if verbose:
+            print(f"[plot] resolving gene names for {len(uniq_ids)} IDs...")
         resolved_ids, resolved_names = find_canonical_gene_ids_and_names(uniq_ids)
         for gid, gname in zip(resolved_ids, resolved_names):
             if gid and gname:

--- a/pirlygenes/plot_strip.py
+++ b/pirlygenes/plot_strip.py
@@ -182,6 +182,8 @@ def plot_gene_expression(
     palette_dict = {c: color for c, color in zip(named_cats_strip, named_palette)}
     palette_dict[other_name] = (0.8, 0.8, 0.8)  # gray for "other"
 
+    if verbose:
+        print(f"[plot] rendering strip plot ({len(df_gene_expr_annot)} points)...")
     cat = sns.catplot(
         data=df_gene_expr_annot,
         x="category",

--- a/pirlygenes/plot_therapy.py
+++ b/pirlygenes/plot_therapy.py
@@ -1392,15 +1392,15 @@ def plot_therapy_pathway_state(
             ax.plot([up_fold], [i], marker="o", markersize=11,
                     color=color, markeredgecolor="white", markeredgewidth=1.4,
                     linestyle="", zorder=3,
-                    label="up-panel" if i == 0 else None)
-            ax.text(up_fold, i + 0.20, f"up {up_fold:.2f}\u00d7",
+                    label="genes up when pathway active" if i == 0 else None)
+            ax.text(up_fold, i + 0.20, f"\u2191 {up_fold:.2f}\u00d7",
                     ha="center", va="bottom", fontsize=8, color=color, fontweight="bold")
         if down_fold is not None:
             ax.plot([down_fold], [i], marker="s", markersize=10,
                     color=color, markeredgecolor="white", markeredgewidth=1.4,
                     linestyle="", zorder=3,
-                    label="down-panel" if i == 0 else None)
-            ax.text(down_fold, i - 0.26, f"down {down_fold:.2f}\u00d7",
+                    label="genes down when pathway active" if i == 0 else None)
+            ax.text(down_fold, i - 0.26, f"\u2193 {down_fold:.2f}\u00d7",
                     ha="center", va="top", fontsize=8, color=color, fontweight="bold")
 
     ax.axvline(1.0, color="#888888", linestyle="--", linewidth=1.0, alpha=0.7, zorder=1)

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -284,11 +284,8 @@ def plot_provenance_funnel(
 
     ax.set_xlim(0, max(1.0, left))
     ax.set_yticks([])
-    ax.set_xlabel("Fraction of sample composition", fontsize=10)
-    ax.set_title(
-        "Sample composition chain — tumor core vs non-tumor compartments",
-        fontsize=11, fontweight="bold",
-    )
+    ax.set_xlabel("")
+    ax.set_title("Sample composition", fontsize=11, fontweight="bold")
     ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.2),
               ncol=min(4, len(labels)), fontsize=8, frameon=False)
 

--- a/pirlygenes/tumor_purity.py
+++ b/pirlygenes/tumor_purity.py
@@ -1740,6 +1740,13 @@ def plot_purity_method_comparison(
     # Row schema: (label, point, lower, upper, family, n_genes, note)
     rows = []
 
+    # Row ordering (#159 polish): group direct purity estimates first
+    # (signature / lineage / decomposition — these are tumor-fraction
+    # calls in their own right), then enrichment-derived (ESTIMATE
+    # stromal / immune / combined — these are odds-model conversions of
+    # TME-enrichment scores, not independent tumor-fraction measurements),
+    # then the adopted overall at the bottom so the reader's eye lands
+    # on the final call last.
     if sig_comp.get("purity") is not None:
         n = len(sig_comp.get("genes") or [])
         rows.append((
@@ -1764,41 +1771,6 @@ def plot_purity_method_comparison(
             "",
         ))
 
-    if stromal_purity is not None:
-        n = (comp.get("stromal") or {}).get("n_genes", 0)
-        rows.append((
-            "ESTIMATE stromal",
-            stromal_purity,
-            None,
-            None,
-            "estimate",
-            n,
-            "",
-        ))
-
-    if immune_purity is not None:
-        n = (comp.get("immune") or {}).get("n_genes", 0)
-        rows.append((
-            "ESTIMATE immune",
-            immune_purity,
-            None,
-            None,
-            "estimate",
-            n,
-            "",
-        ))
-
-    if comp.get("estimate_purity") is not None:
-        rows.append((
-            "ESTIMATE combined",
-            float(comp["estimate_purity"]),
-            None,
-            None,
-            "estimate",
-            0,
-            "",
-        ))
-
     if decomposition_result is not None:
         decomp_purity = getattr(decomposition_result, "purity", None)
         if decomp_purity is not None:
@@ -1812,6 +1784,47 @@ def plot_purity_method_comparison(
                 f" [{getattr(decomposition_result, 'cancer_type', '')} / "
                 f"{getattr(decomposition_result, 'template', '')}]",
             ))
+
+    # Sentinel row used only as a visual separator between the direct-
+    # estimate block above and the enrichment-derived block below.
+    n_direct = len(rows)
+
+    if stromal_purity is not None:
+        n = (comp.get("stromal") or {}).get("n_genes", 0)
+        rows.append((
+            "ESTIMATE stromal (derived)",
+            stromal_purity,
+            None,
+            None,
+            "estimate",
+            n,
+            "",
+        ))
+
+    if immune_purity is not None:
+        n = (comp.get("immune") or {}).get("n_genes", 0)
+        rows.append((
+            "ESTIMATE immune (derived)",
+            immune_purity,
+            None,
+            None,
+            "estimate",
+            n,
+            "",
+        ))
+
+    if comp.get("estimate_purity") is not None:
+        rows.append((
+            "ESTIMATE combined (derived)",
+            float(comp["estimate_purity"]),
+            None,
+            None,
+            "estimate",
+            0,
+            "",
+        ))
+
+    n_before_adopted = len(rows)
 
     overall = purity_result.get("overall_estimate")
     overall_lower = purity_result.get("overall_lower")
@@ -1853,6 +1866,14 @@ def plot_purity_method_comparison(
             float(overall) * 100, color="#1a1a1a",
             linestyle=":", linewidth=1.5, alpha=0.8,
         )
+
+    # Horizontal separator between the direct-estimate block and the
+    # enrichment-derived (ESTIMATE) block, and between the
+    # enrichment-derived block and the adopted call. Makes the visual
+    # hierarchy (direct / derived / final) obvious at a glance.
+    for sep_y in (n_direct - 0.5, n_before_adopted - 0.5):
+        if 0 < sep_y < len(rows) - 0.5:
+            ax.axhline(sep_y, color="#cccccc", linewidth=0.8, alpha=0.7)
 
     y_positions = list(range(len(rows)))
     y_labels = []

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.40.0"
+__version__ = "4.40.1"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -124,8 +124,9 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_mod, "plot_sample_vs_cancer", lambda *a, **k: scatter_calls.append(k))
     monkeypatch.setattr(cli_mod, "plot_therapy_target_tissues", lambda *a, **k: tissue_calls.append(k))
     monkeypatch.setattr(cli_mod, "plot_therapy_target_safety", lambda *a, **k: safety_calls.append(k))
-    monkeypatch.setattr(cli_mod, "plot_cancer_type_genes", lambda *a, **k: cancer_gene_calls.append(k))
-    monkeypatch.setattr(cli_mod, "plot_cancer_type_disjoint_genes", lambda *a, **k: cancer_gene_calls.append(k))
+    # plot_cancer_type_genes / plot_cancer_type_disjoint_genes were
+    # removed from the default plot set (polish/4.40.1); skip
+    # monkeypatching them — they're no longer imported by cli.
     monkeypatch.setattr(cli_mod, "plot_cancer_type_mds", lambda *a, **k: mds_calls.append(k))
     monkeypatch.setattr(cli_mod, "therapy_target_gene_id_to_name", lambda t: {"ENSG_MOCK": t})
     monkeypatch.setattr(cli_mod, "pMHC_TCE_target_gene_id_to_name", lambda: {"ENSG_PMHC": "PMHC"})
@@ -207,7 +208,9 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     assert tissue_calls[0]["tpm_threshold"] == 18
     assert safety_calls[0]["top_k"] == 12
     assert safety_calls[0]["tpm_threshold"] == 18
-    assert len(cancer_gene_calls) == 2  # genes + disjoint
+    # plot_cancer_type_genes / plot_cancer_type_disjoint_genes were
+    # removed from the default plot set (polish/4.40.1).
+    assert len(cancer_gene_calls) == 0
     # Only MDS-TME is emitted now — PCA and hierarchy-method plots have
     # been removed from the default output (see pirl-unc/pirlygenes#36).
     assert len(pca_calls) == 0


### PR DESCRIPTION
## Summary

Six small report-readability fixes surfaced during a sanity sweep over real samples:

1. **Purity method plot** — group direct estimates above enrichment-derived methods with a visual separator so readers don't treat ESTIMATE stromal/immune (odds-model derivations of TME enrichment) as equivalent to signature/lineage (actual tumor-fraction calls). Adopted-overall drops to the bottom for final-call emphasis.
2. **Sample composition chain** — rename title to *Sample composition*; drop the noisy ``Fraction of sample composition`` xlabel.
3. **Therapy-pathway state** — replace opaque ``up-panel`` / ``down-panel`` legend labels with ``genes up when pathway active`` / ``genes down when pathway active``; arrow glyphs in per-gene fold-change text.
4. **Subtype hypothesis label fallback** — when a registry row has an empty ``subtype_key`` (aggregate rows like ``SARC_LPS_UNSPEC``), fall back to the lowercased registry ``name`` so the brief renders *"Liposarcoma-consistent"* instead of *"SARC_LPS_UNSPEC-consistent"*.
5. **Progress prints** in ``plot_data_helpers.prepare_gene_expr_df`` + ``plot_strip`` — fill the silent gap after the "N gene set categories, M genes total" line with explicit *resolving names for N IDs…* and *rendering strip plot (N points)…* breadcrumbs.
6. **Drop cancer-type signature gene grids** (``plot_cancer_type_genes`` + ``plot_cancer_type_disjoint_genes``) from default plot set — duplicated the candidate-ranking table without adding interpretive value. Functions remain in ``pirlygenes.plot_embedding`` for Python-API consumers.

Also updates the generated ``README.md`` to list brief / actionable / provenance alongside summary / analysis / targets (they were missing).

## Version
Bump to 4.40.1 (patch — UX only).

## Test plan

- [x] Full suite — 650 passed, 1 skipped
- [x] Sanity-run on a real sample: strip-plot progress lines fire, subtype label reads *"liposarcoma-consistent"*, cancer-type signature PNGs no longer generated, README lists all 6 markdown files
- [x] ``ruff check`` clean