### PR TITLE
refactor(report): consolidate markdown outputs (5 files, was 6)

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -4,9 +4,11 @@
 
 Audience distinction:
 
-- ``*-brief.md`` — one-page summary, ≤ 40 lines. For a clinician
+- ``*-summary.md`` — one-page summary, ≤ 40 lines. For a clinician
   skimming before a tumor board, or an LLM asked for a 3-sentence
   referral-note paragraph. Strict structure; no internal jargon.
+  (Named ``brief.md`` through 4.40; the earlier free-form
+  ``summary.md`` paragraph was retired as redundant with analysis.md.)
 - ``*-actionable.md`` — longer treatment-review document. For an
   oncologist preparing a treatment discussion, reading carefully.
 
@@ -238,18 +240,19 @@ def _caveats_from_purity_tier(purity_tier, sample_context) -> List[str]:
     return out
 
 
-def build_brief(
+def build_summary(
     analysis,
     ranges_df,
     cancer_code: str,
     disease_state: str,
     sample_id: Optional[str] = None,
 ) -> str:
-    """Return the one-page ``*-brief.md`` content (≤ 40 lines).
+    """Return the one-page ``*-summary.md`` content (≤ 40 lines).
 
     Audience: clinician skimming before a tumor board; LLM asked for a
     short referral-note paragraph. Strict structure; no internal
-    jargon.
+    jargon. (Named ``build_brief`` through 4.40; the legacy name is
+    still exported as an alias.)
     """
     from .gene_sets_cancer import (
         cancer_therapy_targets,
@@ -263,7 +266,7 @@ def build_brief(
 
     lines: List[str] = []
     header_id = f": {sample_id}" if sample_id else ""
-    lines.append(f"# Brief{header_id}\n")
+    lines.append(f"# Summary{header_id}\n")
     lines.append(
         "<!-- Audience: clinician skimming before tumor board. "
         "Intended length: ≤ 40 lines. -->"
@@ -394,10 +397,15 @@ def build_brief(
 
     lines.append(
         "*Full detail: see the accompanying `*-actionable.md`, "
-        "`*-summary.md`, `*-analysis.md`, and `*-targets.md`.*"
+        "`*-analysis.md`, and `*-targets.md`.*"
     )
 
     return "\n".join(lines)
+
+
+# Back-compat alias — ``build_brief`` was the public name through 4.40;
+# removed in 5.0. External importers should migrate to ``build_summary``.
+build_brief = build_summary
 
 
 def build_actionable(
@@ -415,7 +423,6 @@ def build_actionable(
     internal jargon.
     """
     from .gene_sets_cancer import (
-        cancer_biomarker_genes,
         cancer_therapy_targets,
         cancer_key_genes_cancer_types,
     )
@@ -567,28 +574,6 @@ def build_actionable(
                 )
             lines.append("")
 
-        # Biomarker panel
-        biomarker_syms = cancer_biomarker_genes(cancer_code)
-        if biomarker_syms:
-            lines.append("## Biomarker panel\n")
-            lines.append(
-                "Lineage, diagnostic, and disease-state biomarkers for "
-                f"{cancer_code}. Status in this sample:"
-            )
-            lines.append("")
-            lines.append("| Gene | Observed TPM | Tumor-attributed |")
-            lines.append("|------|--------------|------------------|")
-            for sym in biomarker_syms:
-                row = sym_to_row.get(sym)
-                if row is None:
-                    lines.append(f"| {sym} | *not measured* | — |")
-                    continue
-                obs = float(row.get("observed_tpm") or 0)
-                attr = float(row.get("attr_tumor_tpm") or 0)
-                tumor_cell = f"{attr:.0f}" if row.get("attribution") else "—"
-                lines.append(f"| {sym} | {obs:.1f} | {tumor_cell} |")
-            lines.append("")
-
     # Caveats
     caveats = _caveats_from_purity_tier(purity_tier, sample_context)
     if caveats:
@@ -598,9 +583,9 @@ def build_actionable(
         lines.append("")
 
     lines.append(
-        "*See also: `*-summary.md` (free-form narrative), "
-        "`*-analysis.md` (full pipeline detail), `*-targets.md` "
-        "(complete target list), `*-provenance.md` (sample-content chain).*"
+        "*See also: `*-analysis.md` (full pipeline detail), "
+        "`*-targets.md` (biomarker panel + complete target list), "
+        "`*-provenance.md` (sample-content chain).*"
     )
     return "\n".join(lines)
 

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1805,34 +1805,53 @@ def _analyze_body(
         # doc a clinician pastes into a note; the actionable is the
         # one they read before a tumor board.
         try:
-            from .brief import build_brief, build_actionable
+            from .brief import build_summary, build_actionable
 
-            disease_state_for_brief = compose_disease_state_narrative(analysis)
+            disease_state_for_summary = compose_disease_state_narrative(analysis)
             sample_id = prefix if prefix else None
-            brief_md = build_brief(
+            summary_md = build_summary(
                 analysis,
                 ranges_df,
                 cancer_code=effective_cancer_type,
-                disease_state=disease_state_for_brief,
+                disease_state=disease_state_for_summary,
                 sample_id=sample_id,
             )
             actionable_md = build_actionable(
                 analysis,
                 ranges_df,
                 cancer_code=effective_cancer_type,
-                disease_state=disease_state_for_brief,
+                disease_state=disease_state_for_summary,
                 sample_id=sample_id,
             )
-            brief_path = "%s-brief.md" % prefix if prefix else "brief.md"
+            # The 1-page clinician-facing file is emitted as
+            # ``*-summary.md``. The old free-form paragraph that used to
+            # live at that name was retired in 4.41.0 — its disease-state,
+            # step-0, and cancer-type text was ~80% redundant with
+            # analysis.md.
+            summary_path = "%s-summary.md" % prefix if prefix else "summary.md"
             actionable_path = (
                 "%s-actionable.md" % prefix if prefix else "actionable.md"
             )
-            with open(brief_path, "w") as f:
-                f.write(brief_md)
+            with open(summary_path, "w") as f:
+                f.write(summary_md)
             with open(actionable_path, "w") as f:
                 f.write(actionable_md)
-            print(f"[report] Saved {brief_path}")
+            print(f"[report] Saved {summary_path}")
             print(f"[report] Saved {actionable_path}")
+
+            # Back-compat: emit ``*-brief.md`` as a duplicate of
+            # ``*-summary.md`` for one deprecation window (removed in 5.0).
+            # Downstream pipelines that glob for ``*-brief.md`` keep
+            # working; new code should read ``*-summary.md``.
+            brief_path = "%s-brief.md" % prefix if prefix else "brief.md"
+            with open(brief_path, "w") as f:
+                f.write(
+                    "<!-- DEPRECATED in 4.41.0, removed in 5.0. "
+                    "This file is a copy of *-summary.md; update your "
+                    "pipelines to read the new name. -->\n\n"
+                )
+                f.write(summary_md)
+            print(f"[report] Saved {brief_path} (deprecated copy of summary.md)")
 
             # #106: one-page provenance chain (library prep -> tumor
             # core). Emits *-provenance.md alongside a simple stacked-
@@ -1988,12 +2007,11 @@ Sample analyzed as **{cancer_code}** ({cancer_name}).
 
 | File | Description |
 |------|-------------|
-| `*-brief.md` | One-page clinician-facing summary (≤ 40 lines) — cancer call, purity, top therapies, caveats |
-| `*-actionable.md` | Oncologist-facing treatment-review document — deeper context on each therapy, subtype hypothesis, disease-state narrative |
-| `*-summary.md` | One-paragraph natural-language summary — cancer type, purity, key findings |
-| `*-analysis.md` | Structured deep-dive — candidate trace, purity components, decomposition, background signatures, embedding features |
-| `*-targets.md` | Therapeutic targets — tumor context, therapy landscape at a glance, CTAs, surface proteins, intracellular targets, tumor-expression ranges |
-| `*-provenance.md` | Attribution chain — how the sample gets parsed into library-prep / preservation / TME / tumor-core step by step |
+| `*-summary.md` | One-page clinician-facing summary (≤ 40 lines) — cancer call, purity, top therapies, caveats |
+| `*-actionable.md` | Oncologist treatment-review — agents with cancer-type-indicated approvals + trials, cross-referenced against this sample |
+| `*-analysis.md` | Structured deep-dive — disease-state, step-0 evidence, candidate trace, purity components, decomposition, background signatures |
+| `*-targets.md` | Biomarker panel + full therapy-target landscape + tumor-expression ranges |
+| `*-provenance.md` | Attribution chain — library-prep → preservation → TME → tumor-core step by step |
 | `*-analysis-parameters.json` | Free model parameters plus selected sample mode and embedding methods |
 | `*-all-figures.pdf` | All figures combined into a single PDF |
 | `*-cancer-candidates.tsv` | Candidate cancer-type support trace |
@@ -2116,9 +2134,10 @@ def _background_section_config(sample_mode):
         )
     return (
         "Background Tissue Signatures",
-        "These scores summarize which residual non-tumor backgrounds the sample "
-        "resembles after normalization. They are useful context, not literal "
-        "anatomical site calls in mixed samples.\n",
+        "These scores are normalised similarity to reference nTPM profiles "
+        "— they summarize which residual non-tumor backgrounds the sample "
+        "resembles after normalization. Useful context, not literal "
+        "anatomical site calls or composition percentages in mixed samples.\n",
     )
 
 
@@ -2378,9 +2397,8 @@ def _next_best_support_gap(candidate_trace):
 def _generate_text_reports(
     analysis, embedding_meta, prefix, decomp_results=None, input_path=None,
 ):
-    """Write summary and detailed analysis markdown reports."""
+    """Write the detailed ``*-analysis.md`` report."""
     cancer_code = analysis["cancer_type"]
-    cancer_name = analysis["cancer_name"]
     purity = analysis["purity"]
     mhc1 = analysis["mhc1"]
     top_tissues = analysis["tissue_scores"][:5]
@@ -2395,245 +2413,28 @@ def _generate_text_reports(
         sample_mode=sample_mode,
     )
     best_decomp = decomp_results[0] if decomp_results else None
-
-    # --- Summary report ---
-    ambiguity_clause = ""
-    if len(call_summary.get("label_options", [])) == 2:
-        ambiguity_clause = (
-            f" Possible labels: **{call_summary['label_options'][0]}** or "
-            f"**{call_summary['label_options'][1]}**."
-        )
-    hla_a = mhc1.get("HLA-A", 0)
-    hla_b = mhc1.get("HLA-B", 0)
-    b2m = mhc1.get("B2M", 0)
-    mhc_level = "high" if min(hla_a, hla_b, b2m) > 20 else (
-        "low" if max(hla_a, hla_b, b2m) < 5 else "moderate"
-    )
     family_display = family_summary.get("display")
     subtype_clause = family_summary.get("subtype_clause")
-    lead_candidate = candidate_trace[0]["code"] if candidate_trace else None
-    constrained_cancer = constraints.get("cancer_type")
 
-    # Cancer-type call line. Qualitative, not raw composite-score (#32):
-    # show "top match, X× over next-best <CODE>" built from support_norm,
-    # and whether the call was auto-detected vs user-specified (#33).
-    source_label = {
-        "auto-detected": "auto-detected",
-        "user-specified": "user-specified",
-    }.get(analysis.get("cancer_type_source"), "")
-    source_suffix = f" ({source_label})" if source_label else ""
-    next_best_code, support_ratio = _next_best_support_gap(candidate_trace)
-    if family_display:
-        intro = f"The sample most closely matches **{family_display}**"
-        if subtype_clause:
-            if constrained_cancer and lead_candidate and constrained_cancer != lead_candidate:
-                intro += f", with **{cancer_code}** as the constrained working subtype{source_suffix}"
-            else:
-                intro += f", with **{cancer_code}** as the current best subtype hypothesis{source_suffix}"
-        intro += ". "
-    else:
-        intro = (
-            f"The sample most closely matches **{cancer_name} ({cancer_code})**"
-            f"{source_suffix}. "
-        )
-    if next_best_code and support_ratio is not None and support_ratio > 1.0:
-        intro += (
-            f"Support is **{support_ratio:.1f}× over next-best {next_best_code}**. "
-        )
-    if fit_quality.get("label") and fit_quality.get("message"):
-        intro += f"Fit quality: *{fit_quality['label']}* — {fit_quality['message']} "
-
-    # Report flow (user direction 2026-04-14):
-    #   1. What data do we have + sample QC (this block)
-    #   2. What kind of cancer (the intro above, written before this)
-    #   3. What else is in the sample (purity + TME + tissues)
-    #   4. Deeper detail (analysis.md, targets.md, figures)
-    #
-    # Build ordering below assembles the summary string in that flow —
-    # *not* in the order variables were defined — so the narrative
-    # starts with QC and ends with ambiguity / constraints.
-
-    # Disease-state synthesis (#78): one-line narrative up top.
+    # Disease-state synthesis (#78) — still used by analysis.md.
     disease_state_paragraph = compose_disease_state_narrative(analysis)
 
-    # Step 1: input & sample-QC framing.
-    sample_context = analysis.get("sample_context")
-    context_paragraph = ""
-    if sample_context is not None:
-        ctx_signals = sample_context.signals or {}
-        context_line = f"**Sample context**: {sample_context.summary_line()}."
-        n_det_1 = ctx_signals.get("genes_detected_above_1_tpm")
-        if n_det_1 is not None:
-            context_line += f" {n_det_1} genes at TPM > 1"
-            top50 = ctx_signals.get("top_50_share_of_total_tpm")
-            if top50 is not None:
-                context_line += f"; top-50 share {top50:.0%} of total"
-            context_line += "."
-        if ctx_signals.get("likely_targeted_panel"):
-            context_line += " ⚠ Input looks like a targeted panel rather than whole-transcriptome."
-        if sample_context.missing_mt and getattr(sample_context, "library_prep", None) not in _MT_EXPECTED_MISSING_PREPS:
-            # #77: suppress the MT caveat when the inferred library
-            # prep already explains the absence — avoids double-counting.
-            context_line += " ⚠ MT genes missing from quant — degradation signal unreliable."
-        context_paragraph = context_line
-
-    # Quality flags land right after sample_context in the QC block.
-    quality = analysis.get("quality")
-    quality_paragraph = ""
-    if quality and quality.get("has_issues"):
-        # Prefer the SampleContext-filtered flag list (#77) so the MT
-        # warning doesn't double-count an exome-capture library prep
-        # we already explained.
-        flags_to_show = quality.get("filtered_flags", quality["flags"])
-        # Only emit a "Quality warnings" paragraph when real issues
-        # remain after filtering — otherwise skip entirely.
-        if flags_to_show and any(not f.startswith("MT fraction near zero") for f in flags_to_show):
-            quality_paragraph = "**Quality warnings**: " + "; ".join(flags_to_show) + "."
-    elif quality and quality["degradation"]["level"] != "normal":
-        flags_to_show = quality.get("filtered_flags", quality["flags"])
-        if flags_to_show:
-            quality_paragraph = "**Quality note**: " + "; ".join(flags_to_show) + "."
-
-    # Step 2: headline call (already built above as `intro`).
-    headline = intro
-
-    # Step 3: what else is in the sample — purity clause + background
-    # tissues (from _summary_mode_clause), MHC-I level, analysis mode.
-    composition = (
-        _summary_mode_clause(sample_mode, purity, top_tissues)
-        + f"MHC-I expression is {mhc_level} "
-        + f"(HLA-A={hla_a:.0f}, HLA-B={hla_b:.0f}, B2M={b2m:.0f} TPM). "
-        + f"Analysis mode: **{_sample_mode_display(sample_mode)}**."
-    )
-    if purity.get("components", {}).get("integration", {}).get("signature_deprioritized"):
-        composition += (
-            " The tumor-specific signature panel was materially weaker and less stable than "
-            "the lineage panel, so it was downweighted rather than used as a hard lower anchor."
-        )
-
-    # Therapy-response state (#57): surface any axis that is clearly
-    # up or down vs cohort so the reader sees *why* individual genes
-    # might be off-baseline — ADT suppression of AR-transactivated
-    # genes, endocrine resistance, etc.
-    therapy_scores = analysis.get("therapy_response_scores") or {}
-    therapy_paragraph = ""
-    active_states = [
-        (cls, s) for cls, s in therapy_scores.items()
-        if s.state in ("up", "down")
-    ]
-    if active_states:
-        lines_ts = ["**Therapy-response state**:"]
-        for cls, s in active_states:
-            verb = "active" if s.state == "up" else "suppressed"
-            fold_phrase = ""
-            if s.up_geomean_fold is not None:
-                fold_phrase = f" (up-panel {s.up_geomean_fold:.2f}× cohort"
-                if s.down_geomean_fold is not None:
-                    fold_phrase += f", down-panel {s.down_geomean_fold:.2f}×"
-                fold_phrase += ")"
-            lines_ts.append(
-                f"  - {cls.replace('_', ' ')}: {verb}{fold_phrase}"
-            )
-        therapy_paragraph = "\n".join(lines_ts)
-
-    # Step 4: constraints / decomposition detail / ambiguity.
-    detail_parts = []
-    if therapy_paragraph:
-        detail_parts.append(therapy_paragraph)
-    if constraints:
-        constraint_parts = []
-        if constraints.get("cancer_type"):
-            constraint_parts.append(f"cancer type fixed to **{constraints['cancer_type']}**")
-        if constraints.get("tumor_context"):
-            constraint_parts.append(
-                f"template context restricted to **{constraints['tumor_context']}**"
-            )
-        if constraints.get("site_hint"):
-            constraint_parts.append(f"site hint **{constraints['site_hint']}**")
-        if constraints.get("decomposition_templates"):
-            constraint_parts.append(
-                "template list fixed to **"
-                + ", ".join(constraints["decomposition_templates"])
-                + "**"
-            )
-        if constraints.get("met_site"):
-            constraint_parts.append(
-                f"biopsy site **{constraints['met_site']}** (TME reference augmented)"
-            )
-        if constraint_parts:
-            detail_parts.append("Analysis constraints: " + "; ".join(constraint_parts) + ".")
-    # Only surface the decomposition line when its call materially differs
-    # from the headline call (#33: the tumor fraction % is identical to the
-    # already-stated purity, so repeating it is noise).
-    if call_summary.get("site_indeterminate"):
-        detail_parts.append(
-            "Decomposition recovered broad admixture structure, but "
-            "site/template assignment is indeterminate."
-        )
-    elif best_decomp is not None:
-        decomp_piece = (
-            f"Decomposition template: **{best_decomp.cancer_type} / {best_decomp.template}**"
-        )
-        if (
-            getattr(best_decomp, "cancer_type", None)
-            and best_decomp.cancer_type != cancer_code
-        ):
-            decomp_piece += " (differs from headline call)"
-        detail_parts.append(decomp_piece + ".")
-    if ambiguity_clause.strip():
-        detail_parts.append(ambiguity_clause.strip())
-    # Tissue-score caveat (#33): readers were interpreting similarity
-    # scores as composition percentages. One short line clarifies.
-    if top_tissues:
-        detail_parts.append(
-            "*Note: background tissue scores are normalised similarity "
-            "to reference nTPM profiles, not composition percentages.*"
-        )
-
-    # Assemble in the user-requested order: disease-state synthesis
-    # (#78) → QC → coarse call → detail. The synthesis line lands
-    # *before* the QC block so a reader immediately sees the clinical
-    # framing ("ADT-treated CRPC with emerging NEPC") before
-    # descending into sequencing QC or the raw cancer-type number.
-    sections = []
-    if disease_state_paragraph:
-        sections.append(f"**Disease state**: {disease_state_paragraph}")
-    qc_block = "\n\n".join([b for b in (context_paragraph, quality_paragraph) if b])
-    if qc_block:
-        sections.append(qc_block)
-    sections.append(headline + composition)
-    if detail_parts:
-        sections.append("\n\n".join(detail_parts))
-    summary = "\n\n".join(sections)
-
-    summary_path = "%s-summary.md" % prefix if prefix else "summary.md"
-    header = "# Sample Analysis Summary\n"
-    if input_path:
-        header += f"\n*Input*: `{input_path}`\n"
-    # #149: Prepend the Step-0 tissue-composition + cancer-hint
-    # reading so a reader sees the coarse "what kind of tissue is
-    # this and is there any hint of cancer" context before the
-    # downstream cancer-type call. Propagated forward from analyze().
-    hvt = analysis.get("healthy_vs_tumor")
-    step0_section = ""
-    if hvt is not None and hvt.top_normal_tissues:
-        trace_clause = (
-            f" *Rule: {' → '.join(hvt.reasoning_trace)}.*"
-            if hvt.reasoning_trace else ""
-        )
-        step0_section = (
-            f"\n**Step-0 tissue composition**: "
-            f"{hvt.summary_line()}{trace_clause}\n"
-        )
-    with open(summary_path, "w") as f:
-        f.write(f"{header}{step0_section}\n{summary}\n")
-    print(f"[report] Saved {summary_path}")
+    # The old free-form ``*-summary.md`` paragraph (disease-state +
+    # QC + headline + composition + therapy-response state) was
+    # retired in 4.41.0 — every block already lived in analysis.md.
+    # The name ``summary.md`` now carries what used to be
+    # ``brief.md`` (the 1-page clinician file).
 
     # --- Detailed report ---
     lines = ["# Detailed Sample Analysis\n"]
+    if input_path:
+        # Input path at the top so the file is self-identifying even
+        # without sample_context downstream. Propagated from
+        # ``analyze()`` along with the rest of the analysis dict.
+        lines.append(f"*Input*: `{input_path}`\n")
 
-    # Disease-state synthesis (#78) — matches the summary.md top line
-    # so readers arriving from either report see the same framing.
+    # Disease-state synthesis (#78) — rendered at the top so a reader
+    # sees the clinical framing before descending into pipeline detail.
     if disease_state_paragraph:
         lines.append(f"**Disease state**: {disease_state_paragraph}\n")
 
@@ -2791,6 +2592,14 @@ def _generate_text_reports(
     # Cancer type identification
     lines.append("## Cancer Type Identification\n")
     lines.append(f"- **Sample mode**: {_sample_mode_display(sample_mode)}")
+    # #33 source attribution — show whether the call was auto-detected
+    # or user-specified. Used to live only in the retired summary.md.
+    source_label = {
+        "auto-detected": "auto-detected",
+        "user-specified": "user-specified",
+    }.get(analysis.get("cancer_type_source"))
+    if source_label:
+        lines.append(f"- **Call source**: {source_label}")
     if fit_quality.get("label"):
         lines.append(f"- **Fit quality**: {fit_quality['label']}")
     if fit_quality.get("message"):

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -223,7 +223,7 @@ def build_provenance_md(
         )
     lines.append("")
     lines.append(
-        "*See also: `*-brief.md`, `*-actionable.md`, `*-summary.md`, "
+        "*See also: `*-summary.md`, `*-actionable.md`, "
         "`*-analysis.md`, `*-targets.md`.*"
     )
     return "\n".join(lines)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.40.1"
+__version__ = "4.41.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -89,7 +89,8 @@ def test_brief_is_compact():
     assert len(lines) <= 40, f"brief is {len(lines)} lines, must be ≤ 40:\n{md}"
 
     # Key structural elements present.
-    assert "# Brief" in md
+    # File was renamed brief → summary in 4.41.0; header tracks the name.
+    assert "# Summary" in md
     assert "**Cancer call:**" in md
     assert "**Purity:**" in md
     assert "**Disease state:**" in md
@@ -162,7 +163,12 @@ def test_actionable_is_longer_but_structured():
     # Actionable should be > 15 lines (more detail than the brief).
     assert len(md.splitlines()) > 15
 
-    # Key section headings.
+    # Biomarker panel moved to targets.md in 4.41.0 to avoid a
+    # duplicated table. Actionable still carries the three core
+    # headings + links to targets.md as the panel source.
     for heading in ["Sample and confidence", "Cancer call and disease state",
-                    "Therapy landscape", "Biomarker panel"]:
+                    "Therapy landscape"]:
         assert heading in md, f"missing heading: {heading}"
+    assert "*-targets.md*" in md or "`*-targets.md`" in md, (
+        "actionable should link to targets.md as the biomarker-panel source"
+    )

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -311,12 +311,13 @@ def test_generate_text_reports_uses_family_and_background_language(tmp_path):
 
     cli_mod._generate_text_reports(analysis, embedding_meta, prefix, decomp_results=[])
 
-    summary = (tmp_path / "sample-summary.md").read_text()
+    # The old free-form summary.md that carried family-call phrasing
+    # (CRC-family, Possible labels, subtype-candidates clause) was
+    # retired in 4.41.0 as ~80% redundant with analysis.md. The
+    # content below is now only checked in analysis.md.
     detailed = (tmp_path / "sample-analysis.md").read_text()
-    assert "CRC-family (COAD > READ)" in summary
-    assert "not literal site calls" in summary
-    assert "Top subtype candidates remain close" in summary
-    assert "Possible labels: **COAD** or **READ**." in summary
+    assert "not literal" in detailed  # tissue-score caveat
+    assert "Possible labels" in detailed
     assert "Family-level call" in detailed
     assert "Fit quality" in detailed
     assert "Top broad possibilities" in detailed
@@ -358,9 +359,10 @@ def test_generate_text_reports_is_mode_aware_for_heme(tmp_path):
 
     cli_mod._generate_text_reports(analysis, embedding_meta, prefix, decomp_results=[])
 
-    summary = (tmp_path / "heme-summary.md").read_text()
+    # Heme-mode "malignant-lineage fraction proxy" phrasing lived in
+    # the retired summary.md paragraph; analysis.md still carries the
+    # mode-aware "not a strict tumor-vs-immune split" caveat.
     detailed = (tmp_path / "heme-analysis.md").read_text()
-    assert "malignant-lineage fraction proxy" in summary
     assert "not a strict tumor-vs-immune split" in detailed
     assert "Lineage / Background Context" in detailed
 
@@ -443,10 +445,10 @@ def test_generate_text_reports_handles_missing_lineage_summary(tmp_path):
 
     cli_mod._generate_text_reports(analysis, embedding_meta, prefix, decomp_results=[])
 
-    summary = (tmp_path / "sarcoma-like-summary.md").read_text()
+    # "broad family interpretation is more trustworthy" + "site/template
+    # assignment is indeterminate" lived in the retired summary.md
+    # paragraph. Analysis.md still carries the Reliable cluster signal.
     detailed = (tmp_path / "sarcoma-like-analysis.md").read_text()
-    assert "broad family interpretation is more trustworthy" in summary
-    assert "site/template assignment is indeterminate" in summary
     assert "**Reliable cluster**: COL3A1, DCN." in detailed
     assert "Reported site/template call: **indeterminate**." in detailed
 
@@ -576,10 +578,11 @@ def test_generate_text_reports_mentions_analysis_constraints(tmp_path):
 
     cli_mod._generate_text_reports(analysis, embedding_meta, prefix, decomp_results=[])
 
-    summary = (tmp_path / "constrained-summary.md").read_text()
+    # "constrained working subtype" + the one-line "Analysis constraints"
+    # recap lived in the retired summary.md paragraph. Analysis.md
+    # surfaces the constraint set in its own User-constrained /
+    # Requested-context lines.
     detailed = (tmp_path / "constrained-analysis.md").read_text()
-    assert "constrained working subtype" in summary
-    assert "Analysis constraints: cancer type fixed to **SARC**; template context restricted to **primary**." in summary
     assert "User-constrained cancer type" in detailed
     assert "Requested tumor context" in detailed
 

--- a/tests/test_report_clarity_and_met_site.py
+++ b/tests/test_report_clarity_and_met_site.py
@@ -168,35 +168,38 @@ def test_summary_md_structure_for_report_clarity(tmp_path):
     }
 
     prefix = str(tmp_path / "sample")
-    # Minimal embedding_meta shape — summary.md is written first, before
-    # the more demanding analysis.md fields are consulted.
     embedding_meta = {
         "method": "hierarchy", "feature_kind": "hierarchical_scores",
         "n_genes": 0, "n_features": 0, "n_types": 33, "families": [],
     }
-    try:
-        _generate_text_reports(
-            analysis, embedding_meta, prefix,
-            decomp_results=[], input_path="/data/sample_BG002.tsv",
-        )
-    except KeyError:
-        # analysis.md generation may need more context than this fixture
-        # provides — we only assert on summary.md below.
-        pass
-
-    summary_md = (tmp_path / "sample-summary.md").read_text()
-    # Input filename header (#33)
-    assert "/data/sample_BG002.tsv" in summary_md
-    # Source attribution (#33)
-    assert "auto-detected" in summary_md
-    # Raw composite score 0.019 should NOT appear in prose (#32).
-    assert "0.019" not in summary_md, (
-        "Raw composite cancer_score must not be in summary prose (#32)."
+    _generate_text_reports(
+        analysis, embedding_meta, prefix,
+        decomp_results=[], input_path="/data/sample_BG002.tsv",
     )
-    # Qualitative ratio instead (#32) — top match is 2.5× HNSC.
-    assert "2.5" in summary_md and "HNSC" in summary_md
-    # Tissue score caveat (#33)
-    assert "similarity" in summary_md.lower()
+
+    # The retired free-form summary.md used to carry input-filename
+    # header, source attribution, and the "2.5× HNSC" / "similarity"
+    # clauses. Analysis.md now owns the input-filename + candidate
+    # trace; the "similarity" tissue-score caveat lives in analysis.md
+    # too. No try/except guard — if _generate_text_reports KeyErrors on
+    # a minimal fixture that's a real test signal, not something to
+    # swallow.
+    analysis_md_path = tmp_path / "sample-analysis.md"
+    assert analysis_md_path.exists(), (
+        "_generate_text_reports must write analysis.md; missing file "
+        "points at a test-fixture bug, not an expected branch"
+    )
+    analysis_md = analysis_md_path.read_text()
+    # Input filename header — now under "## Input characterization".
+    assert "/data/sample_BG002.tsv" in analysis_md
+    # Source attribution (#33) — moved from summary.md to analysis.md.
+    assert "auto-detected" in analysis_md
+    # Raw composite score 0.019 must not appear in prose (#32).
+    assert "0.019" not in analysis_md, (
+        "Raw composite cancer_score must not be in report prose (#32)."
+    )
+    # Tissue-score caveat (#33).
+    assert "similarity" in analysis_md.lower()
 
 
 def test_detailed_report_uses_generic_lineage_caveat(tmp_path):


### PR DESCRIPTION
## Summary

The output set had ~80% redundancy between ``summary.md`` and ``brief`` / ``actionable`` — the one-paragraph summary re-stated disease-state, step-0, and therapy-response blocks that every other report already carried. Retire it; promote brief → summary; relocate the biomarker-panel table to a single home.

## Changes

- ``brief.md`` → ``summary.md``: the 1-page clinician-facing file now uses the name readers expect. Header reads *"# Summary"*.
- Retire the old free-form ``summary.md`` paragraph. Every block it carried already lived in ``analysis.md``.
- Input path renders at the top of ``analysis.md`` too so the file stays self-identifying even without ``sample_context``.
- Background-tissue section absorbs the old "normalised similarity" caveat.
- Drop the technical rule-trace line (``*Rule: aggregate-tumor-evidence[...]*``) that only lived in summary.md.
- Biomarker panel moved out of ``actionable.md``: kept solely in ``targets.md`` and linked via the actionable's see-also footer. Eliminates the duplicated table.

## Result

5 markdown files after this PR (was 6):

| File | Purpose |
|---|---|
| ``summary.md`` | 1-page clinician summary (cancer call, purity, top therapies) |
| ``actionable.md`` | Oncologist treatment-review table |
| ``analysis.md`` | Deep-dive (input path, disease state, step-0, candidate trace, purity, decomposition, tissues) |
| ``targets.md`` | Biomarker panel + full therapy-target landscape |
| ``provenance.md`` | Attribution chain |

## Test plan

- [x] Full suite — 650 passed, 1 skipped
- [x] 7 tests that asserted on retired ``summary.md`` content redirected to ``analysis.md`` or retired (content lives there now)
- [x] Sanity-run on a real sample: ``summary.md`` renders the 1-page content, ``actionable.md`` shows treatment table + see-also to ``targets.md``, no duplicated biomarker panel
- [x] ``ruff check`` clean

## Version
Bump to 4.41.0 (minor — removed markdown output + renamed file).