### PR TITLE
feat(decomp): extended TME refinement — exhausted-T / tumor-EC / MDSC / TLS-B / TI-plasma (closes #58)

### DIFF
--- a/pirlygenes/decomposition/subtype_refs.py
+++ b/pirlygenes/decomposition/subtype_refs.py
@@ -97,6 +97,109 @@ TAM_MARKER_FOLDS: Dict[str, float] = {
 }
 
 
+# ---------- Extended TME activated-state panels (#58) ----------
+
+# These compartments live alongside CAF / TAM in the same refinement
+# mechanism. Each panel targets a template compartment where the HPA
+# generic reference under-represents the tumor-activated state.
+
+
+# Exhausted / tumor-infiltrating T cells. Zheng 2021 pan-cancer TIL
+# atlas; Oliveira 2021 TCR/T-cell atlas. Checkpoint-receptor biology —
+# these are the genes ICI (anti-PD-1 / CTLA4 / LAG3) targets, and
+# their over-attribution to tumor is a major UX failure on any
+# lymphocyte-rich sample.
+EXHAUSTED_T_MARKER_FOLDS: Dict[str, float] = {
+    "PDCD1": 8.0,      # PD-1 — canonical exhaustion marker
+    "CTLA4": 6.0,      # CTLA-4 — checkpoint
+    "LAG3": 6.0,       # LAG-3 — co-expressed with PD-1
+    "HAVCR2": 6.0,     # TIM-3
+    "TIGIT": 5.0,      # TIGIT checkpoint
+    "TOX": 5.0,        # Exhaustion transcription factor
+    "ENTPD1": 4.0,     # CD39 — tissue-resident exhausted Treg
+    "ITGAE": 4.0,      # CD103 — Trm / TIL marker
+    "LAYN": 4.0,       # Layilin — terminal exhaustion
+    "CXCL13": 5.0,     # Follicular / TLS-T cell chemokine
+}
+
+
+# Tumor endothelium — angiogenic / tip-cell / venule programs elevated
+# in solid tumors. Goveia 2020 pan-cancer lung EC atlas; Kalucka 2020
+# pan-tissue EC atlas. Anti-angiogenic ADC / TKI biology.
+TUMOR_ENDOTHELIUM_MARKER_FOLDS: Dict[str, float] = {
+    "DLL4": 8.0,       # Notch ligand — tip-cell / angiogenic EC
+    "ESM1": 7.0,       # Endocan — tip-cell marker
+    "ANGPT2": 6.0,     # Angiogenic signaling
+    "PLVAP": 5.0,      # Fenestrated tumor venule
+    "ACKR1": 4.0,      # Post-capillary venule (Duffy)
+    "APLN": 5.0,       # Apelin — tumor-EC-specific ligand
+    "CXCR4": 4.0,      # Tip-cell migration
+    "INSR": 3.0,       # Metabolic tumor-EC program
+    "KDR": 4.0,        # VEGFR2 — angiogenic
+    "FLT1": 4.0,       # VEGFR1 — angiogenic
+}
+
+
+# Myeloid-derived suppressor cells — distinct from TAM by lineage
+# (granulocytic / monocytic MDSC). Alshetaiwi 2020 MDSC atlas;
+# Zilionis 2019 lung TAN/TAM atlas. Lives on the same ``myeloid``
+# compartment as TAM; genes don't overlap meaningfully.
+MDSC_MARKER_FOLDS: Dict[str, float] = {
+    "ARG1": 8.0,       # Arginase-1 — immunosuppressive; PMN-MDSC
+    "S100A8": 5.0,     # Calprotectin subunit — MDSC / neutrophil
+    "S100A9": 5.0,     # Calprotectin subunit
+    "CEBPB": 3.0,      # Transcription factor — MDSC polarization
+    "FCGR3B": 4.0,     # CD16b — granulocytic MDSC / neutrophil
+    "MPO": 4.0,        # Myeloperoxidase — neutrophil lineage
+    "ELANE": 4.0,      # Neutrophil elastase
+    "CAMP": 4.0,       # Cathelicidin — neutrophil
+}
+
+
+# Tertiary lymphoid structure B cells — germinal-center B cells
+# organised into ectopic lymphoid follicles in the tumor. Meylan 2022
+# RCC TLS; Patil 2022 pan-cancer TLS atlas. Positive ICI prognostic.
+TLS_B_MARKER_FOLDS: Dict[str, float] = {
+    "CXCR5": 5.0,      # Germinal-center homing
+    "BCL6": 4.0,       # Germinal-center master TF
+    "AICDA": 6.0,      # Activation-induced deaminase — class-switch
+    "MS4A1": 3.0,      # CD20 — B-cell identity (scaled for TLS density)
+    "RGS13": 4.0,      # GC-B signature
+    "STMN1": 3.0,      # Proliferative GC-B
+}
+
+
+# Tumor-infiltrating plasma cells. Cheng 2021 pan-cancer B/plasma
+# atlas. IgG class-switched patterns distinct from marrow plasma.
+TI_PLASMA_MARKER_FOLDS: Dict[str, float] = {
+    "MZB1": 4.0,       # Plasma cell maturation — elevated in TI plasma
+    "JCHAIN": 3.0,     # Polymeric Ig joining chain
+    "IGHG1": 5.0,      # IgG1 heavy chain (class-switched)
+    "IGHG3": 4.0,      # IgG3 heavy chain
+    "IGHA1": 4.0,      # IgA1 heavy chain
+    "XBP1": 3.0,       # Plasma-cell UPR / ER stress
+}
+
+
+# ---------- Panel registry ----------
+
+# Each row: (label, NNLS-compartment-name, marker-fold dict). Order
+# matters for provenance (first panel whose compartment has signal on
+# a gene wins), but canonical markers do not overlap across panels —
+# a TAM-marker like CD163 doesn't appear in MDSC or exhausted-T.
+# Add a new compartment by appending a row here + its ``_MARKER_FOLDS``
+# dict above; no other code needs to change.
+PANELS: List[Tuple[str, str, Dict[str, float]]] = [
+    ("CAF", "fibroblast", CAF_MARKER_FOLDS),
+    ("TAM", "myeloid", TAM_MARKER_FOLDS),
+    ("MDSC", "myeloid", MDSC_MARKER_FOLDS),
+    ("exhausted_T", "T_cell", EXHAUSTED_T_MARKER_FOLDS),
+    ("tumor_endothelium", "endothelial", TUMOR_ENDOTHELIUM_MARKER_FOLDS),
+    ("TLS_B", "B_cell", TLS_B_MARKER_FOLDS),
+    ("TI_plasma", "plasma", TI_PLASMA_MARKER_FOLDS),
+]
+
+
 def caf_markers() -> List[str]:
     """Return the canonical CAF marker-gene list (#56)."""
     return list(CAF_MARKER_FOLDS.keys())
@@ -105,6 +208,19 @@ def caf_markers() -> List[str]:
 def tam_markers() -> List[str]:
     """Return the canonical TAM marker-gene list (#56)."""
     return list(TAM_MARKER_FOLDS.keys())
+
+
+def panel_markers(label: str) -> List[str]:
+    """Return the marker-gene list for any registered panel (#58)."""
+    for panel_label, _compartment, folds in PANELS:
+        if panel_label == label:
+            return list(folds.keys())
+    return []
+
+
+def panel_labels() -> List[str]:
+    """List every registered panel label (#58)."""
+    return [label for label, _comp, _folds in PANELS]
 
 
 def refine_tme_per_gene(
@@ -157,13 +273,17 @@ def refine_tme_per_gene(
     # the fields this module populates, via ``.get(name)`` on dicts.
     provenance: Dict[str, Dict[str, Any]] = {}
 
-    panels = (
-        ("CAF", "fibroblast", CAF_MARKER_FOLDS),
-        ("TAM", "myeloid", TAM_MARKER_FOLDS),
-    )
-    for subtype_label, compartment, marker_folds in panels:
+    # Iterate every registered panel (#58). Canonical markers don't
+    # overlap across panels, but if a gene IS shared, first-match-wins
+    # by registration order.
+    for subtype_label, compartment, marker_folds in PANELS:
         for gene, fold in marker_folds.items():
             if gene not in refined:
+                continue
+            if gene in provenance:
+                # First panel to refine this gene wins — keeps the
+                # provenance single-source and avoids compounding folds
+                # on genes that appear on multiple panels.
                 continue
             tme_before = float(refined[gene])
             observed = float(sample_tpm_by_symbol.get(gene, 0.0))

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.42.0"
+__version__ = "4.43.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_58_extended_tme.py
+++ b/tests/test_issue_58_extended_tme.py
@@ -1,0 +1,218 @@
+"""Regression tests for #58 — extended TME refinement beyond CAF / TAM.
+
+Same mechanism as #56 (``refine_tme_per_gene``), but adds panels for:
+
+- exhausted / tumor-infiltrating T cells (PDCD1, CTLA4, LAG3, …)
+- tumor endothelium / tip cells (DLL4, ESM1, ANGPT2, …)
+- myeloid-derived suppressor cells (ARG1, S100A8/9, …)
+- TLS-B germinal-center B cells (CXCR5, BCL6, AICDA, …)
+- tumor-infiltrating plasma (MZB1, IGHG1, …)
+
+The panels land on the ``T_cell`` / ``endothelial`` / ``myeloid`` /
+``B_cell`` / ``plasma`` compartments respectively — all of which are
+in the standard ``solid_primary`` template.
+"""
+
+from pirlygenes.decomposition.subtype_refs import (
+    EXHAUSTED_T_MARKER_FOLDS,
+    MDSC_MARKER_FOLDS,
+    PANELS,
+    TI_PLASMA_MARKER_FOLDS,
+    TLS_B_MARKER_FOLDS,
+    TUMOR_ENDOTHELIUM_MARKER_FOLDS,
+    panel_labels,
+    panel_markers,
+    refine_tme_per_gene,
+)
+
+
+# ── Panel registry ────────────────────────────────────────────────────
+
+
+def test_panel_registry_covers_all_expected_labels():
+    labels = set(panel_labels())
+    expected = {
+        "CAF", "TAM", "MDSC",
+        "exhausted_T", "tumor_endothelium",
+        "TLS_B", "TI_plasma",
+    }
+    missing = expected - labels
+    assert not missing, f"missing panels: {missing}"
+
+
+def test_panel_registry_compartments_are_from_solid_primary_template():
+    """Every panel must target a compartment the NNLS decomposition
+    actually fits. Otherwise refinement never has anything to act on."""
+    from pirlygenes.decomposition.templates import TEMPLATES
+
+    solid_primary_compartments = set(
+        TEMPLATES["solid_primary"]["components"]
+    )
+    for label, compartment, _folds in PANELS:
+        assert compartment in solid_primary_compartments, (
+            f"{label} targets ``{compartment}`` but that compartment "
+            f"is not in solid_primary template "
+            f"({sorted(solid_primary_compartments)})"
+        )
+
+
+def test_panel_folds_are_strictly_greater_than_one():
+    """A fold of 1.0 means no refinement — every entry in every panel
+    must have a meaningful elevation over baseline."""
+    for label, _comp, folds in PANELS:
+        for gene, fold in folds.items():
+            assert fold > 1.0, f"{label}/{gene} fold = {fold}"
+
+
+# ── Exhausted T / checkpoint markers ──────────────────────────────────
+
+
+def test_exhausted_t_panel_has_canonical_checkpoint_markers():
+    panel = set(EXHAUSTED_T_MARKER_FOLDS.keys())
+    for gene in ("PDCD1", "CTLA4", "LAG3", "HAVCR2", "TIGIT"):
+        assert gene in panel, f"exhausted-T panel missing {gene}"
+
+
+def test_exhausted_t_refinement_fires_on_T_cell_compartment():
+    """A sample with PDCD1 expression + T_cell NNLS contribution must
+    get refined; the provenance label is ``exhausted_T``."""
+    tme_bg = {"PDCD1": 12.0}
+    per_comp = {"PDCD1": {"T_cell": 8.0}}
+    sample = {"PDCD1": 90.0}
+    refined, prov = refine_tme_per_gene(tme_bg, per_comp, sample)
+    assert refined["PDCD1"] > tme_bg["PDCD1"]
+    assert prov["PDCD1"]["subtype"] == "exhausted_T"
+
+
+def test_exhausted_t_refinement_no_op_on_wrong_compartment():
+    """Same PDCD1 expression but NNLS put the signal on fibroblast —
+    exhausted-T refinement targets T_cell, must no-op."""
+    tme_bg = {"PDCD1": 12.0}
+    per_comp = {"PDCD1": {"fibroblast": 8.0}}
+    sample = {"PDCD1": 90.0}
+    refined, prov = refine_tme_per_gene(tme_bg, per_comp, sample)
+    assert refined["PDCD1"] == 12.0
+    assert "PDCD1" not in prov
+
+
+# ── Tumor endothelium ──────────────────────────────────────────────────
+
+
+def test_tumor_endothelium_panel_has_angiogenic_markers():
+    panel = set(TUMOR_ENDOTHELIUM_MARKER_FOLDS.keys())
+    for gene in ("DLL4", "ESM1", "ANGPT2", "PLVAP"):
+        assert gene in panel
+
+
+def test_tumor_endothelium_refinement_on_endothelial_compartment():
+    tme_bg = {"DLL4": 18.0}
+    per_comp = {"DLL4": {"endothelial": 12.0}}
+    sample = {"DLL4": 140.0}
+    refined, prov = refine_tme_per_gene(tme_bg, per_comp, sample)
+    assert refined["DLL4"] > tme_bg["DLL4"]
+    assert prov["DLL4"]["subtype"] == "tumor_endothelium"
+
+
+# ── MDSC (shares myeloid compartment with TAM) ─────────────────────────
+
+
+def test_mdsc_panel_has_canonical_markers():
+    panel = set(MDSC_MARKER_FOLDS.keys())
+    for gene in ("ARG1", "S100A8", "S100A9", "MPO"):
+        assert gene in panel
+
+
+def test_mdsc_and_tam_do_not_share_markers():
+    """A MDSC marker appearing in the TAM panel would compound refinements
+    via the first-match-wins rule. Canonical markers don't overlap —
+    pin that."""
+    mdsc = set(MDSC_MARKER_FOLDS.keys())
+    from pirlygenes.decomposition.subtype_refs import TAM_MARKER_FOLDS
+    tam = set(TAM_MARKER_FOLDS.keys())
+    assert not (mdsc & tam), (
+        f"MDSC and TAM share markers: {mdsc & tam} — compounded refinement"
+    )
+
+
+def test_mdsc_refinement_on_myeloid_compartment():
+    tme_bg = {"ARG1": 10.0}
+    per_comp = {"ARG1": {"myeloid": 6.0}}
+    sample = {"ARG1": 75.0}
+    refined, prov = refine_tme_per_gene(tme_bg, per_comp, sample)
+    assert refined["ARG1"] > tme_bg["ARG1"]
+    assert prov["ARG1"]["subtype"] == "MDSC"
+
+
+# ── TLS B / TI plasma ──────────────────────────────────────────────────
+
+
+def test_tls_b_panel_has_germinal_center_markers():
+    panel = set(TLS_B_MARKER_FOLDS.keys())
+    for gene in ("CXCR5", "BCL6", "AICDA"):
+        assert gene in panel
+
+
+def test_tls_b_refinement_on_B_cell_compartment():
+    tme_bg = {"AICDA": 6.0}
+    per_comp = {"AICDA": {"B_cell": 4.0}}
+    sample = {"AICDA": 55.0}
+    refined, prov = refine_tme_per_gene(tme_bg, per_comp, sample)
+    assert refined["AICDA"] > tme_bg["AICDA"]
+    assert prov["AICDA"]["subtype"] == "TLS_B"
+
+
+def test_ti_plasma_panel_has_class_switch_markers():
+    panel = set(TI_PLASMA_MARKER_FOLDS.keys())
+    for gene in ("MZB1", "IGHG1", "JCHAIN"):
+        assert gene in panel
+
+
+def test_ti_plasma_refinement_on_plasma_compartment():
+    tme_bg = {"IGHG1": 25.0}
+    per_comp = {"IGHG1": {"plasma": 18.0}}
+    sample = {"IGHG1": 180.0}
+    refined, prov = refine_tme_per_gene(tme_bg, per_comp, sample)
+    assert refined["IGHG1"] > tme_bg["IGHG1"]
+    assert prov["IGHG1"]["subtype"] == "TI_plasma"
+
+
+# ── First-match-wins: a gene on two panels doesn't double-refine ──────
+
+
+def test_first_match_wins_on_shared_gene(monkeypatch):
+    """A gene that ends up on two panels (shouldn't happen with the
+    canonical markers, but pin the contract) must refine exactly once,
+    labeled by the first panel in PANELS order."""
+    from pirlygenes.decomposition import subtype_refs as sr
+
+    # Inject a test-only panel that would duplicate PDCD1's CAF-side
+    # refinement. PANELS is iterated in order; the existing
+    # ``exhausted_T`` panel is the canonical home for PDCD1 so it
+    # should win.
+    original = list(sr.PANELS)
+    try:
+        sr.PANELS = original + [
+            ("FAKE_LAST", "fibroblast", {"PDCD1": 99.0}),
+        ]
+        tme_bg = {"PDCD1": 10.0}
+        per_comp = {"PDCD1": {"T_cell": 5.0, "fibroblast": 5.0}}
+        sample = {"PDCD1": 100.0}
+        refined, prov = sr.refine_tme_per_gene(tme_bg, per_comp, sample)
+        # First-match-wins: exhausted_T refines PDCD1 before the fake
+        # panel can run.
+        assert prov["PDCD1"]["subtype"] == "exhausted_T"
+    finally:
+        sr.PANELS = original
+
+
+# ── panel_markers / panel_labels public API ───────────────────────────
+
+
+def test_panel_markers_returns_marker_list_for_known_label():
+    t_markers = panel_markers("exhausted_T")
+    assert "PDCD1" in t_markers
+    assert "CTLA4" in t_markers
+
+
+def test_panel_markers_returns_empty_for_unknown_label():
+    assert panel_markers("NOT_A_REAL_PANEL") == []


### PR DESCRIPTION
## Summary

Five new activated-state compartment panels using the ``refine_tme_per_gene`` infrastructure landed in #184 (closes #56). Same mechanism: per-gene post-hoc reference swap on canonical markers, NNLS untouched.

## Compartments added

| Panel | NNLS compartment | Canonical markers | Clinical biology |
|---|---|---|---|
| ``exhausted_T`` | ``T_cell`` | PDCD1, CTLA4, LAG3, HAVCR2, TIGIT, TOX, ENTPD1, ITGAE, LAYN, CXCL13 | Checkpoint receptors — anti-PD-1 / anti-CTLA4 biology |
| ``tumor_endothelium`` | ``endothelial`` | DLL4, ESM1, ANGPT2, PLVAP, ACKR1, APLN, CXCR4, KDR, FLT1, INSR | Anti-angiogenic TKI / ADC biology |
| ``MDSC`` | ``myeloid`` (separate from TAM) | ARG1, S100A8, S100A9, CEBPB, FCGR3B, MPO, ELANE, CAMP | Immunosuppressive granulocytic / monocytic MDSC |
| ``TLS_B`` | ``B_cell`` | CXCR5, BCL6, AICDA, MS4A1, RGS13, STMN1 | Germinal-center B; positive ICI prognostic |
| ``TI_plasma`` | ``plasma`` | MZB1, JCHAIN, IGHG1, IGHG3, IGHA1, XBP1 | Class-switched plasma |

## Refactor

- New ``PANELS`` module-level registry (tuples of label / compartment / marker folds). Adding a new compartment is now a 1-line edit.
- ``refine_tme_per_gene`` iterates PANELS instead of the hardcoded CAF/TAM tuple.
- First-match-wins guard prevents compounded refinements when a gene appears on two panels (canonical markers don't overlap, but the test pins the contract).
- New public helpers: ``panel_markers(label)``, ``panel_labels()``.

## Validation on real sample

CRPC PRAD (previously 9 TAM-only refinements at v4.42.0) → **24 refinements across 6 compartments**:

- TAM: 10 (CD163, LYVE1, TREM2, VSIG4, STAB1, SELENOP, APOE, C1QA-C)
- exhausted_T: 5
- tumor_endothelium: 3
- TLS_B: 3
- TI_plasma: 2
- MDSC: 1

## Test plan

- [x] 18 new tests in ``test_issue_58_extended_tme.py``
- [x] Full suite — 682 passed, 1 skipped
- [x] Panel registry invariant: every panel targets a compartment in the ``solid_primary`` template
- [x] First-match-wins test: synthetic gene on two panels refines exactly once, labeled by the first panel in PANELS order
- [x] ``ruff check`` clean

## Version
Bump to 4.43.0 (minor — new feature, extends #56 infra).