### PR TITLE
feat(report): smooth-muscle stromal-leakage annotation (partial #59)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -575,6 +575,7 @@ def _format_attribution_cell(row):
     broadly = bool(row.get("broadly_expressed"))
     amplified = bool(row.get("amplified_over_healthy"))
     over_predicted = bool(row.get("matched_normal_over_predicted"))
+    sm_leakage = bool(row.get("smooth_muscle_stromal_leakage"))
     try:
         amp_fold = float(row.get("amplification_fold") or 0.0)
     except (TypeError, ValueError):
@@ -590,6 +591,14 @@ def _format_attribution_cell(row):
         # expressing the gene — it means the reference over-predicted.
         if over_predicted:
             return "matched-normal over-predicted"
+        # #59 item 1: smooth-muscle stromal leakage. Fibromuscular-
+        # stroma density varies sample-to-sample; matched-normal
+        # references carry the cohort-average and under-subtract
+        # SM-lineage genes when the biopsy is SM-rich. The tumor
+        # story for TAGLN / ACTA2 / MYH11 / CNN1 should be read with
+        # that caveat.
+        if sm_leakage:
+            return "likely smooth-muscle stromal leakage"
         # Amplification is a positive specificity signal and takes
         # precedence over the broadly-expressed caution (#128). A gene
         # that's broadly expressed at baseline but observed >= 5× over

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -130,6 +130,31 @@ BREADTH_BASELINE_TOP_N = 10
 #   sees the amplification story, not a spurious caution.
 AMPLIFICATION_MIN_FOLD = 5.0
 
+# Smooth-muscle lineage markers (#59 item 1). Canonical vascular +
+# visceral SM identity genes — not rhabdomyosarcoma / cardiac markers
+# (DES is omitted here because it also fires in skeletal / cardiac
+# muscle and on RMS samples). When these land in the tumor-attributed
+# column at materially high TPM, the reader should treat the
+# tumor-cell story with caution: the matched-normal reference carries
+# average fibromuscular-stroma density for the parent tissue, and a
+# biopsy with above-average SM content leaks SM signal into tumor.
+_SMOOTH_MUSCLE_LINEAGE_MARKERS = frozenset({
+    "TAGLN",   # Transgelin / SM22α
+    "ACTA2",   # α-smooth muscle actin
+    "MYH11",   # Smooth muscle myosin heavy chain 11
+    "CNN1",    # Calponin 1
+    "MYL9",    # Myosin light chain 9
+    "CALD1",   # Caldesmon
+    "SMTN",    # Smoothelin
+    "MYLK",    # Myosin light-chain kinase
+    "TPM2",    # Tropomyosin 2 (SM-enriched isoform)
+})
+# Firing thresholds. Kept conservative — this is an annotation, not a
+# refitting override, so over-annotating is cheap but under-annotating
+# misses the case.
+_SM_LEAKAGE_MIN_OBSERVED_TPM = 50.0
+_SM_LEAKAGE_MIN_TUMOR_FRACTION = 0.30
+
 # ---------------------------------------------------------------------------
 # Functions
 # ---------------------------------------------------------------------------
@@ -1137,6 +1162,20 @@ def estimate_tumor_expression_ranges(
             # kept for audit.
             "matched_normal_over_predicted": matched_normal_over_predicted,
             "attribution_raw_sum_tpm": round(attr_tme_total_raw, 2),
+            # #59 item 1: smooth-muscle stromal leakage. Matched-normal
+            # references carry average fibromuscular-stroma density for
+            # the parent tissue; a biopsy with above-average SM content
+            # leaks SM-lineage signal into the tumor column. When a
+            # canonical SM marker lands with a substantial tumor share
+            # at a non-trivial TPM, annotate rather than silently treat
+            # as tumor-cell expressed. NOT a refitting override — this
+            # is strictly a reader-facing caveat that the tumor-cell
+            # story should be read with skepticism.
+            "smooth_muscle_stromal_leakage": bool(
+                symbol in _SMOOTH_MUSCLE_LINEAGE_MARKERS
+                and observed >= _SM_LEAKAGE_MIN_OBSERVED_TPM
+                and attr_tumor_fraction >= _SM_LEAKAGE_MIN_TUMOR_FRACTION
+            ),
             # #56: post-hoc CAF / TAM reference swap provenance.
             # ``subtype_refined`` is True when the per-gene TME
             # contribution got reference-swapped; the *_before column

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.43.0"
+__version__ = "4.44.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_issue_59_sm_leakage.py
+++ b/tests/test_issue_59_sm_leakage.py
@@ -1,0 +1,139 @@
+"""Regression tests for #59 item 1 — smooth-muscle stromal leakage annotation.
+
+The matched-normal reference (``nTPM_prostate`` / ``nTPM_colon`` / …)
+carries *average* fibromuscular-stroma density for the parent tissue.
+A biopsy with above-average smooth-muscle content leaks SM-lineage
+signal into the tumor-attributed column. This annotation flags
+canonical SM markers (TAGLN, ACTA2, MYH11, CNN1, MYL9, CALD1, SMTN,
+MYLK, TPM2) with material tumor attribution so the reader treats the
+tumor-cell story with skepticism — rather than silently treating as
+tumor-expressed.
+
+NOT a refitting override — strictly a reader-facing caveat.
+"""
+
+from pirlygenes.cli import _format_attribution_cell
+from pirlygenes.plot_tumor_expr import (
+    _SM_LEAKAGE_MIN_OBSERVED_TPM,
+    _SM_LEAKAGE_MIN_TUMOR_FRACTION,
+    _SMOOTH_MUSCLE_LINEAGE_MARKERS,
+)
+
+
+# ── Panel contents ────────────────────────────────────────────────────
+
+
+def test_panel_has_canonical_sm_markers():
+    for gene in ("TAGLN", "ACTA2", "MYH11", "CNN1", "MYL9", "CALD1"):
+        assert gene in _SMOOTH_MUSCLE_LINEAGE_MARKERS
+
+
+def test_panel_excludes_rhabdomyosarcoma_marker():
+    """DES / MYOD1 / MYOG are rhabdomyosarcoma (or cardiac) markers,
+    not smooth-muscle-specific. Flagging them as SM leakage would
+    mis-annotate RMS / cardiac samples. Pin the carve-out."""
+    for gene in ("DES", "MYOD1", "MYOG", "MYF5"):
+        assert gene not in _SMOOTH_MUSCLE_LINEAGE_MARKERS
+
+
+# ── Attribution-cell rendering ───────────────────────────────────────
+
+
+def _row(symbol, observed, attr_tumor, **kwargs):
+    """Build a minimal ranges_df row for rendering."""
+    fraction = (attr_tumor / observed) if observed else 0.0
+    defaults = {
+        "symbol": symbol,
+        "observed_tpm": observed,
+        "attr_tumor_tpm": attr_tumor,
+        "attribution": {"matched_normal_prostate": observed - attr_tumor},
+        "attr_top_compartment": "matched_normal_prostate",
+        "attr_top_compartment_tpm": observed - attr_tumor,
+        "attr_tumor_fraction": fraction,
+        "smooth_muscle_stromal_leakage": (
+            symbol in _SMOOTH_MUSCLE_LINEAGE_MARKERS
+            and observed >= _SM_LEAKAGE_MIN_OBSERVED_TPM
+            and fraction >= _SM_LEAKAGE_MIN_TUMOR_FRACTION
+        ),
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def test_sm_leakage_tag_fires_on_tagln_with_material_tumor_fraction():
+    row = _row("TAGLN", observed=1500.0, attr_tumor=900.0)
+    cell = _format_attribution_cell(row)
+    assert "smooth-muscle stromal leakage" in cell
+
+
+def test_sm_leakage_tag_does_not_fire_below_observed_threshold():
+    """Observed TPM below the floor — too faint to matter."""
+    row = _row("TAGLN", observed=30.0, attr_tumor=20.0)
+    cell = _format_attribution_cell(row)
+    assert "smooth-muscle stromal leakage" not in cell
+
+
+def test_sm_leakage_tag_does_not_fire_when_tumor_share_is_small():
+    """Gene mostly attributed to matched-normal already — no need to
+    flag. The caveat is specifically for cases where tumor share is
+    material enough to mislead the reader."""
+    row = _row("TAGLN", observed=1500.0, attr_tumor=100.0)  # 6.7% tumor
+    cell = _format_attribution_cell(row)
+    assert "smooth-muscle stromal leakage" not in cell
+
+
+def test_sm_leakage_tag_does_not_fire_on_non_sm_gene():
+    row = _row("TP53", observed=500.0, attr_tumor=400.0)
+    cell = _format_attribution_cell(row)
+    assert "smooth-muscle stromal leakage" not in cell
+
+
+def test_matched_normal_over_predicted_wins_over_sm_leakage():
+    """Over-prediction is the strongest caveat — when matched-normal
+    alone predicts more than observed, the tumor attribution is at
+    the zero floor. The over-predicted tag reads first; SM leakage is
+    the weaker / downstream annotation."""
+    row = _row(
+        "TAGLN",
+        observed=1500.0,
+        attr_tumor=0.0,  # zero-floor case
+        matched_normal_over_predicted=True,
+        attr_tumor_fraction=0.0,
+        smooth_muscle_stromal_leakage=False,  # 0% fraction → no SM tag
+    )
+    cell = _format_attribution_cell(row)
+    assert "matched-normal over-predicted" in cell
+
+
+# ── End-to-end: column lands in ranges_df ────────────────────────────
+
+
+def test_ranges_df_emits_smooth_muscle_stromal_leakage_column(tmp_path):
+    """Pin the new column surface area on the real estimator."""
+    import pandas as pd
+    from pirlygenes.gene_sets_cancer import pan_cancer_expression
+    from pirlygenes.plot import estimate_tumor_expression_ranges
+
+    ref = pan_cancer_expression().drop_duplicates(subset="Ensembl_Gene_ID")
+    df = pd.DataFrame({
+        "ensembl_gene_id": ref["Ensembl_Gene_ID"],
+        "gene_symbol": ref["Symbol"],
+        "TPM": ref["nTPM_prostate"].astype(float) + 1.0,
+    })
+    # Inject high TAGLN so the flag has a chance to fire.
+    df.loc[df["gene_symbol"] == "TAGLN", "TPM"] = 1500.0
+
+    purity = {
+        "overall_estimate": 0.3,
+        "overall_lower": 0.2,
+        "overall_upper": 0.4,
+        "components": {"stromal": {"enrichment": 1.2}, "immune": {"enrichment": 1.1}},
+    }
+    out = estimate_tumor_expression_ranges(
+        df_gene_expr=df, cancer_type="PRAD", purity_result=purity,
+    )
+    assert "smooth_muscle_stromal_leakage" in out.columns
+    # Column dtype must be boolean-coercible (the render path calls
+    # ``bool(row.get(...))``).
+    leakage_vals = out["smooth_muscle_stromal_leakage"]
+    assert set(leakage_vals.unique()).issubset({True, False})


### PR DESCRIPTION
## Summary

Item 1 of issue #59 — matched-normal references carry *average* fibromuscular-stroma density for the parent tissue, so biopsies with above-average SM content leak smooth-muscle lineage signal into the tumor-attributed column.

New per-target annotation: when a canonical SM lineage marker (TAGLN, ACTA2, MYH11, CNN1, MYL9, CALD1, SMTN, MYLK, TPM2) lands with material tumor attribution at non-trivial TPM, tag the row as ``smooth_muscle_stromal_leakage`` and render the caveat ``likely smooth-muscle stromal leakage`` in the Attribution cell.

## Design choice: annotate, not refit

Per the issue analysis, adding a SM NNLS column would collide with matched-normal (same collinearity risk that #52 carved out of marker anchoring). Annotation is the lower-risk path that recovers reader awareness without moving the math.

## Carve-outs

- DES / MYOD1 / MYOG / MYF5 are deliberately **not** on the SM panel — those are rhabdomyosarcoma + cardiac markers. A RMS sample with high DES should not be mis-annotated as "smooth muscle leakage".
- Over-prediction (#131) takes precedence over SM leakage when both conditions hold — over-prediction is the stronger caveat.

## Thresholds

- Observed ≥ 50 TPM (too faint to matter below)
- Tumor share ≥ 30% of observed (small tumor shares are already handled by Attribution rendering)

## Validation on real sample

CRPC PRAD: 4 SM markers flagged with the expected pattern (matches issue #59's described behavior):

| Gene | Observed | Tumor-attr | Share |
|---|---|---|---|
| MYLK | 6538 TPM | 5984 TPM | 92% |
| CALD1 | 4076 TPM | 3753 TPM | 92% |
| MYH11 | 1336 TPM | 496 TPM | 37% |
| SMTN | 280 TPM | 88 TPM | 31% |

## Deferred (same issue #59)

Items 2–4 (gated adipocyte / Schwann / erythroid NNLS compartments) require modifying the template-component system. Bigger refactor, separate PR.

## Test plan

- [x] 8 new tests in ``test_issue_59_sm_leakage.py``
- [x] Full suite — 690 passed, 1 skipped
- [x] RMS marker exclusion (DES / MYOD1 / MYOG / MYF5 not on panel)
- [x] Over-prediction precedence over SM-leakage tag
- [x] End-to-end column surface on real estimator
- [x] ``ruff check`` clean

## Version
Bump to 4.44.0 (minor — new TSV column + annotation).