### PR TITLE
chore(report): drop redundant tumor-attribution plots (C3)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1613,7 +1613,6 @@ def _analyze_body(
     # Deep-dive therapy target + CTA + subtype plots
     from .plot_target_deep_dive import (
         plot_actionable_targets,
-        plot_tumor_attribution,
         plot_cta_deep_dive,
     )
     from .plot_subtype_signature import plot_subtype_signature
@@ -1643,29 +1642,15 @@ def _analyze_body(
         print(f"[plot] CTA deep dive failed: {exc}")
         cta_deep_png = None
 
-    try:
-        attrib_targets_png = "%s-tumor-attribution-targets.png" % prefix
-        plot_tumor_attribution(
-            df_expr, cancer_type=effective_cancer_type,
-            purity_estimate=p_est or 0.5, category="surface",
-            save_to_filename=attrib_targets_png, save_dpi=output_dpi,
-        )
-        print(f"[plot] Saved tumor attribution (targets) to {attrib_targets_png}")
-    except Exception as exc:
-        print(f"[plot] tumor attribution (targets) failed: {exc}")
-        attrib_targets_png = None
-
-    try:
-        attrib_cta_png = "%s-tumor-attribution-cta.png" % prefix
-        plot_tumor_attribution(
-            df_expr, cancer_type=effective_cancer_type,
-            purity_estimate=p_est or 0.5, category="CTA",
-            save_to_filename=attrib_cta_png, save_dpi=output_dpi,
-        )
-        print(f"[plot] Saved tumor attribution (CTA) to {attrib_cta_png}")
-    except Exception as exc:
-        print(f"[plot] tumor attribution (CTA) failed: {exc}")
-        attrib_cta_png = None
+    # The pre-#108 ``plot_tumor_attribution`` (reference-based 2-color
+    # tumor-vs-TME view) was removed from the default plot set in
+    # v4.46.0 — ``plot_target_attribution`` (per-compartment stacked
+    # bars keyed on the #108 attribution dict) is strictly more
+    # informative and already emits per-category ``target-attribution-
+    # *.png``. The older function remains in
+    # ``pirlygenes.plot_target_deep_dive`` for Python-API consumers.
+    attrib_targets_png = None
+    attrib_cta_png = None
 
     subtype_png = None
     try:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.45.0"
+__version__ = "4.45.1"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary

Follow-up to the figure-set audit (#188). Drops 2 PNGs per analysis that were near-duplicates of the more informative ``sample-target-attribution-*.png`` set.

## Changes

- CLI no longer invokes ``plot_tumor_attribution`` (the pre-#108 2-color view). ``plot_target_attribution`` — #108 per-compartment stacked bars — is strictly more informative and already covers the same target categories.
- Function remains in ``pirlygenes.plot_target_deep_dive`` for Python-API consumers.

## Net effect

Two fewer PNGs per sample:
- ``sample-tumor-attribution-targets.png`` — dropped
- ``sample-tumor-attribution-cta.png`` — dropped

The informative ``sample-target-attribution-targets.png`` / ``sample-target-attribution-ctas.png`` / ``sample-target-attribution-surface.png`` stay.

## Test plan

- [x] Full suite — 706 passed, 1 skipped
- [x] ``ruff check`` clean

## Version
4.45.1 (patch — no API change, output-set-only).