### PR TITLE
feat(plot): subtype-attribution before/after PNGs (C2)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1756,6 +1756,31 @@ def _analyze_body(
                     adj_pngs.append(attr_png)
                 _plt.close("all")
 
+        # Per-gene subtype-refinement before / after bars (#56 / #58,
+        # figure-audit C2). Only emitted when at least one gene in the
+        # category got refined by the CAF / TAM / ... reference swap.
+        # Separate PNG per category per the plot-crowding preference.
+        if (
+            "subtype_refined" in ranges_df.columns
+            and ranges_df["subtype_refined"].astype(bool).any()
+        ):
+            from .plot_tumor_expr import plot_subtype_attribution
+            for cat_key, cat_slug in _adj_categories:
+                sub_png = (
+                    "%s-subtype-attribution-%s.png" % (prefix, cat_slug)
+                    if prefix else "subtype-attribution-%s.png" % cat_slug
+                )
+                fig = plot_subtype_attribution(
+                    ranges_df,
+                    category=cat_key,
+                    top_n=15,
+                    save_to_filename=sub_png,
+                    save_dpi=output_dpi,
+                )
+                if fig is not None:
+                    adj_pngs.append(sub_png)
+                _plt.close("all")
+
         # Per-gene matched-normal attribution (issue #55). One PNG per
         # category, only emitted when matched-normal subtraction was
         # active. Separate plots rather than a composite figure per the

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -1448,6 +1448,122 @@ def plot_target_attribution(
     return fig
 
 
+def plot_subtype_attribution(
+    df_ranges,
+    category,
+    top_n=15,
+    save_to_filename=None,
+    save_dpi=300,
+    figsize=None,
+):
+    """Per-gene before/after deltas from subtype refinement (#56 / #58).
+
+    For each of the top-N genes in ``category`` that were refined by
+    ``refine_tme_per_gene``, draw paired horizontal bars:
+
+    - BEFORE: tumor residual + aggregate TME under the generic-reference
+      path (pre-#56 behavior).
+    - AFTER: tumor residual + aggregate TME under the tumor-activated
+      reference swap.
+
+    Each gene's pair is labelled with the winning subtype (CAF / TAM /
+    exhausted_T / …). Makes the per-gene effect of the refinement
+    concrete — readers see exactly which genes moved from
+    mis-attributed-to-tumor to correctly-absorbed-by-the-refined-compartment.
+
+    Returns ``None`` when no row in the category has subtype-refinement
+    provenance (e.g. decomposition didn't run, or no marker gene
+    crossed the fold threshold on this category).
+    """
+    if "subtype_refined" not in df_ranges.columns:
+        return None
+    sub = df_ranges[
+        (df_ranges["category"] == category)
+        & (df_ranges["subtype_refined"].astype(bool))
+    ].copy()
+    if sub.empty:
+        return None
+
+    # Rank by the size of the per-gene correction so the most-impactful
+    # refinements appear at the top of the chart.
+    sub["_delta"] = (
+        sub["tme_tpm_before_subtype_refinement"].astype(float)
+        - (sub["observed_tpm"].astype(float) - sub["attr_tumor_tpm"].astype(float))
+    ).abs()
+    sub = sub.sort_values("_delta", ascending=False).head(top_n)
+    sub = sub.sort_values("_delta", ascending=True).reset_index(drop=True)
+
+    n = len(sub)
+    if n == 0:
+        return None
+    if figsize is None:
+        figsize = (11, max(3.0, 0.55 * n + 1.5))
+
+    # Two rows per gene: "before" above, "after" below.
+    fig, ax = plt.subplots(figsize=figsize)
+
+    tumor_color = "#e74c3c"
+    tme_color_before = "#95a5a6"   # grey — generic reference
+    tme_color_after = "#f39c12"    # orange — tumor-activated reference
+
+    row_positions = []
+    labels = []
+    for i, (_, row) in enumerate(sub.iterrows()):
+        observed = float(row.get("observed_tpm") or 0.0)
+        tme_before = float(row.get("tme_tpm_before_subtype_refinement") or 0.0)
+        tumor_before = max(0.0, observed - tme_before)
+        tumor_after = float(row.get("attr_tumor_tpm") or 0.0)
+        tme_after = max(0.0, observed - tumor_after)
+
+        y_before = 2 * i
+        y_after = 2 * i + 0.75
+        ax.barh(y_before, tumor_before, color=tumor_color)
+        ax.barh(y_before, tme_before, left=tumor_before,
+                color=tme_color_before)
+        ax.barh(y_after, tumor_after, color=tumor_color)
+        ax.barh(y_after, tme_after, left=tumor_after,
+                color=tme_color_after)
+
+        sym = str(row["symbol"])
+        label_subtype = row.get("subtype_refinement_label", "") or "refined"
+        row_positions.extend([y_before, y_after])
+        labels.append(f"{sym} · before")
+        labels.append(f"{sym} · after ({label_subtype})")
+
+    ax.set_yticks(row_positions)
+    ax.set_yticklabels(labels, fontsize=9)
+    ax.invert_yaxis()
+    ax.set_xlabel(
+        "TPM (stacked: tumor core + TME background = observed)",
+        fontsize=10,
+    )
+    ax.set_xscale("symlog", linthresh=1.0)
+    ax.grid(axis="x", alpha=0.2)
+
+    import matplotlib.patches as mpatches
+    handles = [
+        mpatches.Patch(color=tumor_color, label="tumor core"),
+        mpatches.Patch(color=tme_color_before,
+                       label="TME — generic reference (pre-#56)"),
+        mpatches.Patch(color=tme_color_after,
+                       label="TME — tumor-activated reference (post-#56)"),
+    ]
+    ax.legend(handles=handles, loc="lower right", fontsize=8, framealpha=0.9)
+    ax.set_title(
+        f"Subtype-refinement before / after — {category}\n"
+        "top rows = largest correction; AFTER-bars show how much "
+        "signal the tumor-activated reference absorbs that the "
+        "generic reference missed.",
+        fontsize=9, fontweight="bold", loc="left",
+    )
+
+    plt.tight_layout()
+    if save_to_filename:
+        fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+        print(f"Saved {save_to_filename}")
+    return fig
+
+
 def plot_tumor_expression_ranges(
     df_ranges,
     purity_result,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.45.3"
+__version__ = "4.46.0"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary

Closes the biggest gap from the figure audit (#188): the ``refine_tme_per_gene`` mechanism from #56 / #58 populates three provenance columns in the tumor-expression-ranges TSV but no figure visualized the per-gene effect.

New ``plot_subtype_attribution(df_ranges, category, ...)`` emits paired horizontal bars per refined gene — BEFORE (tumor + generic-reference TME) and AFTER (tumor + tumor-activated-reference TME) — sorted by absolute correction size with the winning subtype labelled (CAF / TAM / exhausted_T / tumor_endothelium / MDSC / TLS_B / TI_plasma).

## CLI

Adds ``*-subtype-attribution-{cat}.png`` per category (targets / ctas / surface), following the existing ``target-attribution-*.png`` pattern. Silent on samples where no marker-gene crossed the fold threshold.

## Validation

CRPC PRAD sample emits 2 new PNGs (``sample-subtype-attribution-surface.png`` + ``sample-subtype-attribution-targets.png``) showing the TAM / CAF corrections visually. CTAs don't fire because the canonical marker genes don't overlap with the curated CTA panels — expected.

## Test plan

- [x] Full suite — 706 passed, 1 skipped
- [x] ``ruff check`` clean
- [x] End-to-end on real sample — 2 PNGs emitted on PRAD, silent behavior for categories without refinements

## Version
Bump to 4.46.0 (minor — new figure + new plotting function).