### PR TITLE
fix(therapy): FN1-EDB lookup tolerant of broken Ensembl schemas

### DIFF
--- a/pirlygenes/plot_therapy.py
+++ b/pirlygenes/plot_therapy.py
@@ -83,14 +83,33 @@ def _fn1_edb_transcript_ids():
                 continue
             if getattr(transcript, "biotype", None) != "protein_coding":
                 continue
-            exons = list(getattr(transcript, "exons", []) or [])
-            exon_ids = {str(exon.exon_id) for exon in exons if getattr(exon, "exon_id", None)}
-            exon_intervals = {
-                (int(exon.start), int(exon.end))
-                for exon in exons
-                if getattr(exon, "start", None) is not None
-                and getattr(exon, "end", None) is not None
-            }
+            # ``transcript.exons`` is a lazily-evaluated property that
+            # issues a pyensembl SQL query. Older Ensembl releases
+            # (e.g. 54) have an ``exon`` table without an ``exon_id``
+            # column — the query raises ``sqlite3.OperationalError``.
+            # Catch it so one release's schema weirdness doesn't abort
+            # the whole cross-release lookup. Whichever releases still
+            # have intact schemas contribute; broken ones silently skip.
+            try:
+                exons = list(getattr(transcript, "exons", []) or [])
+            except Exception:
+                continue
+            try:
+                exon_ids = {
+                    str(exon.exon_id) for exon in exons
+                    if getattr(exon, "exon_id", None)
+                }
+            except Exception:
+                exon_ids = set()
+            try:
+                exon_intervals = {
+                    (int(exon.start), int(exon.end))
+                    for exon in exons
+                    if getattr(exon, "start", None) is not None
+                    and getattr(exon, "end", None) is not None
+                }
+            except Exception:
+                exon_intervals = set()
             if (
                 getattr(transcript, "transcript_name", None) in _FN1_EDB_TRANSCRIPT_NAMES
                 or exon_ids & _FN1_EDB_EXON_IDS

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.45.2"
+__version__ = "4.45.3"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Diagnosis

``_fn1_edb_transcript_ids()`` iterates every installed Ensembl release (via ``pyensembl.shell.collect_all_installed_ensembl_releases``). Some older releases have an ``exon`` table without an ``exon_id`` column — ``transcript.exons`` triggers pyensembl's internal SQL:

```sql
SELECT exon_number, exon_id FROM exon WHERE transcript_id = ?
```

which raises ``sqlite3.OperationalError: no such column: exon_id``, killing the whole cross-release lookup.

Reproduced with Ensembl release 54 locally:
```
$ python3 -c "from pyensembl import EnsemblRelease; t = EnsemblRelease(54).transcript_by_id('ENST00000265313'); list(t.exons)"
ERROR: no such column: exon_id
```

CI doesn't hit this because it builds a fresh pyensembl cache against a single modern release — schema matches. Any dev whose local install has release 54 (or another legacy release) sees the FN1 tests fail even though the code change in the PR is unrelated.

## Fix

Wrap the ``transcript.exons`` evaluation and per-exon attribute accesses in try/except so one release's schema mismatch can't abort the whole loop. Working releases still contribute; broken ones silently skip. The hardcoded-ID fallback at the top of the function handles the ``no release returns exon data`` case.

## Test plan

- [x] Full suite — 706 passed locally (was 2 FN1 failures before)
- [x] ``ruff check`` clean
- [x] Behavior unchanged on healthy pyensembl setups (CI was passing; trivially stays green)

## Version
Bump to 4.45.3 (patch — resilience fix, no API change).