### PR TITLE
feat(narrative): data-driven disease-state rule engine (closes #202)

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Optional, Set
 
 from .version import print_name_and_version
-from .load_dataset import load_all_dataframes
 from .tumor_purity import (
     analyze_sample,
     get_tumor_purity_parameters,
@@ -97,22 +96,28 @@ _DATASET_SOURCES = {
     "surface-proteins": "Bausch-Fluck et al. 2018, PNAS (SURFY/CSPA)",
     "TCR-T-approved": "FDA approvals",
     "TCR-T-trials": "Literature curation 2024",
+    "disease-state-rules": "Per-cancer narrative rule catalog (#202)",
+    "narrative-gene-sets": "Named gene sets for #202 disease-state rules",
+    "degenerate-subtype-pairs": "Subtype disambiguation catalog (#198)",
+    "fusion-surrogate-expression": "Fusion-surrogate gene catalog (#198)",
 }
 
 
 @named("data")
 def print_dataset_info():
     """List all bundled datasets with row counts and sources."""
-    import os
-    from pathlib import Path
+    import pandas as pd
+
+    from .load_dataset import get_all_csv_paths
 
     total_size = 0
     print("\nBundled datasets (shipped with pip install, no downloads needed):\n")
     print(f"  {'Dataset':<40s} {'Rows':>6s}  {'Size':>8s}  Source")
     print(f"  {'─'*40}  {'─'*6}  {'─'*8}  {'─'*40}")
-    for csv_file, df in load_all_dataframes():
-        name = Path(csv_file).stem
-        size = os.path.getsize(csv_file)
+    for csv_path in get_all_csv_paths():
+        df = pd.read_csv(str(csv_path))
+        name = csv_path.name.removesuffix(".gz").removesuffix(".csv")
+        size = csv_path.stat().st_size
         total_size += size
         if size >= 1024 * 1024:
             size_str = "%.1f MB" % (size / 1024 / 1024)
@@ -279,14 +284,10 @@ def _parse_csv_tokens(arg_value: Optional[str]):
 
 _MT_EXPECTED_MISSING_PREPS = frozenset({"poly_a", "exome_capture"})
 
-# Genes we treat as "AR-transactivation output" — the downstream AR-
-# target program that collapses in castrate-resistant PRAD. Used by
-# the synthesis layer (#78) to detect the AR-retained-but-targets-
-# collapsed pattern typical of ADT-treated CRPC.
-_PRAD_AR_TARGET_GENES = frozenset({
-    "KLK3", "KLK2", "NKX3-1", "HOXB13", "FOLH1", "TMPRSS2",
-    "SLC45A3", "NDRG1", "PMEPA1", "FKBP5",
-})
+# The AR-transactivation output panel used by the CRPC-pattern
+# narrative rule moved to ``narrative-gene-sets.csv`` (#202). The
+# disease-state rule engine looks it up by name (``AR_targets``) so
+# the synthesis layer stays data-driven.
 
 # Genes annotated in the therapy_response AR_signaling *up* panel but
 # also core ISGs — used to tag per-gene surface-target fold-changes as
@@ -350,19 +351,20 @@ def _metabolic_axes_rows(evidence) -> list[tuple[str, str, str]]:
 
 
 def compose_disease_state_narrative(analysis) -> str:
-    """Synthesize a one-line disease-state narrative from combined
-    signals (issue #78).
+    """Synthesize the disease-state narrative line (#78).
 
-    Draws on the candidate trace, lineage-gene calibration, and
-    therapy-response axis scores. Cancer-type-family-specific rules;
-    PRAD covers the castrate-resistant / NEPC pattern first since
-    that's the validation case (Tempus FFPE PRAD sample: AR retained
-    at 51% + KLK3/KLK2/NKX3-1/HOXB13 all < 2% + NE markers elevated
-    = textbook ADT-treated CRPC trending toward NEPC).
+    As of #202 the per-cancer logic lives in ``disease-state-rules.csv``
+    and ``narrative-gene-sets.csv``. This function only prepares the
+    three inputs the rule engine consumes (axis states + lineage-
+    retained / lineage-collapsed gene sets) and dispatches.
 
-    Returns an empty string when no family rule matches — callers
-    skip rendering in that case.
+    Adding a new cancer-specific narrative is a CSV edit — no Python
+    change. This keeps the analyze pipeline uniform across cancer
+    types; differences live in data, not in ``if/elif cancer_code``
+    branches.
     """
+    from .disease_state_rules import synthesize_disease_state
+
     cancer_code = analysis.get("cancer_type")
     therapy_scores = analysis.get("therapy_response_scores") or {}
     purity = analysis.get("purity") or {}
@@ -370,7 +372,6 @@ def compose_disease_state_narrative(analysis) -> str:
     lineage = components.get("lineage") or {}
     per_gene = lineage.get("per_gene") or []
 
-    # Bucket lineage genes by their independent purity estimate.
     retained: set[str] = set()
     collapsed: set[str] = set()
     for g in per_gene:
@@ -383,78 +384,16 @@ def compose_disease_state_narrative(analysis) -> str:
         elif est < 0.05:
             collapsed.add(sym)
 
-    # Axis states
-    def _state(cls):
-        s = therapy_scores.get(cls)
-        return s.state if s is not None else None
+    axis_states: dict[str, str | None] = {}
+    for axis_name, score in therapy_scores.items():
+        axis_states[axis_name] = getattr(score, "state", None)
 
-    ar_state = _state("AR_signaling")
-    ne_state = _state("NE_differentiation")
-    emt_state = _state("EMT")
-    ifn_state = _state("IFN_response")
-    hypoxia_state = _state("hypoxia")
-    er_state = _state("ER_signaling")
-    her2_state = _state("HER2_signaling")
-
-    parts: list[str] = []
-
-    if cancer_code == "PRAD":
-        ar_retained = "AR" in retained
-        ar_targets_collapsed = len(_PRAD_AR_TARGET_GENES & collapsed) >= 3
-        if ar_retained and ar_targets_collapsed and ar_state == "down":
-            verb = (
-                "**Castrate-resistant pattern**: AR receptor retained "
-                "while AR-transactivation targets "
-                f"({', '.join(sorted(_PRAD_AR_TARGET_GENES & collapsed))}) "
-                "are collapsed — consistent with prior ADT exposure"
-            )
-            if ne_state == "up":
-                verb += (
-                    " with **emerging neuroendocrine differentiation** "
-                    "(NE markers elevated; workup for NEPC warranted)"
-                )
-            verb += "."
-            parts.append(verb)
-        elif ar_state == "down":
-            parts.append(
-                "**AR axis suppressed** — consistent with ADT exposure. "
-                "Lineage AR was not retained in the sample; insufficient "
-                "signal for a castrate-resistant call."
-            )
-    elif cancer_code in ("BRCA",):
-        if er_state == "down" and "ESR1" in collapsed:
-            parts.append(
-                "**ER-axis suppressed / endocrine-exposed pattern** "
-                "(ESR1 low, classic ER targets collapsed)."
-            )
-        if her2_state == "up":
-            parts.append(
-                "**HER2-amplification pattern** (ERBB2 / GRB7 / STARD3 "
-                "co-elevated)."
-            )
-
-    # Cross-axis observation: EMT + hypoxia together typically signal
-    # an aggressive / treatment-resistant phenotype regardless of
-    # cancer type.
-    if emt_state == "up" and hypoxia_state == "up":
-        parts.append(
-            "EMT and hypoxia programs are both active — aggressive-"
-            "phenotype pattern."
-        )
-    elif emt_state == "up":
-        parts.append("EMT program is active (mesenchymal switch).")
-
-    # Active IFN response affects how we read high-fold-change
-    # surface / MHC targets; mention so the reader knows the targets
-    # table carries IFN-driven inflation.
-    if ifn_state == "up":
-        parts.append(
-            "**Active IFN response** — MHC-I / ISG surface fold-changes "
-            "in the therapy-target tables carry IFN-driven inflation "
-            "and are not tumor-cell-specific."
-        )
-
-    return " ".join(parts)
+    return synthesize_disease_state(
+        cancer_code=cancer_code,
+        axis_states=axis_states,
+        retained=retained,
+        collapsed=collapsed,
+    )
 
 
 def annotate_surface_targets_with_cross_signals(ranges_df, therapy_scores):

--- a/pirlygenes/data/disease-state-rules.csv
+++ b/pirlygenes/data/disease-state-rules.csv
@@ -1,0 +1,9 @@
+rule_id,cancer_code,priority,claims,conditions,narrative
+prad_crpc_with_ne,PRAD,10,AR_axis,axis:AR_signaling=down | retained:AR | collapsed_ge:3=AR_targets | axis:NE_differentiation=up,"**Castrate-resistant pattern**: AR receptor retained while AR-transactivation targets ({collapsed:AR_targets}) are collapsed — consistent with prior ADT exposure with **emerging neuroendocrine differentiation** (NE markers elevated; workup for NEPC warranted)."
+prad_crpc,PRAD,20,AR_axis,axis:AR_signaling=down | retained:AR | collapsed_ge:3=AR_targets,"**Castrate-resistant pattern**: AR receptor retained while AR-transactivation targets ({collapsed:AR_targets}) are collapsed — consistent with prior ADT exposure."
+prad_ar_suppressed,PRAD,30,AR_axis,axis:AR_signaling=down,**AR axis suppressed** — consistent with ADT exposure. Lineage AR was not retained in the sample; insufficient signal for a castrate-resistant call.
+brca_er_suppressed,BRCA,20,ER_axis,axis:ER_signaling=down | collapsed:ESR1,**ER-axis suppressed / endocrine-exposed pattern** (ESR1 low; classic ER targets collapsed).
+brca_her2_amp,BRCA,20,HER2_axis,axis:HER2_signaling=up,**HER2-amplification pattern** (ERBB2 / GRB7 / STARD3 co-elevated).
+pan_emt_hypoxia,pan_cancer,100,EMT_axis,axis:EMT=up | axis:hypoxia=up,EMT and hypoxia programs are both active — aggressive-phenotype pattern.
+pan_emt_only,pan_cancer,110,EMT_axis,axis:EMT=up,EMT program is active (mesenchymal switch).
+pan_ifn,pan_cancer,120,,axis:IFN_response=up,**Active IFN response** — MHC-I / ISG surface fold-changes in the therapy-target tables carry IFN-driven inflation and are not tumor-cell-specific.

--- a/pirlygenes/data/narrative-gene-sets.csv
+++ b/pirlygenes/data/narrative-gene-sets.csv
@@ -1,0 +1,4 @@
+set_name,members,notes
+AR_targets,KLK3;KLK2;NKX3-1;HOXB13;FOLH1;TMPRSS2;SLC45A3;NDRG1;PMEPA1;FKBP5,AR-transactivation output panel (collapses in castrate-resistant PRAD)
+HER2_amplicon,ERBB2;GRB7;STARD3;PNMT,17q12 HER2-amplification co-expression panel
+NE_markers,CHGA;SYP;ENO2;INSM1;ASCL1;NCAM1,Neuroendocrine-lineage panel

--- a/pirlygenes/disease_state_rules.py
+++ b/pirlygenes/disease_state_rules.py
@@ -1,0 +1,299 @@
+"""Data-driven disease-state narrative rules (#202).
+
+Replaces the hardcoded ``if cancer_code == "PRAD"`` / ``elif
+cancer_code in ("BRCA",)`` branches in ``cli._synthesize_disease_state``
+with a declarative rule engine. Per-cancer narratives live in
+``disease-state-rules.csv``; named gene sets referenced by the rules
+live in ``narrative-gene-sets.csv``.
+
+The uniformity principle: every cancer type runs through the same
+synthesis loop. Differences between cancers live in data, not in
+code branches. Adding a new cancer narrative means adding a CSV row,
+not touching Python.
+
+Rule record
+-----------
+- ``rule_id`` — stable identifier for the rule
+- ``cancer_code`` — specific code (e.g. ``PRAD``) or ``pan_cancer``
+  (applies to every sample)
+- ``priority`` — lower = more specific / evaluated earlier
+- ``claims`` — optional concept name; when a rule fires, any
+  lower-priority rule that claims the same concept is skipped. This
+  expresses mutual-exclusion: ``prad_crpc_with_ne``, ``prad_crpc``,
+  and ``prad_ar_suppressed`` all claim ``AR_axis`` so the most-
+  specific matching rule wins.
+- ``conditions`` — pipe-separated AND expression. Tokens:
+    * ``axis:<axis_name>=<state>`` — the axis's state must equal
+      ``<state>`` (e.g. ``axis:AR_signaling=down``)
+    * ``retained:<gene_or_set>`` — a single gene or any member of a
+      named gene set is in the ``retained`` set
+    * ``retained_all:<set>`` — every member of a named set is
+      retained
+    * ``collapsed:<gene_or_set>`` — single gene or any member of a
+      named set is collapsed
+    * ``collapsed_ge:<N>=<set>`` — at least N members of a named set
+      are collapsed
+- ``narrative`` — emit string with optional ``{collapsed:<set>}`` /
+  ``{retained:<set>}`` placeholders rendered as comma-joined lists
+
+The engine is pure and stateless: ``synthesize_disease_state`` takes
+the three inputs a narrative rule could possibly consult (axis
+states, retained genes, collapsed genes) plus the cancer code, and
+returns a single concatenated string.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+from .load_dataset import get_data
+
+
+# ── Data loaders ──────────────────────────────────────────────────────
+
+
+@lru_cache(maxsize=1)
+def narrative_gene_sets() -> dict[str, tuple[str, ...]]:
+    """Return ``{set_name: tuple[str]}`` from ``narrative-gene-sets.csv``."""
+    df = get_data("narrative-gene-sets")
+    out: dict[str, tuple[str, ...]] = {}
+    for _, row in df.iterrows():
+        name = str(row.get("set_name") or "").strip()
+        members = str(row.get("members") or "")
+        parsed = tuple(m.strip() for m in members.split(";") if m.strip())
+        if name and parsed:
+            out[name] = parsed
+    return out
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    cancer_code: str
+    priority: int
+    claims: str | None
+    conditions_raw: str
+    narrative: str
+
+
+@lru_cache(maxsize=1)
+def _all_rules() -> tuple[Rule, ...]:
+    df = get_data("disease-state-rules")
+    rules: list[Rule] = []
+    for _, row in df.iterrows():
+        rule_id = str(row.get("rule_id") or "").strip()
+        if not rule_id:
+            continue
+        cancer_code = str(row.get("cancer_code") or "").strip()
+        priority = int(row.get("priority") or 100)
+        claims_val = str(row.get("claims") or "").strip() or None
+        conditions = str(row.get("conditions") or "").strip()
+        narrative = str(row.get("narrative") or "").strip()
+        rules.append(
+            Rule(
+                rule_id=rule_id,
+                cancer_code=cancer_code,
+                priority=priority,
+                claims=claims_val,
+                conditions_raw=conditions,
+                narrative=narrative,
+            )
+        )
+    return tuple(rules)
+
+
+# ── Condition DSL ─────────────────────────────────────────────────────
+
+
+_COND_RE = re.compile(
+    r"^(?P<op>[a-z_]+)(?::(?P<arg1>[^=]+))?(?:=(?P<arg2>.+))?$",
+)
+
+
+def _resolve_gene_or_set(token: str) -> tuple[str, ...]:
+    """Token is either a literal gene symbol or a named gene set.
+    Returns the tuple of gene symbols to check."""
+    sets = narrative_gene_sets()
+    if token in sets:
+        return sets[token]
+    return (token,)
+
+
+def _evaluate_condition(
+    condition_str: str,
+    axis_states: dict[str, str | None],
+    retained: set[str],
+    collapsed: set[str],
+) -> bool:
+    """Evaluate a single condition token against the context.
+
+    Token grammar (see module docstring for full list)::
+
+        axis:<name>=<state>
+        retained:<gene_or_set>
+        retained_all:<set>
+        collapsed:<gene_or_set>
+        collapsed_ge:<N>=<set>
+    """
+    cond = condition_str.strip()
+    if not cond:
+        return True
+
+    # axis:NAME=STATE
+    if cond.startswith("axis:"):
+        payload = cond[len("axis:"):]
+        if "=" not in payload:
+            return False
+        axis_name, state = payload.split("=", 1)
+        observed = axis_states.get(axis_name.strip())
+        return observed == state.strip()
+
+    # retained:TOKEN  (any-of if TOKEN is a set)
+    if cond.startswith("retained:"):
+        token = cond[len("retained:"):].strip()
+        genes = _resolve_gene_or_set(token)
+        return any(g in retained for g in genes)
+
+    # retained_all:SET
+    if cond.startswith("retained_all:"):
+        token = cond[len("retained_all:"):].strip()
+        genes = _resolve_gene_or_set(token)
+        return all(g in retained for g in genes)
+
+    # collapsed:TOKEN  (any-of if TOKEN is a set)
+    if cond.startswith("collapsed:"):
+        token = cond[len("collapsed:"):].strip()
+        genes = _resolve_gene_or_set(token)
+        return any(g in collapsed for g in genes)
+
+    # collapsed_ge:N=SET
+    if cond.startswith("collapsed_ge:"):
+        payload = cond[len("collapsed_ge:"):].strip()
+        if "=" not in payload:
+            return False
+        n_str, set_name = payload.split("=", 1)
+        try:
+            n = int(n_str)
+        except ValueError:
+            return False
+        genes = _resolve_gene_or_set(set_name.strip())
+        return sum(1 for g in genes if g in collapsed) >= n
+
+    # Unknown token — fail closed so bad CSVs surface in tests.
+    return False
+
+
+def _conditions_match(
+    conditions_raw: str,
+    axis_states: dict[str, str | None],
+    retained: set[str],
+    collapsed: set[str],
+) -> bool:
+    """Pipe-separated AND. Every subcondition must match."""
+    for part in conditions_raw.split("|"):
+        if not _evaluate_condition(part, axis_states, retained, collapsed):
+            return False
+    return True
+
+
+# ── Template rendering ────────────────────────────────────────────────
+
+
+_TEMPLATE_RE = re.compile(r"\{(?P<op>retained|collapsed):(?P<set_name>[^}]+)\}")
+
+
+def _render_narrative(
+    narrative: str,
+    retained: set[str],
+    collapsed: set[str],
+) -> str:
+    """Expand ``{retained:SET}`` / ``{collapsed:SET}`` placeholders.
+
+    Renders the intersection of the named set's members with the
+    corresponding bucket, in the order declared in the gene-set CSV.
+    """
+    sets = narrative_gene_sets()
+
+    def replace(match: re.Match) -> str:
+        op = match.group("op")
+        set_name = match.group("set_name").strip()
+        members = sets.get(set_name, ())
+        if op == "retained":
+            matched = [g for g in members if g in retained]
+        else:  # collapsed
+            matched = [g for g in members if g in collapsed]
+        return ", ".join(matched)
+
+    return _TEMPLATE_RE.sub(replace, narrative)
+
+
+# ── Public API ────────────────────────────────────────────────────────
+
+
+def _rules_for_cancer(cancer_code: str | None) -> list[Rule]:
+    """Return rules applicable to this cancer, sorted by priority
+    ascending. Includes ``pan_cancer`` rules regardless of code."""
+    rules = _all_rules()
+    out = []
+    for r in rules:
+        if r.cancer_code == "pan_cancer":
+            out.append(r)
+        elif cancer_code and r.cancer_code == cancer_code:
+            out.append(r)
+    return sorted(out, key=lambda r: r.priority)
+
+
+def synthesize_disease_state(
+    cancer_code: str | None,
+    axis_states: dict[str, str | None],
+    retained: Iterable[str],
+    collapsed: Iterable[str],
+) -> str:
+    """Return the composed disease-state narrative.
+
+    Parameters
+    ----------
+    cancer_code : str or None
+        TCGA code (PRAD, BRCA, SARC, ...). Determines which
+        cancer-specific rules are in scope in addition to pan-cancer
+        rules.
+    axis_states : dict[str, str | None]
+        Map from therapy-axis name (``AR_signaling``, ``EMT``,
+        ``hypoxia``, ...) to the axis's state string (``"up"``,
+        ``"down"``, ``"intact"``, ``None``).
+    retained : iterable[str]
+        Gene symbols classified as lineage-retained (purity ≥ 0.30).
+    collapsed : iterable[str]
+        Gene symbols classified as lineage-collapsed (purity < 0.05).
+
+    Returns
+    -------
+    str
+        Space-joined narrative. Empty string when no rule matches.
+    """
+    retained_set = set(retained)
+    collapsed_set = set(collapsed)
+    rules = _rules_for_cancer(cancer_code)
+
+    claimed: set[str] = set()
+    parts: list[str] = []
+    for rule in rules:
+        if rule.claims and rule.claims in claimed:
+            continue
+        if _conditions_match(
+            rule.conditions_raw,
+            axis_states,
+            retained_set,
+            collapsed_set,
+        ):
+            rendered = _render_narrative(
+                rule.narrative, retained_set, collapsed_set,
+            )
+            if rendered:
+                parts.append(rendered)
+            if rule.claims:
+                claimed.add(rule.claims)
+    return " ".join(parts)

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -1805,3 +1805,73 @@ def cancer_key_genes_subtypes(cancer_code):
         sub["subtype"].fillna("").astype(str).replace("nan", "").str.strip()
     )
     return sorted(s for s in set(subtypes) if s)
+
+
+# ── #202 narrative gene sets + #198 degenerate-pair / fusion-surrogate
+# public exposure. These CSVs are already auto-loaded by
+# ``load_dataset.get_data``; re-exporting the high-level accessors
+# here so ``pirlygenes.gene_sets_cancer`` is the single discovery
+# surface for every curated gene set bundled with the package.
+
+
+def narrative_gene_sets_df():
+    """Return the raw ``narrative-gene-sets.csv`` DataFrame.
+
+    Columns: ``set_name``, ``members`` (``;``-delimited), ``notes``.
+    Each row is a named gene set referenced by the #202 disease-state
+    rule engine (``AR_targets``, ``HER2_amplicon``, ``NE_markers``,
+    ...). Use :func:`narrative_gene_set` to look up members by name.
+    """
+    from .disease_state_rules import narrative_gene_sets
+    sets = narrative_gene_sets()
+    import pandas as pd
+    rows = [
+        {"set_name": name, "members": ";".join(members)}
+        for name, members in sets.items()
+    ]
+    return pd.DataFrame(rows)
+
+
+def narrative_gene_set(set_name):
+    """Return the tuple of gene symbols in a named narrative set, or
+    ``()`` when unknown. Case-sensitive."""
+    from .disease_state_rules import narrative_gene_sets
+    return narrative_gene_sets().get(set_name, ())
+
+
+def narrative_gene_set_names():
+    """Return the list of known narrative gene-set names."""
+    from .disease_state_rules import narrative_gene_sets
+    return sorted(narrative_gene_sets().keys())
+
+
+def degenerate_subtype_pairs_df():
+    """Return the parsed ``degenerate-subtype-pairs.csv`` DataFrame
+    (#198). Members are lists of subtype codes, mappings are dicts,
+    activation_signatures are ``{gene: min_tpm}`` dicts."""
+    from .degenerate_subtype import degenerate_subtype_pairs
+    return degenerate_subtype_pairs()
+
+
+def fusion_surrogate_expression_df():
+    """Return the raw ``fusion-surrogate-expression.csv`` DataFrame
+    (#198) — genes whose expression serves as a deterministic
+    surrogate for a specific fusion/translocation class."""
+    from .degenerate_subtype import fusion_surrogate_expression
+    return fusion_surrogate_expression()
+
+
+def fusion_surrogate_genes_for_cancer(cancer_code):
+    """Return the list of ``{gene, fusion_class, role, rationale}``
+    dicts applicable to a cancer code (includes ``pan_cancer``
+    entries)."""
+    from .degenerate_subtype import fusion_surrogate_genes_for
+    return fusion_surrogate_genes_for(cancer_code)
+
+
+def disease_state_rules_df():
+    """Return the raw ``disease-state-rules.csv`` DataFrame (#202) —
+    declarative per-cancer narrative rules consumed by
+    ``compose_disease_state_narrative``."""
+    from .load_dataset import get_data
+    return get_data("disease-state-rules")

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.49.1"
+__version__ = "4.49.2"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_disease_state_rules.py
+++ b/tests/test_disease_state_rules.py
@@ -1,0 +1,344 @@
+"""Tests for the data-driven disease-state narrative engine (#202).
+
+Pins the narratives previously produced by the hardcoded PRAD / BRCA
+branches in ``cli._synthesize_disease_state``, plus the pan-cancer
+EMT/hypoxia/IFN rules. Also exercises the rule engine primitives
+(condition DSL, template rendering, priority/claims) so regressions
+in the engine surface independently of the catalog content.
+"""
+
+import pandas as pd
+
+from pirlygenes.disease_state_rules import (
+    _all_rules,
+    _conditions_match,
+    _render_narrative,
+    narrative_gene_sets,
+    synthesize_disease_state,
+)
+
+
+# ── Data loading ─────────────────────────────────────────────────────
+
+
+def test_narrative_gene_sets_loads():
+    sets = narrative_gene_sets()
+    # AR_targets is the validation anchor for CRPC pattern detection
+    # and must not drift silently. The 10-gene panel is the one the
+    # hardcoded cli code used pre-#202.
+    assert "AR_targets" in sets
+    ar_targets = set(sets["AR_targets"])
+    for g in (
+        "KLK3", "KLK2", "NKX3-1", "HOXB13", "FOLH1",
+        "TMPRSS2", "SLC45A3", "NDRG1", "PMEPA1", "FKBP5",
+    ):
+        assert g in ar_targets, f"AR_targets missing {g}"
+    # HER2 amplicon panel used by the BRCA rule's narrative string.
+    assert "HER2_amplicon" in sets
+    assert "ERBB2" in sets["HER2_amplicon"]
+
+
+def test_rule_csv_loads_and_priority_order():
+    rules = _all_rules()
+    assert len(rules) >= 6
+    # Pan-cancer rules and cancer-specific rules coexist.
+    cancers = {r.cancer_code for r in rules}
+    assert "pan_cancer" in cancers
+    assert "PRAD" in cancers
+    assert "BRCA" in cancers
+
+
+# ── Condition DSL ────────────────────────────────────────────────────
+
+
+def test_axis_state_condition():
+    assert _conditions_match(
+        "axis:AR_signaling=down",
+        {"AR_signaling": "down"},
+        retained=set(), collapsed=set(),
+    )
+    assert not _conditions_match(
+        "axis:AR_signaling=down",
+        {"AR_signaling": "up"},
+        retained=set(), collapsed=set(),
+    )
+    # Missing axis reads as None and fails.
+    assert not _conditions_match(
+        "axis:AR_signaling=down",
+        {}, retained=set(), collapsed=set(),
+    )
+
+
+def test_retained_and_collapsed_tokens():
+    # retained:<gene> — single gene
+    assert _conditions_match(
+        "retained:AR",
+        axis_states={}, retained={"AR"}, collapsed=set(),
+    )
+    # retained:<set_name> — any-of semantics
+    assert _conditions_match(
+        "retained:AR_targets",
+        axis_states={}, retained={"KLK3"}, collapsed=set(),
+    )
+    # collapsed:<gene>
+    assert _conditions_match(
+        "collapsed:ESR1",
+        axis_states={}, retained=set(), collapsed={"ESR1"},
+    )
+    # collapsed_ge:N=SET
+    assert _conditions_match(
+        "collapsed_ge:3=AR_targets",
+        axis_states={}, retained=set(),
+        collapsed={"KLK3", "KLK2", "FKBP5"},
+    )
+    assert not _conditions_match(
+        "collapsed_ge:3=AR_targets",
+        axis_states={}, retained=set(),
+        collapsed={"KLK3", "KLK2"},  # only 2
+    )
+
+
+def test_pipe_is_and_all_subconditions_must_match():
+    """Pipe separator means AND; every subcondition must match."""
+    condition = (
+        "axis:AR_signaling=down | retained:AR | collapsed_ge:3=AR_targets"
+    )
+    axis = {"AR_signaling": "down"}
+    # All three met
+    assert _conditions_match(
+        condition, axis, {"AR"}, {"KLK3", "KLK2", "FKBP5", "TMPRSS2"},
+    )
+    # AR_signaling missing
+    assert not _conditions_match(
+        condition, {}, {"AR"}, {"KLK3", "KLK2", "FKBP5"},
+    )
+    # AR not retained
+    assert not _conditions_match(
+        condition, axis, set(), {"KLK3", "KLK2", "FKBP5"},
+    )
+
+
+def test_unknown_token_fails_closed():
+    """Typos in CSVs must fail the match, not silently pass."""
+    assert not _conditions_match(
+        "unknown_op:AR", {}, set(), set(),
+    )
+
+
+# ── Template rendering ───────────────────────────────────────────────
+
+
+def test_collapsed_placeholder_expands_in_declared_order():
+    """Placeholders render members in the gene-set's declared order
+    (not set-iteration order, which is nondeterministic)."""
+    collapsed = {"TMPRSS2", "KLK3", "KLK2"}
+    out = _render_narrative(
+        "targets ({collapsed:AR_targets}) are collapsed",
+        retained=set(), collapsed=collapsed,
+    )
+    # CSV order is KLK3;KLK2;NKX3-1;HOXB13;FOLH1;TMPRSS2;... so the
+    # rendered list should follow that order for the subset present.
+    assert "KLK3, KLK2, TMPRSS2" in out
+
+
+def test_retained_placeholder_expands():
+    out = _render_narrative(
+        "retained: {retained:AR_targets}",
+        retained={"KLK3"}, collapsed=set(),
+    )
+    assert "retained: KLK3" in out
+
+
+def test_empty_placeholder_renders_empty_string():
+    out = _render_narrative(
+        "({collapsed:AR_targets})",
+        retained=set(), collapsed=set(),
+    )
+    assert out == "()"
+
+
+# ── Cancer-specific narrative synthesis ──────────────────────────────
+
+
+def test_prad_castrate_resistant_narrative():
+    """Tempus-PRAD validation case: AR retained + AR-target panel
+    collapsed + AR axis down → textbook castrate-resistant narrative."""
+    result = synthesize_disease_state(
+        cancer_code="PRAD",
+        axis_states={"AR_signaling": "down", "NE_differentiation": None},
+        retained={"AR"},
+        collapsed={"KLK3", "KLK2", "FKBP5", "TMPRSS2", "NKX3-1"},
+    )
+    assert "Castrate-resistant pattern" in result
+    assert "KLK3" in result  # collapsed targets rendered
+    assert "prior ADT exposure" in result
+
+
+def test_prad_castrate_resistant_with_ne_emerges():
+    """Same as above + NE axis up → emerging-NEPC narrative."""
+    result = synthesize_disease_state(
+        cancer_code="PRAD",
+        axis_states={"AR_signaling": "down", "NE_differentiation": "up"},
+        retained={"AR"},
+        collapsed={"KLK3", "KLK2", "FKBP5", "TMPRSS2", "NKX3-1"},
+    )
+    assert "emerging neuroendocrine differentiation" in result
+    assert "NEPC" in result
+
+
+def test_prad_ar_suppressed_fallback():
+    """AR axis down but AR not retained → "AR axis suppressed"
+    fallback narrative (the castrate-resistant rules don't match)."""
+    result = synthesize_disease_state(
+        cancer_code="PRAD",
+        axis_states={"AR_signaling": "down"},
+        retained=set(),  # AR NOT retained
+        collapsed={"KLK3"},  # only one collapsed, fails the >=3 rule
+    )
+    assert "AR axis suppressed" in result
+    # And the more-specific castrate-resistant narrative didn't fire
+    assert "Castrate-resistant pattern" not in result
+
+
+def test_prad_claims_prevents_double_emit():
+    """Priority + claims: when castrate-resistant rule fires, the
+    lower-priority AR-suppressed rule must NOT also emit — both claim
+    ``AR_axis``."""
+    result = synthesize_disease_state(
+        cancer_code="PRAD",
+        axis_states={"AR_signaling": "down"},
+        retained={"AR"},
+        collapsed={"KLK3", "KLK2", "FKBP5"},
+    )
+    assert "Castrate-resistant pattern" in result
+    assert "AR axis suppressed" not in result
+
+
+def test_brca_her2_amplification_pattern():
+    result = synthesize_disease_state(
+        cancer_code="BRCA",
+        axis_states={"HER2_signaling": "up"},
+        retained=set(),
+        collapsed=set(),
+    )
+    assert "HER2-amplification pattern" in result
+
+
+def test_brca_er_suppressed_pattern():
+    result = synthesize_disease_state(
+        cancer_code="BRCA",
+        axis_states={"ER_signaling": "down"},
+        retained=set(),
+        collapsed={"ESR1"},
+    )
+    assert "ER-axis suppressed" in result
+    assert "ESR1" in result
+
+
+# ── Pan-cancer rules ─────────────────────────────────────────────────
+
+
+def test_pan_emt_hypoxia_claims_emt_axis():
+    """When both EMT + hypoxia are up, the combined narrative fires;
+    the lower-priority EMT-only rule must NOT also fire."""
+    result = synthesize_disease_state(
+        cancer_code="SARC",
+        axis_states={"EMT": "up", "hypoxia": "up"},
+        retained=set(),
+        collapsed=set(),
+    )
+    assert "EMT and hypoxia programs are both active" in result
+    assert "mesenchymal switch" not in result
+
+
+def test_pan_emt_only_fires_when_hypoxia_absent():
+    result = synthesize_disease_state(
+        cancer_code="SARC",
+        axis_states={"EMT": "up", "hypoxia": None},
+        retained=set(),
+        collapsed=set(),
+    )
+    assert "EMT program is active (mesenchymal switch)" in result
+
+
+def test_pan_ifn_fires_on_any_cancer():
+    """IFN rule has no ``cancer_code`` restriction — applies to every
+    sample whose IFN_response axis is up."""
+    result = synthesize_disease_state(
+        cancer_code="READ",
+        axis_states={"IFN_response": "up"},
+        retained=set(), collapsed=set(),
+    )
+    assert "Active IFN response" in result
+
+
+def test_pan_rules_apply_even_without_cancer_code():
+    """Pan-cancer rules must fire for the ``None`` cancer_code case
+    (e.g. when the classifier couldn't commit to a code)."""
+    result = synthesize_disease_state(
+        cancer_code=None,
+        axis_states={"IFN_response": "up"},
+        retained=set(), collapsed=set(),
+    )
+    assert "Active IFN response" in result
+
+
+# ── Uniformity / regression ──────────────────────────────────────────
+
+
+def test_unknown_cancer_code_runs_only_pan_cancer_rules():
+    """A cancer the catalog doesn't name should still get pan-cancer
+    narratives — no silent skip."""
+    result = synthesize_disease_state(
+        cancer_code="NUTM",  # not referenced in disease-state-rules.csv
+        axis_states={"EMT": "up"},
+        retained=set(), collapsed=set(),
+    )
+    assert "EMT program is active" in result
+
+
+def test_empty_axes_empty_result():
+    result = synthesize_disease_state(
+        cancer_code="PRAD",
+        axis_states={},
+        retained=set(), collapsed=set(),
+    )
+    assert result == ""
+
+
+def test_every_rule_id_and_cancer_code_valid():
+    """Catch malformed rows in the CSV."""
+    rules = _all_rules()
+    seen_ids = set()
+    for r in rules:
+        assert r.rule_id and r.rule_id not in seen_ids, (
+            f"rule_id {r.rule_id!r} is empty or duplicate"
+        )
+        seen_ids.add(r.rule_id)
+        assert r.cancer_code, f"rule {r.rule_id} has empty cancer_code"
+        assert r.narrative, f"rule {r.rule_id} has empty narrative"
+
+
+def test_no_prad_ar_target_genes_hardcoded_anymore():
+    """Ensure the old frozenset ``_PRAD_AR_TARGET_GENES`` is gone.
+    If someone reinstates it they bring back the asymmetry this PR
+    was trying to remove."""
+    from pirlygenes import cli
+    assert not hasattr(cli, "_PRAD_AR_TARGET_GENES"), (
+        "Hardcoded PRAD AR target set re-appeared in cli; move it to "
+        "narrative-gene-sets.csv per #202."
+    )
+
+
+def test_narrative_gene_sets_csv_headers():
+    """Schema contract for the gene-sets CSV — no silent drift."""
+    df = pd.read_csv("pirlygenes/data/narrative-gene-sets.csv")
+    assert set(df.columns) >= {"set_name", "members"}
+
+
+def test_disease_state_rules_csv_headers():
+    df = pd.read_csv("pirlygenes/data/disease-state-rules.csv")
+    assert set(df.columns) == {
+        "rule_id", "cancer_code", "priority", "claims",
+        "conditions", "narrative",
+    }


### PR DESCRIPTION
## Summary

Removes the last two cancer-specific \`if cancer_code == ...\` code branches in the analyze pipeline and replaces them with a declarative, data-driven rule engine. Per-cancer narratives now live in data, not Python.

## What changed

### Data files (new)
- \`pirlygenes/data/disease-state-rules.csv\` — 8 rules covering every narrative the old hardcoded synthesizer produced (PRAD castrate-resistant + optional NE; PRAD AR-suppressed fallback; BRCA ER-suppressed; BRCA HER2-amp; pan-cancer EMT+hypoxia; pan-cancer EMT-only; pan-cancer IFN). Each row: \`rule_id, cancer_code, priority, claims, conditions, narrative\`.
- \`pirlygenes/data/narrative-gene-sets.csv\` — named gene sets (\`AR_targets\`, \`HER2_amplicon\`, \`NE_markers\`) referenced by condition tokens and narrative templates. Replaces the private \`_PRAD_AR_TARGET_GENES\` frozenset in \`cli.py\`.

### Engine (new)
- \`pirlygenes/disease_state_rules.py\` — pure stateless rule loader + DSL parser + template renderer + \`synthesize_disease_state()\`.

### Condition DSL
Pipe-separated AND. Tokens:
- \`axis:<name>=<state>\` — axis state match
- \`retained:<gene_or_set>\` / \`retained_all:<set>\` — gene or any/all members of named set in the lineage-retained bucket
- \`collapsed:<gene_or_set>\` / \`collapsed_ge:N=<set>\` — single gene / any member / at least N members in the collapsed bucket

### Template placeholders
\`{retained:<set>}\` / \`{collapsed:<set>}\` — expand to comma-joined intersection with the gene set, in declared order.

### Priority + claims
Lower priority wins. When a rule fires, any lower-priority rule that declares the same \`claims\` concept is skipped. This expresses "castrate-resistant" preempts "AR-suppressed fallback" without imperative code.

## Public API
The new catalogs are first-class, discoverable via \`pirlygenes.gene_sets_cancer\`:
- \`narrative_gene_set(name)\` / \`narrative_gene_set_names()\` / \`narrative_gene_sets_df()\`
- \`disease_state_rules_df()\`
- Plus re-exports of \`degenerate_subtype_pairs_df()\` / \`fusion_surrogate_expression_df()\` / \`fusion_surrogate_genes_for_cancer()\` from #198, for unified discovery of all bundled catalogs.

## Drive-by bug fix
\`pirlygenes data\` crashed with \`FileNotFoundError: ADC-approved.csv\` unless cwd was \`pirlygenes/data/\` — it was passing the bare CSV basename to \`os.path.getsize\`. Now uses the full path. \`pirlygenes data\` lists all 43 bundled CSVs with source descriptions including the four new catalogs.

## Validation

- rs sample (PRAD ADT-exposed, ~20% pure) continues to render the exact same disease-state narrative as before the refactor: \`**AR axis suppressed** — consistent with ADT exposure. Lineage AR was not retained in the sample; insufficient signal for a castrate-resistant call. EMT and hypoxia programs are both active — aggressive-phenotype pattern. **Active IFN response** — MHC-I / ISG surface fold-changes...\`.

## Test plan
- [x] \`pytest tests/test_disease_state_rules.py\` — 25 tests (condition DSL, template rendering, priority+claims mutual exclusion, cancer-specific regression pins, pan-cancer rule coverage, uniformity assertions including \`_PRAD_AR_TARGET_GENES\` no longer exists in cli)
- [x] Full suite: 755 passed, 1 skipped
- [x] \`ruff check\` clean
- [x] \`pirlygenes data\` runs cleanly from any cwd and lists new catalogs

## Relationship to other open PRs
- #200 (registry essentials) and #201 (degenerate-subtype) are independent; version bumps will need to resolve on rebase — whichever lands last settles to the next patch.