### PR TITLE
fix(plot): honest 'n/a' for zero-marker compartments + PDF source-filename captions

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1855,7 +1855,7 @@ def _analyze_body(
 
     # Collect all figures into one PDF (native resolution)
     from pathlib import Path
-    from PIL import Image
+    from PIL import Image, ImageDraw, ImageFont
 
     all_pdf = "%s-all-figures.pdf" % prefix if prefix else "all-figures.pdf"
     print("[output] Collecting figures into PDF...")
@@ -1913,6 +1913,35 @@ def _analyze_body(
         if Path(adj_p).exists():
             png_files.append(adj_p)
 
+    def _with_filename_caption(img, filename):
+        """Add a light-gray filename caption in a small strip below
+        the figure so readers can locate the source PNG later. Caption
+        sits in its own strip so it never overlaps the plot."""
+        caption_h = 18
+        new_w, new_h = img.width, img.height + caption_h
+        canvas = Image.new("RGB", (new_w, new_h), color="white")
+        canvas.paste(img, (0, 0))
+        draw = ImageDraw.Draw(canvas)
+        try:
+            font = ImageFont.load_default()
+        except Exception:
+            font = None
+        # Bottom-right, light gray.
+        text = filename
+        if font is not None:
+            try:
+                bbox = draw.textbbox((0, 0), text, font=font)
+                tw = bbox[2] - bbox[0]
+            except AttributeError:  # pragma: no cover — very old PIL
+                tw = len(text) * 6
+        else:
+            tw = len(text) * 6
+        draw.text(
+            (max(4, new_w - tw - 8), img.height + 3),
+            text, fill="#AAAAAA", font=font,
+        )
+        return canvas
+
     images = []
     for png_path in png_files:
         if not png_path:
@@ -1920,7 +1949,7 @@ def _analyze_body(
         p = Path(png_path)
         if p.exists():
             img = Image.open(p).convert("RGB")
-            images.append(img)
+            images.append(_with_filename_caption(img, p.name))
 
     if images:
         images[0].save(all_pdf, save_all=True, append_images=images[1:], resolution=output_dpi)

--- a/pirlygenes/decomposition/plot.py
+++ b/pirlygenes/decomposition/plot.py
@@ -63,7 +63,15 @@ def _render_component_breakdown(ax, best, title="TME cell-type breakdown"):
     for idx, row in comp_df.iterrows():
         if row["fraction"] < 0.005:
             continue  # skip labels for sub-0.5% components (#96)
-        txt = f"{row['marker_score']:.2f}" if row["marker_score"] is not None else "n/a"
+        # A marker_score of 0.00 with n_markers=0 means the compartment
+        # had no markers to evaluate (typical for matched-normal
+        # compartments in mixture-cohort templates). Showing "0.00"
+        # reads as a bad fit; "n/a" is more honest.
+        n_markers = int(row.get("n_markers") or 0)
+        if n_markers == 0 or row["marker_score"] is None:
+            txt = "n/a"
+        else:
+            txt = f"{row['marker_score']:.2f}"
         ax.text(row["fraction"] * 100 + 0.8, idx, txt, va="center", fontsize=8)
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.49.2"
+__version__ = "4.49.3"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary
Two small polish fixes noticed while reading rs output:

1. **TME cell-type breakdown bar**: compartments with \`n_markers=0\` (typical for matched-normal in mixture-cohort templates) were labelled with \`marker_score=0.00\` — reads as a bad fit even though no markers were evaluated. Now renders \`n/a\`.
2. **sample-all-figures.pdf**: adds a light-gray source-filename caption in a small strip below each page so readers can locate the source PNG later. Dedicated strip so captions never overlap the plot.

Also version bump 4.49.1 → 4.49.2.

## Test plan
- [x] ruff clean; decomposition + plot+cli targeted tests pass (64 tests)