### PR TITLE
feat(decomp): proxy cell-type mappings for gap tissues + coverage contract (#214)

### DIFF
--- a/pirlygenes/decomposition/signature.py
+++ b/pirlygenes/decomposition/signature.py
@@ -112,15 +112,18 @@ MATCHED_NORMAL_CELL_TYPE = {
     "breast": ["Breast glandular cells"],
     "liver": ["Hepatocytes"],
     "gallbladder": ["Cholangiocytes"],
+    "bile_duct": ["Cholangiocytes"],  # registry key for CHOL
     "pancreas": ["Ductal cells"],
     "kidney": ["Proximal tubular cells"],
     "lung": ["Alveolar cells type 2", "Club cells"],
+    "pleura": ["Mesothelial cells"],  # MESO registry key
     "stomach": ["Gastric mucus-secreting cells"],
     "ovary": ["Granulosa cells"],
     "testis": ["Spermatocytes", "Sertoli cells"],
     "endometrium": ["Glandular and luminal cells"],
     "salivary_gland": ["Salivary duct cells", "Serous glandular cells"],
     "retina": ["Rod photoreceptor cells", "Cone photoreceptor cells"],
+    "eye": ["Melanocytes"],  # UVM arises in uveal melanocytes
     "cerebrum": ["Astrocytes"],
     "cerebellum": ["Astrocytes"],
     "skeletal_muscle": ["Skeletal myocytes"],
@@ -129,15 +132,122 @@ MATCHED_NORMAL_CELL_TYPE = {
     # colon / rectum / esophagus / cervix / tongue / skin / small_intestine
     # left using bulk-tissue fallback for now — their CRC/squamous
     # decomposition tests expect the bulk-reference semantics.
-    # Heme / lymphoid are handled by their dedicated templates
-    # (heme_marrow, heme_nodal, heme_blood) + matched-normal
-    # compartments in those templates are bulk-tissue; expanding
-    # the cell-type map into heme is a separate PR.
-    #
-    # Tissues with no cell-type match (fall back to bulk):
-    # thyroid_gland, urinary_bladder, adrenal_gland, tonsil,
-    # nasopharynx, bone, cartilage, notochord, thymus.
 }
+
+
+# Proxy mappings for tissues without a direct HPA single-cell match.
+# These are imperfect — each entry carries a ``confidence`` score — and
+# are consumed by the ensemble uncertainty scoring (#216) which runs
+# attribution multiple ways and reports inter-method spread. Also
+# consulted at lookup time as a secondary fallback when
+# ``MATCHED_NORMAL_CELL_TYPE`` has no direct match.
+#
+# Confidence scale:
+#   0.8-1.0 : very close lineage match (urothelial ≈ basal squamous)
+#   0.5-0.7 : shared functional axis (chromaffin ≈ pancreatic endocrine
+#             — both NE)
+#   0.3-0.5 : rough proxy (osteoblast ≈ Fibroblasts — same mesenchymal
+#             origin, very different phenotype)
+#   < 0.3   : we don't list it; use bulk fallback instead
+#
+# When ``MATCHED_NORMAL_CELL_TYPE_BLEND`` override is 0 (default),
+# proxies have no runtime effect — they're declarative metadata for
+# the ensemble synthesis plan in #216.
+MATCHED_NORMAL_CELL_TYPE_PROXY = {
+    "thyroid_gland": {
+        "cell_types": ["Serous glandular cells"],
+        "confidence": 0.45,
+        "rationale": "thyroid follicular cells not in HPA; secretory glandular epithelium as functional proxy",
+    },
+    "thyroid": {  # registry key alias for THCA
+        "cell_types": ["Serous glandular cells"],
+        "confidence": 0.45,
+        "rationale": "thyroid follicular cells not in HPA; secretory glandular epithelium as functional proxy",
+    },
+    "pharynx": {  # NPC-adjacent registry key
+        "cell_types": ["Squamous epithelial cells"],
+        "confidence": 0.70,
+        "rationale": "pharyngeal mucosa is predominantly stratified squamous epithelium; covered well by HPA Squamous epithelial cells",
+    },
+    "bladder": {  # registry key alias for BLCA
+        "cell_types": ["Basal squamous epithelial cells"],
+        "confidence": 0.60,
+        "rationale": "urothelial cells not in HPA; basal squamous shares KRT5/6/14 basal-layer phenotype that transitional epithelium expresses",
+    },
+    "thyroid_c_cell": {
+        "cell_types": ["Pancreatic endocrine cells", "Enteroendocrine cells"],
+        "confidence": 0.50,
+        "rationale": "thyroid C-cells (parafollicular / calcitonin+) not in HPA; both pancreatic endocrine and enteroendocrine share the NE-hormone-secreting lineage",
+    },
+    "urinary_bladder": {
+        "cell_types": ["Basal squamous epithelial cells"],
+        "confidence": 0.60,
+        "rationale": "urothelial cells not in HPA; basal squamous shares the KRT5/6/14 basal-layer phenotype that transitional epithelium expresses",
+    },
+    "adrenal_cortex": {
+        "cell_types": ["Hepatocytes"],
+        "confidence": 0.35,
+        "rationale": "adrenocortical steroidogenic cells not in HPA; hepatocytes share steroid / lipid metabolism axis + secretory phenotype; IGF2 is the literature-anchored marker in the curated matched-normal panel",
+    },
+    "adrenal_medulla": {
+        "cell_types": ["Pancreatic endocrine cells", "Excitatory neurons"],
+        "confidence": 0.50,
+        "rationale": "chromaffin cells (PCPG) not in HPA; pancreatic endocrine shares NE-secretory axis; excitatory neurons share sympathetic-lineage neural genes",
+    },
+    "bone": {
+        "cell_types": ["Fibroblasts", "Undifferentiated cells"],
+        "confidence": 0.35,
+        "rationale": "osteoblasts not in HPA; fibroblasts share mesenchymal origin + type I collagen production; osteoblast-specific markers (BGLAP / ALPL / SPP1) handled via COMPONENT_MARKERS[osteoblast]",
+    },
+    "cartilage": {
+        "cell_types": ["Fibroblasts"],
+        "confidence": 0.30,
+        "rationale": "chondrocytes not in HPA; fibroblast proxy captures mesenchymal signature but misses COL2A1 / ACAN / cartilage-specific biology",
+    },
+    "sympathetic_ganglia": {
+        "cell_types": ["Excitatory neurons", "Schwann cells"],
+        "confidence": 0.45,
+        "rationale": "peripheral sympathetic neurons (NBL origin) not in HPA; CNS excitatory neurons share SYP / CHGA / ENO2 neural genes; Schwann cells are the peripheral-nerve-sheath partner",
+    },
+    "thymus": {
+        "cell_types": ["T-cells", "B-cells", "Basal keratinocytes"],
+        "confidence": 0.40,
+        "rationale": "thymic epithelial cells (cortical / medullary TECs, Hassall corpuscles) not in HPA; bulk thymus is dominated by T / B cells anyway; basal keratinocytes partially mimic Hassall-corpuscle keratin signature",
+    },
+    "nasopharynx": {
+        "cell_types": ["Squamous epithelial cells"],
+        "confidence": 0.70,
+        "rationale": "nasopharyngeal mucosa is pseudostratified + squamous; Squamous epithelial cells cover the squamous portion well",
+    },
+    "notochord": {
+        "cell_types": ["Fibroblasts"],
+        "confidence": 0.30,
+        "rationale": "notochord remnant cells (CHOR origin) not in HPA; fibroblast proxy captures mesenchymal ECM signature but misses brachyury-driven notochord biology",
+    },
+    "midline_structures": {
+        "cell_types": ["Squamous epithelial cells"],
+        "confidence": 0.60,
+        "rationale": "NUTM arises in midline mucosal sites (sinonasal / mediastinal / supraglottic); squamous epithelium covers most origin sites; NUTM1-itself is in the fusion-surrogate catalog (#198)",
+    },
+}
+
+
+def get_matched_normal_cell_type(tissue):
+    """Return ``(cell_types, confidence, source)`` for a matched-normal
+    tissue. ``source`` is one of:
+
+    - ``'direct'`` — exact HPA single-cell match (confidence 1.0)
+    - ``'proxy'`` — closest-related proxy (confidence < 1.0; see
+      :data:`MATCHED_NORMAL_CELL_TYPE_PROXY` for rationale)
+    - ``'bulk_fallback'`` — no mapping available; callers should use
+      the bulk ``nTPM_<tissue>`` column from pan-cancer-expression
+    """
+    if tissue in MATCHED_NORMAL_CELL_TYPE:
+        return (MATCHED_NORMAL_CELL_TYPE[tissue], 1.0, "direct")
+    if tissue in MATCHED_NORMAL_CELL_TYPE_PROXY:
+        entry = MATCHED_NORMAL_CELL_TYPE_PROXY[tissue]
+        return (entry["cell_types"], entry["confidence"], "proxy")
+    return ([], 0.0, "bulk_fallback")
 
 
 COMPONENT_MARKERS = {
@@ -313,7 +423,7 @@ def build_signature_matrix(components, gene_subset=None, sample_by_eid=None):
                     .values
                 )
 
-            cell_types = MATCHED_NORMAL_CELL_TYPE.get(tissue) or []
+            cell_types, _proxy_confidence, _source = get_matched_normal_cell_type(tissue)
             present_cell_types = [t for t in cell_types if t in hpa.columns]
             cell_type_vals = None
             if present_cell_types:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.50.5"
+__version__ = "4.50.6"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_matched_normal_cell_type.py
+++ b/tests/test_matched_normal_cell_type.py
@@ -1,0 +1,122 @@
+"""Tests for the cell-type-resolved matched-normal reference map (#214)
+and its proxy extension (#216)."""
+
+from pirlygenes.decomposition.signature import (
+    MATCHED_NORMAL_CELL_TYPE,
+    MATCHED_NORMAL_CELL_TYPE_PROXY,
+    get_matched_normal_cell_type,
+    _load_hpa_cell_types,
+)
+
+
+def test_direct_mappings_hit_real_hpa_cell_types():
+    """Every cell type listed in the direct map must exist in
+    hpa-cell-type-expression.csv — prevents silent typos."""
+    hpa_columns = set(_load_hpa_cell_types().columns)
+    for tissue, cell_types in MATCHED_NORMAL_CELL_TYPE.items():
+        for cell_type in cell_types:
+            assert cell_type in hpa_columns, (
+                f"{tissue!r} → {cell_type!r} not in HPA atlas"
+            )
+
+
+def test_proxy_mappings_hit_real_hpa_cell_types():
+    hpa_columns = set(_load_hpa_cell_types().columns)
+    for tissue, entry in MATCHED_NORMAL_CELL_TYPE_PROXY.items():
+        for cell_type in entry["cell_types"]:
+            assert cell_type in hpa_columns, (
+                f"proxy {tissue!r} → {cell_type!r} not in HPA atlas"
+            )
+
+
+def test_proxy_confidences_in_valid_range():
+    """Proxies must declare confidence in (0, 1); direct entries are
+    implicit 1.0. Anything below 0.3 should have been rejected during
+    curation (use bulk fallback instead)."""
+    for tissue, entry in MATCHED_NORMAL_CELL_TYPE_PROXY.items():
+        confidence = entry["confidence"]
+        assert 0.3 <= confidence < 1.0, (
+            f"proxy {tissue!r} confidence {confidence} out of valid range"
+        )
+
+
+def test_proxy_entries_have_rationale():
+    for tissue, entry in MATCHED_NORMAL_CELL_TYPE_PROXY.items():
+        rationale = entry.get("rationale", "")
+        assert rationale and len(rationale) > 20, (
+            f"proxy {tissue!r} needs a rationale"
+        )
+
+
+def test_get_matched_normal_cell_type_direct():
+    cell_types, confidence, source = get_matched_normal_cell_type("prostate")
+    assert cell_types == ["Prostatic glandular cells"]
+    assert confidence == 1.0
+    assert source == "direct"
+
+
+def test_get_matched_normal_cell_type_proxy():
+    cell_types, confidence, source = get_matched_normal_cell_type("urinary_bladder")
+    assert "Basal squamous epithelial cells" in cell_types
+    assert 0.3 <= confidence < 1.0
+    assert source == "proxy"
+
+
+def test_get_matched_normal_cell_type_unknown_tissue():
+    """Tissues with neither direct nor proxy map return empty +
+    source='bulk_fallback' — callers must fall through to the bulk
+    nTPM column."""
+    cell_types, confidence, source = get_matched_normal_cell_type("xyz_unknown_tissue")
+    assert cell_types == []
+    assert confidence == 0.0
+    assert source == "bulk_fallback"
+
+
+def test_direct_and_proxy_are_disjoint():
+    """A tissue should be in one map or the other, not both —
+    otherwise the ``get_matched_normal_cell_type`` direct-before-proxy
+    precedence hides the proxy."""
+    overlap = set(MATCHED_NORMAL_CELL_TYPE) & set(MATCHED_NORMAL_CELL_TYPE_PROXY)
+    assert not overlap, f"tissues in both maps: {overlap}"
+
+
+def test_all_leaf_tissues_either_covered_or_documented():
+    """Every leaf-cancer ``primary_tissue`` should either (a) have
+    a direct cell-type match, (b) have a proxy entry, or (c) be
+    explicitly known to fall back to bulk. Catches new registry
+    tissues that silently regress to bulk without justification."""
+    from pirlygenes.gene_sets_cancer import cancer_type_registry
+    reg = cancer_type_registry()
+    leaf = reg[reg["parent_code"].fillna("").astype(str).eq("")]
+    all_tissues = set(leaf["primary_tissue"].dropna().astype(str))
+
+    covered = set(MATCHED_NORMAL_CELL_TYPE) | set(MATCHED_NORMAL_CELL_TYPE_PROXY)
+
+    # Tissues that deliberately fall back to bulk (matched-normal
+    # isn't expected to have a single-cell reference — e.g. heme
+    # tissues are handled by dedicated heme templates, colon/rectum
+    # left on bulk by choice during v4.50.5 roll-out, etc).
+    _ACKNOWLEDGED_BULK_FALLBACK = {
+        "peripheral_blood",  # blood tumors: heme template uses bulk lymph
+        "lymph_node", "spleen", "spleen_marrow", "bone_marrow",
+        "soft_tissue",       # SARC umbrella — dispatched via subtype
+        "", "nan", "NaN",    # registry junk
+        # The following are in MATCHED_NORMAL_CELL_TYPE_BLEND=0 v4.50.5
+        # list — left on bulk until their synthetic tests are updated:
+        "colon", "rectum", "esophagus", "cervix", "tongue", "skin",
+        "small_intestine",
+        # Head-neck region not yet mapped — HNSC uses tongue (already
+        # acknowledged-bulk), NPC → proxy above, oral/laryngeal
+        # composites not yet broken out in registry:
+        "head_neck", "oral", "oropharynx", "larynx",
+        # Cerebellum and CNS subtypes covered by "cerebellum" /
+        # "cerebrum" in the direct map; other CNS subtissues fall
+        # back transparently.
+        # Kidney composite for pediatric:
+        "kidney_cns_soft",
+    }
+    uncovered = all_tissues - covered - _ACKNOWLEDGED_BULK_FALLBACK
+    assert not uncovered, (
+        f"registry tissues with no cell-type mapping and not in the "
+        f"acknowledged-bulk-fallback allowlist: {sorted(uncovered)}"
+    )


### PR DESCRIPTION
## Summary
Stacks on #215. Adds proxy mappings for the 12 tissues without a direct HPA single-cell match + three direct-mapping additions (bile_duct, pleura, eye).

## Proxies (each with confidence + rationale)

| Tissue | Proxy | Confidence | Rationale |
|---|---|---|---|
| thyroid / thyroid_gland | Serous glandular cells | 0.45 | thyroid follicular not in HPA; secretory glandular functional match |
| thyroid_c_cell | Pancreatic endocrine + Enteroendocrine | 0.50 | C-cells not in HPA; shared NE-hormone-secreting lineage |
| bladder / urinary_bladder | Basal squamous epithelial cells | 0.60 | urothelial shares KRT5/6/14 basal phenotype |
| adrenal_cortex | Hepatocytes | 0.35 | steroidogenic + lipid metabolism axis |
| adrenal_medulla | Pancreatic endocrine + Excitatory neurons | 0.50 | NE + sympathetic lineage |
| bone | Fibroblasts + Undifferentiated | 0.35 | mesenchymal + collagen overlap |
| cartilage | Fibroblasts | 0.30 | mesenchymal only — COL2A1/ACAN missed |
| sympathetic_ganglia | Excitatory neurons + Schwann | 0.45 | neural lineage |
| thymus | T-cells + B-cells + Basal keratinocytes | 0.40 | bulk thymus dominated by lymphoid; keratin via Hassall |
| nasopharynx / pharynx | Squamous epithelial | 0.70 | pseudostratified squamous match |
| notochord | Fibroblasts | 0.30 | misses brachyury-notochord biology |
| midline_structures | Squamous epithelial (NUTM) | 0.60 | midline mucosa is squamous |

## Public API
\`get_matched_normal_cell_type(tissue)\` returns \`(cell_types, confidence, source)\` — source is \`'direct'\`/\`'proxy'\`/\`'bulk_fallback'\`. Consumed by the ensemble synthesis (#216) to weight methods by confidence.

## Coverage contract
New test enforces that every leaf-cancer primary_tissue has a direct mapping, a proxy, or is on an acknowledged-bulk-fallback allowlist with a documented reason — prevents silent regressions when new registry entries land.

## Behavior
Default blend remains 0.0 (from #215) so runtime behavior unchanged. Proxies are declarative metadata ready for the ensemble / blend activation in #216.

## Test plan
- [x] 796 passed, 1 skipped (9 new tests)
- [x] ruff clean
- [x] Coverage contract pins all 76 leaf tissues

Depends on #215.