### PR TITLE
feat(plot): faint dashed p90-TPM reference line on every sample-TPM plot

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1120,6 +1120,7 @@ def _analyze_body(
     # (AR / ER / HER2 / MAPK-EGFR / NE / EMT / hypoxia / IFN) so the
     # report can explain *why* individual genes are high or low
     # (e.g. KLK3 ↓ + FOLH1 ↑ → AR-suppressed, consistent with ADT).
+    sample_tpm_by_symbol = None
     try:
         from .common import build_sample_tpm_by_symbol
         sample_tpm_by_symbol = build_sample_tpm_by_symbol(df_expr)
@@ -1704,6 +1705,7 @@ def _analyze_body(
                     top_n=15,
                     save_to_filename=attr_png,
                     save_dpi=output_dpi,
+                    sample_tpm_by_symbol=sample_tpm_by_symbol,
                 )
                 if fig is not None:
                     adj_pngs.append(attr_png)
@@ -1754,6 +1756,7 @@ def _analyze_body(
                     top_n=15,
                     save_to_filename=mn_png,
                     save_dpi=output_dpi,
+                    sample_tpm_by_symbol=sample_tpm_by_symbol,
                 )
                 if fig is not None:
                     adj_pngs.append(mn_png)

--- a/pirlygenes/plot_reference_lines.py
+++ b/pirlygenes/plot_reference_lines.py
@@ -1,0 +1,136 @@
+# Licensed under the Apache License, Version 2.0
+
+"""Shared reference-line helpers for sample-TPM plots.
+
+Every plot that renders per-gene sample TPM values benefits from a
+consistent visual anchor for "where does this gene's expression sit
+relative to the rest of the sample?". A single faint dashed line at
+the sample's 90th-percentile TPM gives that anchor cheaply — readers
+can immediately see which genes are in the top decile of the whole
+transcriptome.
+
+The percentile is computed from the expressed portion of the sample
+(TPM > 0) rather than the full gene universe, so near-zero gene
+noise doesn't pull the reference down toward zero.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+_P90_LINE_COLOR = "#888888"
+_P90_LINE_DASHES = (1, 4)
+_P90_LINE_WIDTH = 0.8
+_P90_LINE_ALPHA = 0.55
+_P90_LABEL_FONTSIZE = 7
+_P90_LABEL_COLOR = "#555555"
+
+
+def compute_sample_p90_tpm(sample_tpm_by_symbol, *, min_tpm=0.0, percentile=90.0):
+    """Return the nth-percentile TPM over expressed genes (TPM > ``min_tpm``).
+
+    Parameters
+    ----------
+    sample_tpm_by_symbol : dict, pandas Series, or iterable of floats
+    min_tpm : float
+        Excludes genes at or below this TPM (default 0.0 = keep only
+        positively-expressed genes).
+    percentile : float
+        Percentile to compute (default 90).
+
+    Returns
+    -------
+    float or None
+        The percentile value, or ``None`` when the sample has too few
+        expressed genes (< 50) to compute a meaningful percentile.
+    """
+    try:
+        import pandas as pd
+        if isinstance(sample_tpm_by_symbol, dict):
+            values = np.array(
+                list(sample_tpm_by_symbol.values()), dtype=float,
+            )
+        elif isinstance(sample_tpm_by_symbol, pd.Series):
+            values = sample_tpm_by_symbol.astype(float).to_numpy()
+        else:
+            values = np.asarray(list(sample_tpm_by_symbol), dtype=float)
+    except Exception:
+        return None
+
+    expressed = values[(values > min_tpm) & np.isfinite(values)]
+    if expressed.size < 50:
+        return None
+    return float(np.percentile(expressed, percentile))
+
+
+def add_p90_reference_line(
+    ax,
+    sample_tpm_by_symbol,
+    *,
+    orientation="vertical",
+    label_fmt=None,
+    min_tpm=0.0,
+    percentile=90.0,
+):
+    """Overlay a faint dashed line at the sample's 90th-percentile TPM.
+
+    ``orientation="vertical"`` draws a vertical line at x = p90 — use
+    for horizontal-bar plots where TPM is the x-axis.
+    ``orientation="horizontal"`` draws a horizontal line at y = p90 —
+    use for scatter / vertical-bar plots where TPM is the y-axis.
+
+    The line is cheap visual chrome: no-op when the percentile can't
+    be computed (too few expressed genes). A tiny label is placed
+    near the line so the reader knows what the threshold represents.
+
+    Returns the p90 TPM (float) or ``None`` when skipped.
+    """
+    p90 = compute_sample_p90_tpm(
+        sample_tpm_by_symbol, min_tpm=min_tpm, percentile=percentile,
+    )
+    if p90 is None or p90 <= 0:
+        return None
+
+    if label_fmt is None:
+        label_fmt = f"sample p{int(percentile)} ({{:.0f}} TPM)"
+
+    if orientation == "vertical":
+        ax.axvline(
+            p90,
+            color=_P90_LINE_COLOR,
+            linestyle=(0, _P90_LINE_DASHES),
+            linewidth=_P90_LINE_WIDTH,
+            alpha=_P90_LINE_ALPHA,
+            zorder=0.5,
+        )
+        ax.text(
+            p90, ax.get_ylim()[1],
+            " " + label_fmt.format(p90),
+            ha="left", va="top",
+            fontsize=_P90_LABEL_FONTSIZE,
+            color=_P90_LABEL_COLOR,
+            alpha=_P90_LINE_ALPHA + 0.2,
+        )
+    elif orientation == "horizontal":
+        ax.axhline(
+            p90,
+            color=_P90_LINE_COLOR,
+            linestyle=(0, _P90_LINE_DASHES),
+            linewidth=_P90_LINE_WIDTH,
+            alpha=_P90_LINE_ALPHA,
+            zorder=0.5,
+        )
+        ax.text(
+            ax.get_xlim()[1], p90,
+            label_fmt.format(p90) + " ",
+            ha="right", va="bottom",
+            fontsize=_P90_LABEL_FONTSIZE,
+            color=_P90_LABEL_COLOR,
+            alpha=_P90_LINE_ALPHA + 0.2,
+        )
+    else:
+        raise ValueError(
+            f"orientation must be 'vertical' or 'horizontal'; got {orientation!r}"
+        )
+    return p90

--- a/pirlygenes/plot_target_deep_dive.py
+++ b/pirlygenes/plot_target_deep_dive.py
@@ -335,6 +335,18 @@ def plot_actionable_targets(
     ax.invert_yaxis()
     ax.legend(loc="lower right", fontsize=8)
     ax.set_title(title or f"Actionable Surface Targets — {cancer_code}")
+
+    # Sample-wide 90th-percentile anchor (faint dashed).
+    try:
+        from .plot_reference_lines import add_p90_reference_line
+        from .common import build_sample_tpm_by_symbol
+        add_p90_reference_line(
+            ax, build_sample_tpm_by_symbol(df_gene_expr),
+            orientation="vertical",
+        )
+    except Exception:
+        pass
+
     fig.tight_layout()
 
     if save_to_filename:
@@ -506,6 +518,17 @@ def plot_cta_deep_dive(
     ax.invert_yaxis()
     ax.legend(loc="lower right", fontsize=8)
     ax.set_title(f"Cancer-Testis Antigens — {cancer_code}")
+
+    try:
+        from .plot_reference_lines import add_p90_reference_line
+        from .common import build_sample_tpm_by_symbol
+        add_p90_reference_line(
+            ax, build_sample_tpm_by_symbol(df_gene_expr),
+            orientation="vertical",
+        )
+    except Exception:
+        pass
+
     fig.tight_layout()
 
     if save_to_filename:

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -1263,6 +1263,7 @@ def plot_matched_normal_attribution(
     save_to_filename=None,
     save_dpi=300,
     figsize=None,
+    sample_tpm_by_symbol=None,
 ):
     """Stacked horizontal-bar plot of per-gene tumor / matched-normal / TME
     attribution for a single target category (issue #55).
@@ -1360,6 +1361,15 @@ def plot_matched_normal_attribution(
     ax.grid(axis="x", alpha=0.2)
     ax.legend(loc="lower right", fontsize=9, framealpha=0.9)
 
+    # Sample-wide 90th-percentile reference line — faint dashed anchor
+    # so readers see where each gene sits relative to the rest of the
+    # transcriptome.
+    if sample_tpm_by_symbol is not None:
+        from .plot_reference_lines import add_p90_reference_line
+        add_p90_reference_line(
+            ax, sample_tpm_by_symbol, orientation="vertical",
+        )
+
     mn_tissue = ""
     if "matched_normal_tissue" in sub.columns:
         nonempty = sub["matched_normal_tissue"].astype(str).replace("nan", "")
@@ -1383,6 +1393,7 @@ def plot_target_attribution(
     cancer_type,
     category,
     top_n=15,
+    sample_tpm_by_symbol=None,
     save_to_filename=None,
     save_dpi=300,
     figsize=None,
@@ -1476,6 +1487,12 @@ def plot_target_attribution(
         "(\u26a0\u26a0 = tumor < 30% of observed; \u26a0 = single-tissue-explainable)",
         fontsize=10, fontweight="bold",
     )
+    # Sample-wide 90th-percentile reference line (faint dashed).
+    if sample_tpm_by_symbol is not None:
+        from .plot_reference_lines import add_p90_reference_line
+        add_p90_reference_line(
+            ax, sample_tpm_by_symbol, orientation="vertical",
+        )
 
     plt.tight_layout()
     if save_to_filename:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.50.6"
+__version__ = "4.50.7"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_plot_reference_lines.py
+++ b/tests/test_plot_reference_lines.py
@@ -1,0 +1,103 @@
+"""Tests for the sample-wide p90 TPM reference-line helper."""
+
+import pytest
+
+from pirlygenes.plot_reference_lines import (
+    add_p90_reference_line,
+    compute_sample_p90_tpm,
+)
+
+
+def test_compute_p90_from_dict():
+    sample = {f"GENE{i}": float(i) for i in range(200)}
+    p90 = compute_sample_p90_tpm(sample)
+    # Genes 1..199 are expressed (0 filtered out). 90th percentile of
+    # 1..199 is 179.2 (approximately).
+    assert p90 is not None
+    assert 170 < p90 < 190
+
+
+def test_compute_p90_returns_none_for_small_sample():
+    """Fewer than 50 expressed genes → too noisy for a meaningful
+    percentile."""
+    sample = {f"G{i}": float(i) for i in range(10)}
+    assert compute_sample_p90_tpm(sample) is None
+
+
+def test_compute_p90_ignores_zero_genes():
+    """Zero-TPM genes shouldn't drag the percentile down."""
+    sample = {f"G{i}": 0.0 for i in range(200)}
+    sample.update({f"E{i}": 50.0 + i for i in range(100)})
+    p90 = compute_sample_p90_tpm(sample)
+    assert p90 is not None
+    assert 130 < p90 < 155  # 90th %ile of 50..149
+
+
+def test_add_p90_vertical():
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 200)
+    ax.set_ylim(0, 10)
+    sample = {f"G{i}": float(i) for i in range(200)}
+    p90 = add_p90_reference_line(ax, sample, orientation="vertical")
+    assert p90 is not None
+    # Should have added one vertical line
+    vlines = [ln for ln in ax.get_lines() if ln.get_xdata()[0] == ln.get_xdata()[-1]]
+    assert len(vlines) >= 1
+    plt.close(fig)
+
+
+def test_add_p90_horizontal():
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 10)
+    ax.set_ylim(0, 200)
+    sample = {f"G{i}": float(i) for i in range(200)}
+    p90 = add_p90_reference_line(ax, sample, orientation="horizontal")
+    assert p90 is not None
+    plt.close(fig)
+
+
+def test_add_p90_noop_on_empty_sample():
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    p90 = add_p90_reference_line(ax, {})
+    assert p90 is None
+    plt.close(fig)
+
+
+def test_add_p90_raises_on_bad_orientation():
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        add_p90_reference_line(
+            ax, {f"G{i}": float(i) for i in range(100)},
+            orientation="diagonal",
+        )
+    plt.close(fig)
+
+
+def test_add_p90_accepts_pandas_series():
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    s = pd.Series({f"G{i}": float(i) for i in range(200)})
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 200)
+    ax.set_ylim(0, 10)
+    p90 = add_p90_reference_line(ax, s, orientation="vertical")
+    assert p90 is not None
+    assert isinstance(p90, (int, float))
+    plt.close(fig)
+
+
+def test_add_p90_custom_percentile():
+    sample = {f"G{i}": float(i) for i in range(200)}
+    p50 = compute_sample_p90_tpm(sample, percentile=50)
+    p99 = compute_sample_p90_tpm(sample, percentile=99)
+    # p99 > p90 > p50 by definition when using standard dataset
+    assert p50 < p99


### PR DESCRIPTION
## Summary
Adds a shared reference-line helper + consistent visual anchor to plots that render per-gene sample TPM values. A faint grey dashed vertical line at the sample's 90th-percentile TPM shows readers where each gene sits relative to the rest of the transcriptome — a gene at 100 TPM reads very differently when the sample's p90 is 30 vs 300.

## What ships
- \`pirlygenes/plot_reference_lines.py\` — \`compute_sample_p90_tpm\` + \`add_p90_reference_line\` helpers
- \`plot_matched_normal_attribution\` / \`plot_target_attribution\` — new \`sample_tpm_by_symbol\` kwarg
- \`plot_actionable_targets\` / \`plot_cta_deep_dive\` — pull directly from \`df_gene_expr\` already in scope
- cli.py threads the already-available \`sample_tpm_by_symbol\` through

## Design notes
- Computed over expressed genes (TPM > 0) — near-zero noise can't drag the reference down
- Returns \`None\` for samples with < 50 expressed genes (too noisy for a meaningful percentile)
- Color \`#888888\`, alpha 0.55, tiny labelled marker — purposefully faint so it doesn't compete with the data
- Orientation-aware (vertical for horizontal-bar plots, horizontal for scatter plots)

## Test plan
- [x] 9 new tests: helper correctness, empty/small samples, horizontal + vertical orientations, pandas Series input, custom percentile, bad orientation
- [x] Full suite: 805 passed
- [x] rs sanity run produced matched-normal-*, target-attribution-*, deep-dive PNGs (line rendered)