### PR TITLE
[codex] Improve report evidence synthesis and subtype-aware curation

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 import logging
 from typing import List, Optional
 
+from .reporting import cancer_key_genes_lookup_for_analysis
+
 logger = logging.getLogger(__name__)
 
 
@@ -175,6 +177,27 @@ def _top_therapies(
         if len(deduped) >= limit:
             break
     return deduped
+
+
+def _panel_display_label(panel_code, panel_subtype=None):
+    if panel_subtype:
+        return f"{panel_code} ({str(panel_subtype).replace('_', ' ')})"
+    return panel_code
+
+
+def _curated_target_panel_for_sample(cancer_code, analysis, ranges_df=None):
+    from .gene_sets_cancer import cancer_therapy_targets
+
+    panel_code, panel_subtype = cancer_key_genes_lookup_for_analysis(
+        cancer_code,
+        analysis,
+        ranges_df=ranges_df,
+    )
+    if panel_subtype:
+        targets_df = cancer_therapy_targets(panel_code, subtype=panel_subtype)
+    else:
+        targets_df = cancer_therapy_targets(panel_code)
+    return panel_code, panel_subtype, targets_df.reset_index(drop=True)
 
 
 def _caveats_from_purity_tier(purity_tier, sample_context) -> List[str]:
@@ -438,18 +461,25 @@ def build_summary(
 
     lines.append("")
 
-    # Top therapies — only if the cancer type is curated.
-    if cancer_code in cancer_key_genes_cancer_types():
-        targets_df = cancer_therapy_targets(cancer_code)
+    # Top therapies — subtype/direct-code resolved when the umbrella
+    # cancer call narrows onto a more specific curated panel.
+    panel_code, panel_subtype, targets_df = _curated_target_panel_for_sample(
+        cancer_code, analysis, ranges_df=ranges_df,
+    )
+    panel_label = _panel_display_label(panel_code, panel_subtype)
+    if panel_code in cancer_key_genes_cancer_types():
         top = _top_therapies(targets_df, ranges_df, limit=3)
+        lines.append("## Top candidate therapies\n")
+        if panel_code != cancer_code or panel_subtype:
+            lines.append(
+                f"*Subtype-resolved therapy curation:* using the `{panel_label}` panel rather than the umbrella `{cancer_code}` union.\n"
+            )
         if top:
-            lines.append("## Top candidate therapies\n")
             for target_row, expression_row in top:
                 lines.append(_format_therapy_bullet(target_row, expression_row))
             lines.append("")
         else:
             lines.append(
-                "## Top candidate therapies\n"
                 "*No approved or trialed agents with a measured, "
                 "tumor-attributed target in this sample.*\n"
             )
@@ -577,17 +607,24 @@ def build_actionable(
     lines.append("")
 
     # Therapy landscape
-    if cancer_code in cancer_key_genes_cancer_types():
-        targets_df = cancer_therapy_targets(cancer_code)
+    panel_code, panel_subtype, targets_df = _curated_target_panel_for_sample(
+        cancer_code, analysis, ranges_df=ranges_df,
+    )
+    panel_label = _panel_display_label(panel_code, panel_subtype)
+    if panel_code in cancer_key_genes_cancer_types():
         sym_to_row = {}
         for _, rrow in ranges_df.iterrows():
             sym_to_row[str(rrow["symbol"])] = rrow
 
         if len(targets_df):
             lines.append("## Therapy landscape\n")
+            if panel_code != cancer_code or panel_subtype:
+                lines.append(
+                    f"*Subtype-resolved therapy curation:* `{panel_label}` panel selected from the broader `{cancer_code}` call.\n"
+                )
             lines.append(
                 "Agents with an approved or trialed indication for "
-                f"{cancer_code}, cross-referenced to this sample. "
+                f"{panel_label}, cross-referenced to this sample. "
                 "Approved agents listed first."
             )
             lines.append("")
@@ -647,6 +684,18 @@ def build_actionable(
                     f"{_cell(t.get('indication'))} | {obs_cell} | {tumor_cell} |"
                 )
             lines.append("")
+        else:
+            lines.append(
+                "## Therapy landscape\n"
+                "*No curated therapy targets are available for this resolved panel.*\n"
+            )
+    else:
+        lines.append(
+            "## Therapy landscape\n"
+            f"*Cancer type {cancer_code} is not yet in the curated "
+            "key-genes panel — see `targets.md` for the generic "
+            "expression-ranked tables.*\n"
+        )
 
     # Caveats
     caveats = _caveats_from_purity_tier(purity_tier, sample_context)

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -34,9 +34,11 @@ from pathlib import Path
 from typing import List, Optional
 
 from .reporting import (
+    cancer_code_display_name,
     cancer_key_genes_lookup_for_analysis,
     clinical_maturity_summary,
     normal_expression_context,
+    subtype_curation_scope_note,
     tumor_band_available,
     tumor_band_cell,
     target_reliability_status,
@@ -55,6 +57,122 @@ def _display_sample_id(sample_id: Optional[str]) -> Optional[str]:
     if "/" in text or "\\" in text:
         text = Path(text).name.strip()
     return text or None
+
+
+def _display_subtype_code(code: Optional[str]) -> str:
+    text = str(code or "").strip()
+    if not text:
+        return "the alternate subtype"
+    try:
+        from .gene_sets_cancer import cancer_type_registry
+
+        reg = cancer_type_registry()
+        match = reg[reg["code"] == text]
+        if not match.empty:
+            row = match.iloc[0]
+            subtype_key = row.get("subtype_key")
+            if isinstance(subtype_key, str) and subtype_key and subtype_key.lower() != "nan":
+                return subtype_key.replace("_", " ")
+            name = row.get("name")
+            if isinstance(name, str) and name:
+                return name.split("(")[0].strip().lower()
+    except Exception:
+        logger.debug("subtype display lookup failed", exc_info=True)
+    return text.replace("_", " ").lower()
+
+
+def _site_template_note_label(template_name: Optional[str]) -> str:
+    mapping = {
+        "met_adrenal": "adrenal-site",
+        "met_bone": "bone-site",
+        "met_brain": "brain-site",
+        "met_liver": "liver-site",
+        "met_lung": "lung-site",
+        "met_lymph_node": "lymph-node",
+        "met_peritoneal": "peritoneal-site",
+        "met_skin": "skin-site",
+        "met_soft_tissue": "soft-tissue",
+        "solid_primary": "primary-site",
+    }
+    text = str(template_name or "").strip()
+    if not text:
+        return "site"
+    return mapping.get(text, text.replace("_", " "))
+
+
+def _shared_signature_note(shared_signature: Optional[str]) -> str:
+    text = str(shared_signature or "").strip()
+    if not text:
+        return "shared lineage pattern"
+    text = text.replace("_", " ")
+    text = text.replace("+", " / ")
+    text = text.replace(" amp", " amplification")
+    return text
+
+
+def _render_subtype_note(
+    resolution: dict,
+    *,
+    original_subtype: Optional[str],
+    site_template: Optional[str],
+) -> str:
+    if not resolution:
+        return ""
+    status = str(resolution.get("status") or "")
+    rule = str(resolution.get("rule") or "")
+    shared_signature = _shared_signature_note(resolution.get("shared_signature"))
+    final_label = _display_subtype_code(resolution.get("final_subtype"))
+    original_label = _display_subtype_code(original_subtype)
+    alternatives = [
+        _display_subtype_code(code)
+        for code in (resolution.get("alternatives") or [])
+    ]
+
+    if status == "corrected":
+        if rule == "site_template":
+            site_label = _site_template_note_label(site_template)
+            return (
+                f"{site_label.capitalize()} context favors {final_label} over {original_label}; "
+                f"both can share the {shared_signature}."
+            )
+        if rule == "fusion_surrogate":
+            return (
+                f"Fusion-surrogate expression favors {final_label} over {original_label}; "
+                f"both can share the {shared_signature}."
+            )
+        if rule == "marker_combo":
+            return (
+                f"The marker combination is more consistent with {final_label} than {original_label}; "
+                f"both can share the {shared_signature}."
+            )
+        return (
+            f"Additional subtype evidence favors {final_label} over {original_label}; "
+            f"both can share the {shared_signature}."
+        )
+
+    if status == "degenerate":
+        option_text = " vs ".join([final_label] + alternatives) if alternatives else final_label
+        if rule == "site_template":
+            return (
+                f"Subtype remains unresolved between {option_text}; the available site context does not break the tie, "
+                f"and these options can share the {shared_signature}."
+            )
+        if rule == "fusion_surrogate":
+            return (
+                f"Subtype remains unresolved between {option_text}; the available fusion-surrogate expression does not break the tie, "
+                f"and these options can share the {shared_signature}."
+            )
+        if rule == "marker_combo":
+            return (
+                f"Subtype remains unresolved between {option_text}; the available marker combination does not break the tie, "
+                f"and these options can share the {shared_signature}."
+            )
+        return (
+            f"Subtype remains unresolved between {option_text}; the available evidence does not break the tie, "
+            f"and these options can share the {shared_signature}."
+        )
+
+    return str(resolution.get("reason") or "").strip()
 
 
 def _phase_label(phase: str) -> str:
@@ -376,6 +494,8 @@ def build_summary(
     degenerate_status = None
     degenerate_reason = ""
     degenerate_alternatives = []
+    degenerate_resolution = None
+    original_winning_subtype = winning_subtype
     if winning_subtype:
         try:
             from .degenerate_subtype import resolve_degenerate_subtype
@@ -411,6 +531,7 @@ def build_summary(
                 site_template=site_template,
                 tumor_tpm_by_symbol=tumor_tpm_by_symbol,
             )
+            degenerate_resolution = resolution
             if resolution["status"] == "corrected":
                 winning_subtype = resolution["final_subtype"]
             degenerate_status = resolution["status"]
@@ -460,8 +581,14 @@ def build_summary(
     # Surface a subtype note only when the resolver changed the call or
     # flagged irreducible ambiguity. ``pair_inactive`` means the pair
     # didn't apply — no reader-facing note needed.
-    if degenerate_status in ("corrected", "degenerate") and degenerate_reason:
-        lines.append(f"**Subtype note:** {degenerate_reason}")
+    if degenerate_status in ("corrected", "degenerate"):
+        subtype_note = _render_subtype_note(
+            degenerate_resolution or {},
+            original_subtype=original_winning_subtype,
+            site_template=(analysis.get("decomposition") or {}).get("best_template"),
+        ).strip()
+        if subtype_note:
+            lines.append(f"**Subtype note:** {subtype_note}")
 
     # Purity
     overall = purity.get("overall_estimate")
@@ -497,7 +624,15 @@ def build_summary(
         lines.append("## Top candidate therapies\n")
         if panel_code != cancer_code or panel_subtype:
             lines.append(
-                f"*Subtype-resolved therapy curation:* using the `{panel_label}` panel rather than the umbrella `{cancer_code}` union.\n"
+                "*Subtype-resolved therapy curation:* "
+                + subtype_curation_scope_note(
+                    panel_code,
+                    panel_subtype=panel_subtype,
+                    base_code=cancer_code,
+                    base_name=analysis.get("cancer_name") or cancer_code,
+                    noun="therapy evidence",
+                )
+                + "\n"
             )
         if top:
             for target_row, expression_row in top:
@@ -652,11 +787,19 @@ def build_actionable(
             lines.append("## Therapy landscape\n")
             if panel_code != cancer_code or panel_subtype:
                 lines.append(
-                    f"*Subtype-resolved therapy curation:* `{panel_label}` panel selected from the broader `{cancer_code}` call.\n"
+                    "*Subtype-resolved therapy curation:* "
+                    + subtype_curation_scope_note(
+                        panel_code,
+                        panel_subtype=panel_subtype,
+                        base_code=cancer_code,
+                        base_name=cancer_name or cancer_code,
+                        noun="therapy evidence",
+                    )
+                    + "\n"
                 )
             lines.append(
                 "Agents with an approved or trialed indication for "
-                f"{panel_label}, cross-referenced to this sample. "
+                f"{cancer_code_display_name(panel_code, panel_label)}, cross-referenced to this sample. "
                 "Approved agents listed first. Interpretation separates "
                 "tumor-source support from normal-expression context so "
                 "lineage markers are not confused with tumor-exclusive "

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -30,17 +30,31 @@ parseable?".)
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import List, Optional
 
 from .reporting import (
     cancer_key_genes_lookup_for_analysis,
     clinical_maturity_summary,
     normal_expression_context,
+    tumor_band_available,
+    tumor_band_cell,
     target_reliability_status,
     tumor_attribution_context,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _display_sample_id(sample_id: Optional[str]) -> Optional[str]:
+    if sample_id is None:
+        return None
+    text = str(sample_id).strip()
+    if not text:
+        return None
+    if "/" in text or "\\" in text:
+        text = Path(text).name.strip()
+    return text or None
 
 
 def _phase_label(phase: str) -> str:
@@ -91,16 +105,15 @@ def _format_therapy_bullet(target_row, expression_row, target_panel=None) -> str
             f"Target **not measured** in this sample."
         )
     observed = float(expression_row.get("observed_tpm") or 0.0)
-    has_attribution = bool(expression_row.get("attribution"))
     if observed < 1.0:
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
             f"Observed {observed:.1f} TPM — **target absent** in this sample."
         )
-    if not has_attribution:
+    if not tumor_band_available(expression_row):
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-            f"Observed {observed:.0f} TPM; tumor-specific decomposition was unavailable."
+            f"Observed {observed:.0f} TPM; a tumor-core uncertainty band was not available for this run."
         )
     source = tumor_attribution_context(expression_row)
     normal = normal_expression_context(expression_row)
@@ -302,6 +315,7 @@ def build_summary(
     cancer_name = analysis.get("cancer_name") or cancer_code
 
     lines: List[str] = []
+    sample_id = _display_sample_id(sample_id)
     header_id = f": {sample_id}" if sample_id else ""
     lines.append(f"# Summary{header_id}\n")
     lines.append(
@@ -554,6 +568,7 @@ def build_actionable(
     cancer_name = analysis.get("cancer_name") or cancer_code
 
     lines: List[str] = []
+    sample_id = _display_sample_id(sample_id)
     header_id = f" — {sample_id}" if sample_id else ""
     lines.append(f"# Actionable review{header_id}\n")
     lines.append(
@@ -694,14 +709,7 @@ def build_actionable(
                         interp_cell = "not measured"
                     else:
                         obs_cell = f"{float(expr.get('observed_tpm') or 0):.1f}"
-                        if expr.get("attribution"):
-                            tumor_cell = (
-                                f"{float(expr.get('attr_tumor_tpm') or 0.0):.0f} "
-                                f"({float(expr.get('attr_tumor_tpm_low') or expr.get('attr_tumor_tpm') or 0.0):.0f}-"
-                                f"{float(expr.get('attr_tumor_tpm_high') or expr.get('attr_tumor_tpm') or 0.0):.0f})"
-                            )
-                        else:
-                            tumor_cell = "—"
+                        tumor_cell = tumor_band_cell(expr)
                         source = tumor_attribution_context(expr)
                         normal = normal_expression_context(expr)
                         interp_parts = [source["label"], normal["label"]]

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -32,7 +32,13 @@ from __future__ import annotations
 import logging
 from typing import List, Optional
 
-from .reporting import cancer_key_genes_lookup_for_analysis
+from .reporting import (
+    cancer_key_genes_lookup_for_analysis,
+    clinical_maturity_summary,
+    normal_expression_context,
+    target_reliability_status,
+    tumor_attribution_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +78,7 @@ def _top_candidate_signature_score(analysis) -> float | None:
     return None
 
 
-def _format_therapy_bullet(target_row, expression_row) -> str:
+def _format_therapy_bullet(target_row, expression_row, target_panel=None) -> str:
     """One standardized therapy bullet for the brief."""
     sym = str(target_row.get("symbol") or "")
     agent = str(target_row.get("agent") or "—")
@@ -85,27 +91,28 @@ def _format_therapy_bullet(target_row, expression_row) -> str:
             f"Target **not measured** in this sample."
         )
     observed = float(expression_row.get("observed_tpm") or 0.0)
-    attr_tumor = float(expression_row.get("attr_tumor_tpm") or 0.0)
     has_attribution = bool(expression_row.get("attribution"))
-    attr_fraction = float(expression_row.get("attr_tumor_fraction") or 0.0)
     if observed < 1.0:
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
             f"Observed {observed:.1f} TPM — **target absent** in this sample."
         )
-    if has_attribution:
-        tumor_clause = f"tumor-attributed {attr_tumor:.0f} TPM"
-    else:
-        tumor_clause = f"observed {observed:.0f} TPM"
-    if attr_fraction >= 0.5:
-        conf = "high"
-    elif attr_fraction >= 0.3 or not has_attribution:
-        conf = "moderate"
-    else:
-        conf = "low (mostly non-tumor)"
+    if not has_attribution:
+        return (
+            f"- **{sym}** — {agent} ({phase}{indication_clause}). "
+            f"Observed {observed:.0f} TPM; tumor-specific decomposition was unavailable."
+        )
+    source = tumor_attribution_context(expression_row)
+    normal = normal_expression_context(expression_row)
+    maturity = clinical_maturity_summary(target_row, target_panel=target_panel)
+    interpretation_parts = [source["label"], source["band"], normal["label"]]
+    notes = list(source.get("notes") or []) + list(normal.get("details") or [])
+    if notes:
+        interpretation_parts.append(notes[0])
+    interpretation = "; ".join(part for part in interpretation_parts if part)
     return (
         f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-        f"{tumor_clause.capitalize()}. Confidence: {conf}."
+        f"{interpretation}. Clinical maturity: {maturity}."
     )
 
 
@@ -148,6 +155,9 @@ def _top_therapies(
         # don't belong in the clinician handoff per #79 semantics.
         if attr_fraction < 0.30:
             continue
+        reliability_status = target_reliability_status(expr)
+        if reliability_status == "unsupported":
+            continue
         # Note (#128): we deliberately do NOT filter on
         # ``broadly_expressed`` here. The caller's ``targets_df`` is
         # the **curated** cancer-key-genes panel (#110) — every row
@@ -160,7 +170,8 @@ def _top_therapies(
         # / Intracellular target tables where ranking is by raw
         # expression, not curation.
         phase = str(t.get("phase") or "")
-        sort_key = (phase_priority.get(phase, 99), -attr_tumor, sym)
+        reliability_rank = 0 if reliability_status == "supported" else 1
+        sort_key = (phase_priority.get(phase, 99), reliability_rank, -attr_tumor, sym)
         scored.append((sort_key, t, expr))
 
     # Sort by key only — avoid pandas Series comparison in tie-break.
@@ -169,7 +180,7 @@ def _top_therapies(
     deduped = []
     seen_symbols = set()
     for sort_key, t, expr in scored:
-        sym = sort_key[2]
+        sym = str(t.get("symbol") or "")
         if sym in seen_symbols:
             continue
         seen_symbols.add(sym)
@@ -476,7 +487,13 @@ def build_summary(
             )
         if top:
             for target_row, expression_row in top:
-                lines.append(_format_therapy_bullet(target_row, expression_row))
+                lines.append(
+                    _format_therapy_bullet(
+                        target_row,
+                        expression_row,
+                        target_panel=targets_df,
+                    )
+                )
             lines.append("")
         else:
             lines.append(
@@ -625,16 +642,19 @@ def build_actionable(
             lines.append(
                 "Agents with an approved or trialed indication for "
                 f"{panel_label}, cross-referenced to this sample. "
-                "Approved agents listed first."
+                "Approved agents listed first. Interpretation separates "
+                "tumor-source support from normal-expression context so "
+                "lineage markers are not confused with tumor-exclusive "
+                "targets."
             )
             lines.append("")
             lines.append(
                 "| Target | Agent | Class | Phase | Indication | "
-                "Observed | Tumor-attr. |"
+                "Observed | Tumor-core | Interpretation |"
             )
             lines.append(
                 "|--------|-------|-------|-------|------------|"
-                "----------|-------------|"
+                "----------|------------|----------------|"
             )
             phase_order = {
                 "approved": 0, "phase_3": 1, "phase_2": 2,
@@ -665,23 +685,41 @@ def build_actionable(
                 if sym == "—":
                     obs_cell = "*not measured*"
                     tumor_cell = "—"
+                    interp_cell = "agent-only / no direct gene target"
                 else:
                     expr = sym_to_row.get(sym)
                     if expr is None:
                         obs_cell = "*not measured*"
                         tumor_cell = "—"
+                        interp_cell = "not measured"
                     else:
                         obs_cell = f"{float(expr.get('observed_tpm') or 0):.1f}"
-                        attr_tumor = float(expr.get("attr_tumor_tpm") or 0)
-                        tumor_cell = (
-                            f"{attr_tumor:.0f}" if expr.get("attribution") else "—"
+                        if expr.get("attribution"):
+                            tumor_cell = (
+                                f"{float(expr.get('attr_tumor_tpm') or 0.0):.0f} "
+                                f"({float(expr.get('attr_tumor_tpm_low') or expr.get('attr_tumor_tpm') or 0.0):.0f}-"
+                                f"{float(expr.get('attr_tumor_tpm_high') or expr.get('attr_tumor_tpm') or 0.0):.0f})"
+                            )
+                        else:
+                            tumor_cell = "—"
+                        source = tumor_attribution_context(expr)
+                        normal = normal_expression_context(expr)
+                        interp_parts = [source["label"], normal["label"]]
+                        notes = list(source.get("notes") or []) + list(normal.get("details") or [])
+                        if notes:
+                            interp_parts.append(notes[0])
+                        interp_parts.append(
+                            clinical_maturity_summary(t, target_panel=targets_df)
+                        )
+                        interp_cell = "; ".join(
+                            part for part in interp_parts if part
                         )
                 phase = _phase_label(str(t.get("phase") or ""))
                 bold = "**" if phase == "Approved" and sym != "—" else ""
                 lines.append(
                     f"| {bold}{sym}{bold} | {_cell(t.get('agent'))} | "
                     f"{_cell(t.get('agent_class'))} | {phase} | "
-                    f"{_cell(t.get('indication'))} | {obs_cell} | {tumor_cell} |"
+                    f"{_cell(t.get('indication'))} | {obs_cell} | {tumor_cell} | {interp_cell} |"
                 )
             lines.append("")
         else:

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -13,6 +13,7 @@
 from argh import named, dispatch_commands
 import json
 from pathlib import Path
+import re
 from typing import Optional, Set
 
 from .version import print_name_and_version
@@ -82,6 +83,7 @@ from .reporting import (
     cancer_key_genes_lookup_for_analysis,
     clinical_maturity_summary,
     normal_expression_context,
+    tumor_band_cell,
     target_interpretation_summary,
     target_reliability_reasons,
     target_reliability_status,
@@ -113,6 +115,38 @@ _DATASET_SOURCES = {
     "degenerate-subtype-pairs": "Subtype disambiguation catalog (#198)",
     "fusion-surrogate-expression": "Fusion-surrogate gene catalog (#198)",
 }
+
+_GENERIC_OUTPUT_NAME_PARTS = {
+    "",
+    "sample",
+    "input",
+    "expression",
+    "gene-expression",
+    "gene_expression",
+    "gene-expression.csv",
+    "gene_expression_salmon",
+    "transcript_expression_salmon",
+    "rna_stringtie_gene_expression",
+    "gene_abundance",
+    "abundance",
+    "quant",
+    "quant.gene_tpm",
+    "pipeline_results",
+    "mcdb-workflow_results",
+    "fda-submission",
+    "analysis",
+    "results",
+    "processed",
+    "salmon_rich_quant",
+}
+
+_PREFERRED_SAMPLE_ID_PATTERNS = [
+    re.compile(r"(?i)\b(pfo\d{3,})\b"),
+    re.compile(r"(?i)\b(rs)\b"),
+    re.compile(r"\b(TL-\d{2}-[A-Z0-9]+)\b"),
+    re.compile(r"\b(BG\d{5,})\b"),
+    re.compile(r"\b(PSNLDx\d+)\b", re.IGNORECASE),
+]
 
 
 @named("data")
@@ -741,6 +775,41 @@ def _clean_prefix_outputs(out_dir: Path, prefix_path: str) -> int:
     return removed
 
 
+def _sanitize_output_basename(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    if "/" in text or "\\" in text:
+        text = Path(text).name
+    stem = Path(text).stem.strip()
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", stem).strip("._-")
+    return slug
+
+
+def _derive_sample_display_id(input_path: str, sample_id_value: Optional[str] = None) -> str:
+    explicit = _sanitize_output_basename(sample_id_value)
+    if explicit:
+        return explicit
+
+    path = Path(str(input_path))
+    parts = [path.stem] + [parent.name for parent in path.parents if parent.name]
+    for pattern in _PREFERRED_SAMPLE_ID_PATTERNS:
+        for part in parts:
+            match = pattern.search(part)
+            if match:
+                derived = _sanitize_output_basename(match.group(1))
+                if derived:
+                    return derived
+
+    for part in parts:
+        derived = _sanitize_output_basename(part)
+        if derived and derived.lower() not in _GENERIC_OUTPUT_NAME_PARTS:
+            return derived
+    return "sample"
+
+
 _TX_HEADER_TOKENS = frozenset({
     "name", "target_id", "transcript_id", "transcript",
     "transcriptid", "targetid", "effectivelength", "numreads",
@@ -900,12 +969,20 @@ def _analyze_body(
     therapy_target_top_k: int,
     therapy_target_tpm_threshold: float,
 ):
-    if output_image_prefix:
-        prefix = str(out_dir / output_image_prefix)
-    else:
-        prefix = str(out_dir / "sample")
+    sample_display_id = _derive_sample_display_id(
+        input_path,
+        sample_id_value=sample_id_value,
+    )
+    prefix_base = (
+        _sanitize_output_basename(output_image_prefix)
+        if output_image_prefix else sample_display_id
+    ) or "sample"
+    prefix = str(out_dir / prefix_base)
 
     stale_removed = _clean_prefix_outputs(out_dir, prefix)
+    legacy_default_prefix = str(out_dir / "sample")
+    if not output_image_prefix and prefix != legacy_default_prefix:
+        stale_removed += _clean_prefix_outputs(out_dir, legacy_default_prefix)
     if stale_removed:
         print(f"[output] Removed {stale_removed} stale files from prior run")
 
@@ -1864,7 +1941,7 @@ def _analyze_body(
             from .brief import build_summary, build_actionable
 
             disease_state_for_summary = compose_disease_state_narrative(analysis)
-            sample_id = prefix if prefix else None
+            sample_id = sample_display_id or None
             summary_md = build_summary(
                 analysis,
                 ranges_df,
@@ -2545,8 +2622,11 @@ def _matched_normal_split_summary(ranges_df):
         .dropna()
     )
     mn_frac = float(mn_frac_series.iloc[0]) if len(mn_frac_series) else 0.0
+    if mn_frac < 0.01:
+        return None
+    tissue_label = mn_tissue.replace("_", " ")
     return (
-        f"`matched_normal_{mn_tissue}` at **{mn_frac:.2%}** of the sample. "
+        f"estimated benign parent-tissue admixture from a {tissue_label}-like matched-normal reference at **{mn_frac:.0%}** of the sample. "
         "Per-gene estimates subtract both stromal/immune TME and benign parent-tissue "
         "signal before dividing by purity."
     )
@@ -2581,6 +2661,22 @@ def _template_site_display(template_name):
         "heme_nodal": "lymphoid / nodal",
     }
     return mapping.get(template_name, template_name.replace("_", " "))
+
+
+def _hypothesis_display_label(result, *, primary_code=None):
+    cancer_label = str(getattr(result, "cancer_type", "") or "").strip()
+    template_label = _template_site_display(
+        str(getattr(result, "template", "") or "").strip()
+    )
+    if not cancer_label:
+        return template_label
+    if template_label == "primary site":
+        if primary_code and cancer_label == primary_code:
+            return f"{cancer_label} primary-site pattern"
+        return f"{cancer_label}-like primary-site pattern"
+    if primary_code and cancer_label == primary_code:
+        return f"{cancer_label} {template_label} pattern"
+    return f"{cancer_label}-like {template_label} pattern"
 
 
 def _analysis_constraints(
@@ -2659,7 +2755,10 @@ def _summarize_sample_call(analysis, decomp_results, sample_mode):
 
     label_display = " or ".join(label_options) if label_options else analysis.get("cancer_type")
     hypothesis_display = [
-        f"{row.cancer_type} / {row.template}"
+        _hypothesis_display_label(
+            row,
+            primary_code=analysis.get("cancer_type"),
+        )
         for row in hypothesis_options[:2]
     ]
     return {
@@ -2779,7 +2878,7 @@ def _integrated_evidence_bullets(analysis, decomp_results=None):
     if best_decomp is not None:
         comp_bits = _composition_highlights(best_decomp)
         sentence = (
-            f"- **Decomposition line**: best template is `{best_decomp.cancer_type} / {best_decomp.template}`"
+            f"- **Decomposition line**: best template is {_hypothesis_display_label(best_decomp, primary_code=cancer_code)}"
         )
         if best_decomp.cancer_type == cancer_code:
             sentence += ", consistent with the classifier"
@@ -3624,12 +3723,8 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                         lines.append(f"| {sym} | *not measured* | — | — |")
                         continue
                     obs = float(row.get("observed_tpm") or 0.0)
-                    attr_tumor = float(row.get("attr_tumor_tpm") or 0.0)
                     attribution_cell = _format_attribution_cell(row)
-                    tumor_cell = (
-                        f"{attr_tumor:.0f}" if row.get("attribution")
-                        else "—"
-                    )
+                    tumor_cell = tumor_band_cell(row)
                     lines.append(
                         f"| {sym} | {obs:.1f} | {tumor_cell} | {attribution_cell} |"
                     )
@@ -3708,14 +3803,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                             interpretation_cell = "not measured"
                         else:
                             obs_cell = f"{float(expr.get('observed_tpm') or 0.0):.1f}"
-                            if expr.get("attribution"):
-                                tumor_cell = (
-                                    f"{float(expr.get('attr_tumor_tpm') or 0.0):.0f} "
-                                    f"({float(expr.get('attr_tumor_tpm_low') or expr.get('attr_tumor_tpm') or 0.0):.0f}-"
-                                    f"{float(expr.get('attr_tumor_tpm_high') or expr.get('attr_tumor_tpm') or 0.0):.0f})"
-                                )
-                            else:
-                                tumor_cell = "—"
+                            tumor_cell = tumor_band_cell(expr)
                             attr_cell = _format_attribution_cell(expr)
                             interpretation_cell = _target_interpretation_cell(
                                 trow,

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -48,6 +48,7 @@ from .plot import (
     plot_cohort_surface_proteins,
     plot_cohort_ctas,
     plot_curated_target_evidence,
+    plot_priority_targets,
     get_embedding_feature_metadata,
     estimate_tumor_expression_ranges,
     plot_matched_normal_attribution,
@@ -1531,11 +1532,21 @@ def _analyze_body(
     # Therapy target tissue expression / safety
     print("[plot] Generating therapy target tissue expression...")
     tissue_pdf = "%s-target-tissues.pdf" % prefix if prefix else "target-tissues.pdf"
+    tissue_png_manifest = (
+        "%s-target-tissues.png" % prefix if prefix else "target-tissues.png"
+    )
     plot_therapy_target_tissues(
         df_expr,
         top_k=therapy_target_top_k,
         tpm_threshold=therapy_target_tpm_threshold,
         save_to_filename=tissue_pdf,
+        save_dpi=output_dpi,
+    )
+    plot_therapy_target_tissues(
+        df_expr,
+        top_k=therapy_target_top_k,
+        tpm_threshold=therapy_target_tpm_threshold,
+        save_to_filename=tissue_png_manifest,
         save_dpi=output_dpi,
     )
 
@@ -1782,6 +1793,7 @@ def _analyze_body(
         )
 
         curated_evidence_png = None
+        priority_targets_png = None
         try:
             from .gene_sets_cancer import (
                 cancer_key_genes_cancer_types,
@@ -1793,6 +1805,7 @@ def _analyze_body(
                 analysis,
                 ranges_df=ranges_df,
             )
+            target_panel = None
             if panel_code in cancer_key_genes_cancer_types():
                 target_panel = (
                     cancer_therapy_targets(panel_code, subtype=panel_subtype)
@@ -1815,9 +1828,33 @@ def _analyze_body(
                 else:
                     curated_evidence_png = None
                 _plt.close("all")
+
+            priority_targets_png = (
+                "%s-priority-targets.png" % prefix
+                if prefix else "priority-targets.png"
+            )
+            fig = plot_priority_targets(
+                ranges_df,
+                cancer_type=panel_code if target_panel is not None else effective_cancer_type,
+                target_panel=(
+                    target_panel.reset_index(drop=True)
+                    if target_panel is not None else None
+                ),
+                df_gene_expr=df_expr,
+                save_to_filename=priority_targets_png,
+                save_dpi=output_dpi,
+            )
+            if fig is not None:
+                adj_pngs.append(priority_targets_png)
+                print(f"[plot] Saved priority targets to {priority_targets_png}")
+            else:
+                priority_targets_png = None
+            _plt.close("all")
+
         except Exception as curated_err:
             print(f"[plot] curated target evidence failed: {curated_err}")
             curated_evidence_png = None
+            priority_targets_png = None
 
         # #111: two-tier markdown handoff. Emitted after the detailed
         # reports so both can reference each other. The brief is the
@@ -1959,6 +1996,9 @@ def _analyze_body(
     scatter_dir = Path(scatter_pdf).parent / Path(scatter_pdf).stem
     if scatter_dir.is_dir():
         png_files.extend(sorted(str(p) for p in scatter_dir.glob("*.png")))
+    tissue_dir = Path(tissue_png_manifest).parent / Path(tissue_png_manifest).stem
+    if tissue_dir.is_dir():
+        png_files.extend(sorted(str(p) for p in tissue_dir.glob("*.png")))
 
     # Purity-adjusted plots go last (different RNA measure)
     for adj_p in adj_pngs:
@@ -2032,6 +2072,14 @@ def _analyze_body(
             scatter_dir.rmdir()
         except OSError:
             pass
+    if tissue_dir.is_dir():
+        for p in tissue_dir.glob("*.png"):
+            p.rename(figures_dir / p.name)
+            moved += 1
+        try:
+            tissue_dir.rmdir()
+        except OSError:
+            pass
     for extra in [scatter_pdf, tissue_pdf]:
         p = Path(extra) if isinstance(extra, str) else extra
         if p.exists():
@@ -2070,6 +2118,20 @@ def _analyze_body(
             if any(path.name.endswith(suffix) for suffix in suffixes):
                 out.append(path)
         return out
+
+    def _artifact_page(path):
+        path = Path(path)
+        if path.suffix.lower() == ".png":
+            img = Image.open(path).convert("RGB")
+            return _with_filename_caption(img, path.name)
+        return _make_audit_text_page(
+            f"Figure Artifact: {path.name}",
+            [
+                "This figure is emitted as a PDF artifact rather than a single PNG page.",
+                f"Path: {path}",
+                "If a sibling PNG page series exists, those pages appear elsewhere in this audit packet.",
+            ],
+        )
 
     audit_sections = [
         (
@@ -2116,6 +2178,7 @@ def _analyze_body(
                         "matched-normal-surface.png",
                         "subtype-attribution-targets.png",
                         "curated-target-evidence.png",
+                        "priority-targets.png",
                     ),
                 },
             ],
@@ -2146,6 +2209,7 @@ def _analyze_body(
                         "purity-methods.png",
                         "target-safety.png",
                         "curated-target-evidence.png",
+                        "priority-targets.png",
                         "provenance.png",
                         "therapy-pathway-state.png",
                     ),
@@ -2153,6 +2217,7 @@ def _analyze_body(
             ],
         ),
     ]
+    audit_seen = set()
 
     audit_images = [
         _make_audit_text_page(
@@ -2186,10 +2251,34 @@ def _analyze_body(
                 )
             )
             for path in files:
-                if path.suffix.lower() != ".png":
-                    continue
-                img = Image.open(path).convert("RGB")
-                audit_images.append(_with_filename_caption(img, path.name))
+                audit_seen.add(path.name)
+                audit_images.append(_artifact_page(path))
+
+    remaining_files = [
+        path
+        for path in sorted(figures_dir.iterdir())
+        if path.name not in audit_seen
+    ]
+    if remaining_files:
+        audit_images.append(
+            _make_audit_text_page(
+                "Coverage Appendix",
+                [
+                    "Every emitted figure is included at least once in this packet.",
+                    "The following pages cover artifacts that did not fit one of the opinionated groups above.",
+                ],
+            )
+        )
+        audit_images.append(
+            _make_audit_text_page(
+                "Other Emitted Figures",
+                [
+                    "Included: " + ", ".join(path.name for path in remaining_files),
+                ],
+            )
+        )
+        for path in remaining_files:
+            audit_images.append(_artifact_page(path))
 
     if audit_images:
         audit_images[0].save(
@@ -2240,6 +2329,8 @@ Prefer the standalone decomposition figures for review and sharing. They replace
 | `*-purity.png` | Tumor purity estimation detail |
 | `*-treatments.png` | Therapy target expression by modality |
 | `*-target-safety.png` | Therapy target normal tissue expression |
+| `*-priority-targets.png` | Integrated priority ranking: actionability + tumor-source support + uncertainty |
+| `*-curated-target-evidence.png` | Curated cancer-type targets with tumor-core band, normal context, and maturity |
 | `*-purity-targets.png` | Tumor-expression ranges for therapeutic targets |
 | `*-purity-ctas.png` | Tumor-expression ranges for CTAs |
 | `*-purity-surface.png` | Tumor-expression ranges for surface proteins |

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -47,6 +47,7 @@ from .plot import (
     plot_cohort_therapy_targets,
     plot_cohort_surface_proteins,
     plot_cohort_ctas,
+    plot_curated_target_evidence,
     get_embedding_feature_metadata,
     estimate_tumor_expression_ranges,
     plot_matched_normal_attribution,
@@ -78,8 +79,13 @@ from .format import (
 )
 from .reporting import (
     cancer_key_genes_lookup_for_analysis,
+    clinical_maturity_summary,
+    normal_expression_context,
+    target_interpretation_summary,
     target_reliability_reasons,
     target_reliability_status,
+    tumor_attribution_band_text,
+    tumor_attribution_context,
 )
 
 _DATASET_SOURCES = {
@@ -1775,6 +1781,44 @@ def _analyze_body(
             purity_result=purity_dict,
         )
 
+        curated_evidence_png = None
+        try:
+            from .gene_sets_cancer import (
+                cancer_key_genes_cancer_types,
+                cancer_therapy_targets,
+            )
+
+            panel_code, panel_subtype = cancer_key_genes_lookup_for_analysis(
+                effective_cancer_type,
+                analysis,
+                ranges_df=ranges_df,
+            )
+            if panel_code in cancer_key_genes_cancer_types():
+                target_panel = (
+                    cancer_therapy_targets(panel_code, subtype=panel_subtype)
+                    if panel_subtype else cancer_therapy_targets(panel_code)
+                )
+                curated_evidence_png = (
+                    "%s-curated-target-evidence.png" % prefix
+                    if prefix else "curated-target-evidence.png"
+                )
+                fig = plot_curated_target_evidence(
+                    ranges_df,
+                    target_panel.reset_index(drop=True),
+                    cancer_type=panel_code,
+                    save_to_filename=curated_evidence_png,
+                    save_dpi=output_dpi,
+                )
+                if fig is not None:
+                    adj_pngs.append(curated_evidence_png)
+                    print(f"[plot] Saved curated target evidence to {curated_evidence_png}")
+                else:
+                    curated_evidence_png = None
+                _plt.close("all")
+        except Exception as curated_err:
+            print(f"[plot] curated target evidence failed: {curated_err}")
+            curated_evidence_png = None
+
         # #111: two-tier markdown handoff. Emitted after the detailed
         # reports so both can reference each other. The brief is the
         # doc a clinician pastes into a note; the actionable is the
@@ -1996,6 +2040,166 @@ def _analyze_body(
     if moved:
         print(f"[output] Moved {moved} figures to {figures_dir}/")
 
+    figure_audit_pdf = "%s-figure-audit.pdf" % prefix if prefix else "figure-audit.pdf"
+
+    def _make_audit_text_page(title, lines):
+        from textwrap import wrap
+
+        width, height = 1800, 2400
+        img = Image.new("RGB", (width, height), color="white")
+        draw = ImageDraw.Draw(img)
+        try:
+            font = ImageFont.load_default()
+        except Exception:
+            font = None
+        y = 80
+        draw.text((80, y), title, fill="black", font=font)
+        y += 70
+        for line in lines:
+            wrapped = wrap(str(line), width=90) or [""]
+            for piece in wrapped:
+                draw.text((80, y), piece, fill="#333333", font=font)
+                y += 28
+            y += 12
+        return img
+
+    def _existing_figure_paths(*suffixes):
+        out = []
+        suffixes = tuple(suffixes)
+        for path in sorted(figures_dir.iterdir()):
+            if any(path.name.endswith(suffix) for suffix in suffixes):
+                out.append(path)
+        return out
+
+    audit_sections = [
+        (
+            "Potentially Redundant Groups",
+            [
+                {
+                    "title": "Sample Snapshot Cluster",
+                    "note": "These all answer variants of 'what kind of sample is this and is it technically trustworthy?'",
+                    "files": _existing_figure_paths(
+                        "sample-summary.png",
+                        "sample-context.png",
+                        "degradation-index.png",
+                        "background-tissues.png",
+                    ),
+                },
+                {
+                    "title": "Cancer-Call Cluster",
+                    "note": "These all support the cancer label from different angles; good candidates for consolidation when the call is already clear.",
+                    "files": _existing_figure_paths(
+                        "cancer-hypotheses.png",
+                        "mds-tme.png",
+                        "subtype-signature.png",
+                        "vs-cancer.pdf",
+                    ),
+                },
+                {
+                    "title": "Purity + Expression Range Cluster",
+                    "note": "These explain purity and then immediately apply that estimate to targets/CTAs/surface proteins.",
+                    "files": _existing_figure_paths(
+                        "purity.png",
+                        "purity-methods.png",
+                        "purity-targets.png",
+                        "purity-ctas.png",
+                        "purity-surface.png",
+                    ),
+                },
+                {
+                    "title": "Attribution / Matched-Normal Cluster",
+                    "note": "These are the most likely to feel repetitive because they all inspect the same targets from adjacent decomposition views.",
+                    "files": _existing_figure_paths(
+                        "target-attribution-targets.png",
+                        "target-attribution-surface.png",
+                        "matched-normal-targets.png",
+                        "matched-normal-surface.png",
+                        "subtype-attribution-targets.png",
+                        "curated-target-evidence.png",
+                    ),
+                },
+            ],
+        ),
+        (
+            "Low-Value Figures",
+            [
+                {
+                    "title": "Low-Value in the Default Packet",
+                    "note": "These currently add the least unique decision support relative to the rest of the packet.",
+                    "files": _existing_figure_paths(
+                        "background-tissues.png",
+                        "TLR.png",
+                        "DNA_repair.png",
+                    ),
+                },
+            ],
+        ),
+        (
+            "Unique Figures I Like",
+            [
+                {
+                    "title": "Distinctive / Keep",
+                    "note": "These each answer a question that the rest of the packet does not cover cleanly.",
+                    "files": _existing_figure_paths(
+                        "sample-summary.png",
+                        "cancer-hypotheses.png",
+                        "purity-methods.png",
+                        "target-safety.png",
+                        "curated-target-evidence.png",
+                        "provenance.png",
+                        "therapy-pathway-state.png",
+                    ),
+                },
+            ],
+        ),
+    ]
+
+    audit_images = [
+        _make_audit_text_page(
+            "Figure Audit",
+            [
+                "This PDF groups emitted figures by likely redundancy, low-value defaults, and distinctive keepers.",
+                "PNG pages are reproduced directly after each group cover page; PDF-only figures are listed on the cover page but not rasterized here.",
+                f"Source directory: {figures_dir}",
+            ],
+        )
+    ]
+    for section_title, groups in audit_sections:
+        audit_images.append(
+            _make_audit_text_page(
+                section_title,
+                [
+                    "The following pages are grouped by how they function in the report packet.",
+                ],
+            )
+        )
+        for group in groups:
+            files = group["files"]
+            file_labels = ", ".join(path.name for path in files) if files else "No matching figures emitted for this run."
+            audit_images.append(
+                _make_audit_text_page(
+                    group["title"],
+                    [
+                        group["note"],
+                        f"Included: {file_labels}",
+                    ],
+                )
+            )
+            for path in files:
+                if path.suffix.lower() != ".png":
+                    continue
+                img = Image.open(path).convert("RGB")
+                audit_images.append(_with_filename_caption(img, path.name))
+
+    if audit_images:
+        audit_images[0].save(
+            figure_audit_pdf,
+            save_all=True,
+            append_images=audit_images[1:],
+            resolution=output_dpi,
+        )
+        print(f"Saved {figure_audit_pdf} ({len(audit_images)} pages)")
+
     # Write README explaining output files
     readme_path = Path(prefix).parent / "README.md"
     cancer_code = analysis["cancer_type"]
@@ -2015,6 +2219,7 @@ Sample analyzed as **{cancer_code}** ({cancer_name}).
 | `*-provenance.md` | Attribution chain — library-prep → preservation → TME → tumor-core step by step |
 | `*-analysis-parameters.json` | Free model parameters plus selected sample mode and embedding methods |
 | `*-all-figures.pdf` | All figures combined into a single PDF |
+| `*-figure-audit.pdf` | Figure packet grouped into redundant / low-value / distinctive sections |
 | `*-cancer-candidates.tsv` | Candidate cancer-type support trace |
 | `*-decomposition-hypotheses.tsv` | Ranked decomposition hypotheses |
 | `*-decomposition-components.tsv` | Component-level fit for best decomposition |
@@ -3225,19 +3430,39 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         return pd.Series(False, index=df.index)
 
     def _format_target_stub(row, *, include_tcga=False):
-        parts = [f"{row['median_est']:.0f} {value_label}"]
+        source = tumor_attribution_context(row)
+        normal = normal_expression_context(row)
+        parts = [tumor_attribution_band_text(row), normal["label"]]
         therapies = str(row.get("therapies") or "").strip()
         if therapies:
             parts.append(therapies)
         if include_tcga and pd.notna(row.get("tcga_percentile")):
             parts.append(f"TCGA {row['tcga_percentile']:.0%}")
-        reliability_status = target_reliability_status(row)
-        reliability_reasons = target_reliability_reasons(row)
-        if reliability_status == "provisional" and reliability_reasons:
-            parts.append(f"provisional: {reliability_reasons[0]}")
-        if row.get("tme_explainable"):
-            parts.append("single-tissue-explainable")
+        if source["tier"] != "tumor_supported":
+            parts.append(source["label"])
+        if source.get("notes"):
+            parts.append(source["notes"][0])
+        elif normal.get("details"):
+            parts.append(normal["details"][0])
         return f"{row['symbol']} ({'; '.join(parts)})"
+
+    def _target_interpretation_cell(target_row, expr_row, *, include_maturity=False, target_panel=None):
+        if expr_row is None:
+            return "not measured"
+        if include_maturity:
+            return target_interpretation_summary(
+                target_row,
+                expr_row,
+                target_panel=target_panel,
+            )
+        source = tumor_attribution_context(expr_row)
+        normal = normal_expression_context(expr_row)
+        parts = [source["label"], normal["label"]]
+        if source.get("notes"):
+            parts.append(source["notes"][0])
+        elif normal.get("details"):
+            parts.append(normal["details"][0])
+        return "; ".join(part for part in parts if part)
 
     therapy_scores = analysis.get("therapy_response_scores") or {}
     ts_to_show = [
@@ -3328,6 +3553,14 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                 "Rows where the target is absent from the sample are "
                 "still shown to make that explicit.\n"
             )
+            lines.append(
+                "Interpretation separates **tumor-source support** "
+                "(`tumor-supported`, `mixed-source`, `background-dominant`) "
+                "from **normal-expression context** "
+                "(`same-lineage expected`, `broad healthy expression`, "
+                "`vital-tissue concern`, etc.). Phase / class still carry "
+                "the clinical-development tier.\n"
+            )
             targets_df = (
                 cancer_therapy_targets(panel_code, subtype=panel_subtype)
                 if panel_subtype else cancer_therapy_targets(panel_code)
@@ -3335,11 +3568,11 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             if len(targets_df):
                 lines.append(
                     "| Target | Agent | Class | Phase | Indication | "
-                    "Observed | Tumor-attr. | Attribution |"
+                    "Observed | Tumor-core | Attribution | Interpretation |"
                 )
                 lines.append(
                     "|--------|-------|-------|-------|------------|"
-                    "----------|-------------|-------------|"
+                    "----------|------------|-------------|----------------|"
                 )
                 # Approved first, then phase_3, phase_2, phase_1,
                 # preclinical. Within phase, agent name for stability.
@@ -3374,25 +3607,35 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                         obs_cell = "*not measured*"
                         tumor_cell = "—"
                         attr_cell = "—"
+                        interpretation_cell = "agent-only / no direct gene target"
                     else:
                         expr = sym_to_row.get(sym)
                         if expr is None:
                             obs_cell = "*not measured*"
                             tumor_cell = "—"
                             attr_cell = "—"
+                            interpretation_cell = "not measured"
                         else:
                             obs_cell = f"{float(expr.get('observed_tpm') or 0.0):.1f}"
-                            attr_tumor = float(expr.get("attr_tumor_tpm") or 0.0)
-                            tumor_cell = (
-                                f"{attr_tumor:.0f}" if expr.get("attribution")
-                                else "—"
-                            )
+                            if expr.get("attribution"):
+                                tumor_cell = (
+                                    f"{float(expr.get('attr_tumor_tpm') or 0.0):.0f} "
+                                    f"({float(expr.get('attr_tumor_tpm_low') or expr.get('attr_tumor_tpm') or 0.0):.0f}-"
+                                    f"{float(expr.get('attr_tumor_tpm_high') or expr.get('attr_tumor_tpm') or 0.0):.0f})"
+                                )
+                            else:
+                                tumor_cell = "—"
                             attr_cell = _format_attribution_cell(expr)
+                            interpretation_cell = _target_interpretation_cell(
+                                trow,
+                                expr,
+                                target_panel=targets_df,
+                            )
                     bold = "**" if phase == "approved" and sym != "—" else ""
                     lines.append(
                         f"| {bold}{sym}{bold} | {agent} | {agent_class} | "
                         f"{phase} | {indication} | {obs_cell} | "
-                        f"{tumor_cell} | {attr_cell} |"
+                        f"{tumor_cell} | {attr_cell} | {interpretation_cell} |"
                     )
                 lines.append("")
             else:
@@ -3441,7 +3684,35 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     cta_status = _target_reliability_series(ctas, category="CTA")
     intracellular_status = _target_reliability_series(intracellular)
 
-    safe_surface = surface_targets[surface_status == "supported"].head(3)
+    def _headline_surface_row(row):
+        normal = normal_expression_context(row)
+        detail_text = " ".join(normal.get("details") or [])
+        therapies = str(row.get("therapies") or "").strip()
+        if therapies:
+            return True
+        if normal["tier"] in {"broad_healthy_expression", "vital_tissue_concern"}:
+            return False
+        if "broader healthy-tissue signal" in detail_text:
+            return False
+        return True
+
+    headline_surface = surface_targets[
+        surface_targets.apply(_headline_surface_row, axis=1)
+    ].copy()
+    if len(headline_surface):
+        headline_surface["_status"] = surface_status.loc[headline_surface.index].values
+        headline_surface["_status_rank"] = headline_surface["_status"].map(
+            {"supported": 0, "provisional": 1, "unsupported": 2}
+        ).fillna(9)
+        headline_surface = headline_surface.sort_values(
+            ["_status_rank", "median_est"],
+            ascending=[True, False],
+        )
+    else:
+        headline_surface["_status"] = pd.Series(dtype=object)
+        headline_surface["_status_rank"] = pd.Series(dtype=float)
+    safe_surface = headline_surface[headline_surface["_status"] == "supported"].head(3)
+    mixed_surface = headline_surface[headline_surface["_status"] == "provisional"].head(3)
     best_cta = ctas.head(3)
     clean_intracellular = intracellular[intracellular_status == "supported"].head(3)
 
@@ -3510,10 +3781,17 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             + ", ".join(_format_target_stub(row) for _, row in safe_surface.iterrows())
             + "."
         )
+    elif len(mixed_surface):
+        lines.append(
+            "- **Surface-directed modalities**: no surface target stayed tumor-supported across the current uncertainty band; "
+            "best mixed-source options are "
+            + ", ".join(_format_target_stub(row) for _, row in mixed_surface.iterrows())
+            + "."
+        )
     elif len(surface_targets):
         lines.append(
-            "- **Surface-directed modalities**: no clean surface target passed the current reliability filter; "
-            "top rows were provisional or unsupported under the attribution reliability filters."
+            "- **Surface-directed modalities**: no surface target stayed tumor-supported across the current uncertainty band; "
+            "the leading rows remain mixed-source or background-dominant."
         )
     else:
         lines.append("- **Surface-directed modalities**: no surface target rose above the reporting threshold.")
@@ -3533,8 +3811,8 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         )
     elif mhc_status_label == "adequate" and len(intracellular):
         lines.append(
-            "- **Intracellular / TCR-style ideas**: MHC-I is adequate, but the current intracellular rows are mostly "
-            "provisional or unsupported under the attribution reliability filters."
+            "- **Intracellular / TCR-style ideas**: MHC-I is adequate, but the current intracellular rows remain "
+            "mixed-source or background-dominant under the tumor-source uncertainty band."
         )
     elif len(intracellular):
         lines.append(
@@ -3548,7 +3826,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     if len(surface_targets) and _flag_series(surface_targets.head(10), "tme_dominant").any():
         landscape_cautions.append("some of the numerically highest surface rows are TME-dominant and should not be treated as tumor-cell targets")
     if len(surface_targets) and (surface_status.head(10) == "provisional").any():
-        landscape_cautions.append("several high-signal surface rows remain provisional because their tumor attribution is not cleanly separated from benign/background signal")
+        landscape_cautions.append("several high-signal surface rows remain mixed-source because their tumor contribution is not cleanly separated from benign/background signal")
     if matched_normal_summary:
         landscape_cautions.append("benign parent-tissue admixture is active")
     if (
@@ -3816,8 +4094,9 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
 
     # Best surface — promote only rows that remain supported after the
     # attribution reliability pass.
-    safe_surface = surface_targets[surface_status == "supported"].head(3)
-    dropped_dominant = int((surface_status.head(10) != "supported").sum())
+    safe_surface = headline_surface[headline_surface["_status"] == "supported"].head(3)
+    mixed_surface = headline_surface[headline_surface["_status"] == "provisional"].head(3)
+    dropped_dominant = int((surface_status.head(10) == "unsupported").sum())
     if len(safe_surface):
         lines.append("**Best surface targets** (ADC/CAR-T/bispecific):")
         for _, row in safe_surface.iterrows():
@@ -3834,15 +4113,29 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             lines.append(
                 f"- *{dropped_dominant} top-ranked row"
                 + ("s" if dropped_dominant != 1 else "")
-                + " excluded from this summary because their tumor attribution remained provisional or unsupported"
+                + " excluded from this summary because they remained background-dominant"
                 " (see Surface Protein Targets table).*"
             )
+        lines.append("")
+    elif len(mixed_surface):
+        lines.append("**Best surface targets** (ADC/CAR-T/bispecific):")
+        for _, row in mixed_surface.iterrows():
+            reasons = target_reliability_reasons(row)
+            caveat = f", ⚠ {reasons[0]}" if reasons else ""
+            therapy_note = f" — active in {row['therapies']}" if row["therapies"] else ""
+            lines.append(
+                f"- **{row['symbol']}** ({row['median_est']:.0f} TPM, "
+                f"{tumor_attribution_band_text(row)}{caveat}){therapy_note}"
+            )
+        lines.append(
+            "- *These remain mixed-source rather than tumor-supported; treat them as lineage-guided options that need the full attribution and safety context.*"
+        )
         lines.append("")
     elif dropped_dominant:
         lines.append(
             "**Best surface targets** (ADC/CAR-T/bispecific): "
-            "all top-ranked rows were flagged TME-dominant (⚠⚠) and "
-            "are not safe to recommend. See Surface Protein Targets "
+            "all top-ranked rows remained background-dominant "
+            "after the current uncertainty pass. See Surface Protein Targets "
             "table for full context."
         )
         lines.append("")

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -80,9 +80,11 @@ from .format import (
     render_tpm,
 )
 from .reporting import (
+    cancer_code_display_name,
     cancer_key_genes_lookup_for_analysis,
     clinical_maturity_summary,
     normal_expression_context,
+    subtype_curation_scope_note,
     tumor_band_cell,
     target_interpretation_summary,
     target_reliability_reasons,
@@ -3708,7 +3710,15 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             )
             if panel_code != cancer_code or panel_subtype:
                 lines.append(
-                    f"*Subtype-resolved curation:* using the `{panel_display}` panel rather than the umbrella `{cancer_code}` union.\n"
+                    "*Subtype-resolved curation:* "
+                    + subtype_curation_scope_note(
+                        panel_code,
+                        panel_subtype=panel_subtype,
+                        base_code=cancer_code,
+                        base_name=analysis.get("cancer_name") or cancer_code,
+                        noun="biomarker and therapy curation",
+                    )
+                    + "\n"
                 )
             biomarker_syms = (
                 cancer_biomarker_genes(panel_code, subtype=panel_subtype)
@@ -3735,7 +3745,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             lines.append(f"## Therapy Target Landscape — {panel_display}\n")
             lines.append(
                 "Approved and trialed agents with an indication for this "
-                "cancer type, cross-referenced against sample expression. "
+                f"{cancer_code_display_name(panel_code, panel_display)}, cross-referenced against sample expression. "
                 "Rows where the target is absent from the sample are "
                 "still shown to make that explicit.\n"
             )

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -76,6 +76,11 @@ from .format import (
     render_fraction_no_decimal,
     render_tpm,
 )
+from .reporting import (
+    cancer_key_genes_lookup_for_analysis,
+    target_reliability_reasons,
+    target_reliability_status,
+)
 
 _DATASET_SOURCES = {
     "ADC-approved": "Wiley, doi:10.1002/cac2.12517",
@@ -2387,6 +2392,156 @@ def _next_best_support_gap(candidate_trace):
     return runner.get("code"), top_n / runner_n
 
 
+def _strip_terminal_punctuation(text):
+    if text is None:
+        return ""
+    return str(text).strip().rstrip(".;:! ")
+
+
+def _target_reliability_series(df, *, category=None):
+    import pandas as pd
+
+    if df is None:
+        return pd.Series(dtype=object)
+    if len(df) == 0:
+        return pd.Series(dtype=object, index=df.index)
+    return pd.Series(
+        [
+            target_reliability_status(row, category=category)
+            for _, row in df.iterrows()
+        ],
+        index=df.index,
+    )
+
+
+def _composition_highlights(decomp_result, *, top_n=3):
+    if decomp_result is None:
+        return []
+    fractions = dict(getattr(decomp_result, "fractions", {}) or {})
+    non_tumor = sorted(
+        (
+            (comp, float(frac))
+            for comp, frac in fractions.items()
+            if comp != "tumor" and float(frac) >= 0.03
+        ),
+        key=lambda kv: -kv[1],
+    )
+    highlights = []
+    for comp, frac in non_tumor[:top_n]:
+        label = str(comp).replace("matched_normal_", "matched-normal ").replace("_", " ")
+        highlights.append(f"{label} {frac:.0%}")
+    return highlights
+
+
+def _integrated_evidence_bullets(analysis, decomp_results=None):
+    candidate_trace = analysis.get("candidate_trace", [])
+    fit_quality = analysis.get("fit_quality", {})
+    cancer_code = analysis.get("cancer_type")
+    purity = analysis.get("purity") or {}
+    sample_context = analysis.get("sample_context")
+    hvt = analysis.get("healthy_vs_tumor")
+    call_summary = analysis.get("call_summary") or _summarize_sample_call(
+        analysis,
+        decomp_results or [],
+        sample_mode=analysis.get("sample_mode", "auto"),
+    )
+    best_decomp = decomp_results[0] if decomp_results else None
+    bullets = []
+
+    if candidate_trace:
+        best = candidate_trace[0]
+        runner = candidate_trace[1] if len(candidate_trace) > 1 else None
+        sentence = f"- **Classifier line**: {best['code']} is the leading label"
+        if runner is not None:
+            runner_norm = float(runner.get("support_norm", 0.0) or 0.0)
+            if runner_norm > 0:
+                sentence += f", ahead of {runner['code']} by {1.0 / runner_norm:.1f}x on normalized support"
+            else:
+                sentence += f", with {runner['code']} the next candidate"
+        if best.get("signature_score") is not None:
+            sentence += f"; signature {best['signature_score']:.2f}"
+        if best.get("lineage_concordance") is not None:
+            sentence += f", lineage concordance {best['lineage_concordance']:.2f}"
+        sentence += "."
+        bullets.append(sentence)
+
+    if hvt is not None and getattr(hvt, "top_tcga_cohorts", None):
+        coarse = str(hvt.top_tcga_cohorts[0][0]).replace("FPKM_", "")
+        if coarse == cancer_code:
+            bullets.append(
+                f"- **Coarse prior**: Step-0 is `{hvt.cancer_hint}` and its top TCGA match ({coarse}) agrees with the working call."
+            )
+        elif coarse in call_summary.get("label_options", []):
+            bullets.append(
+                f"- **Coarse prior**: Step-0 is `{hvt.cancer_hint}` and keeps {coarse} alive as one of the same competing labels carried downstream."
+            )
+        else:
+            bullets.append(
+                f"- **Coarse prior**: Step-0 is `{hvt.cancer_hint}`, but its top TCGA match is {coarse}; the final {cancer_code} call depends on the later classifier/decomposition evidence rather than the coarse screen alone."
+            )
+
+    if best_decomp is not None:
+        comp_bits = _composition_highlights(best_decomp)
+        sentence = (
+            f"- **Decomposition line**: best template is `{best_decomp.cancer_type} / {best_decomp.template}`"
+        )
+        if best_decomp.cancer_type == cancer_code:
+            sentence += ", consistent with the classifier"
+        else:
+            sentence += f", diverging from the classifier's {cancer_code} call"
+        if comp_bits:
+            sentence += "; dominant non-tumor components are " + ", ".join(comp_bits)
+        if getattr(best_decomp, "warnings", None):
+            sentence += f"; key warning: {_strip_terminal_punctuation(best_decomp.warnings[0])}"
+        sentence += "."
+        bullets.append(sentence)
+
+    parallel = []
+    label_options = call_summary.get("label_options", [])
+    if len(label_options) >= 2:
+        parallel.append("cancer-type labels " + " vs ".join(label_options[:2]))
+    hypothesis_display = call_summary.get("hypothesis_display", [])
+    if len(hypothesis_display) >= 2:
+        parallel.append("template/site hypotheses " + " vs ".join(hypothesis_display[:2]))
+    if parallel:
+        bullets.append(
+            "- **Parallel hypotheses still alive**: " + "; ".join(parallel) + "."
+        )
+
+    uncertainty = []
+    fit_label = fit_quality.get("label")
+    fit_message = _strip_terminal_punctuation(fit_quality.get("message"))
+    if fit_label in {"weak", "ambiguous"} and fit_message:
+        uncertainty.append(fit_message)
+    try:
+        overall = float(purity.get("overall_estimate"))
+        lower = float(purity.get("overall_lower"))
+        upper = float(purity.get("overall_upper"))
+        if overall < 0.20:
+            uncertainty.append("low purity amplifies residual host/background signal")
+        if upper - lower >= 0.25:
+            uncertainty.append(f"purity remains broad at {lower:.0%}-{upper:.0%}")
+    except (TypeError, ValueError):
+        pass
+    integration = purity.get("components", {}).get("integration", {})
+    if integration.get("signature_deprioritized"):
+        uncertainty.append("tumor-specific signature evidence was downweighted relative to lineage/background evidence")
+    if sample_context is not None and getattr(sample_context, "is_degraded", False):
+        uncertainty.append("RNA degradation lowers confidence for long-transcript negatives")
+    if call_summary.get("site_indeterminate"):
+        note = _strip_terminal_punctuation(call_summary.get("site_note") or "site/template assignment remains indeterminate")
+        if note:
+            uncertainty.append(note)
+    if best_decomp is not None and getattr(best_decomp, "matched_normal_fraction", 0.0) >= 0.15:
+        uncertainty.append(
+            f"benign parent-tissue admixture is large ({best_decomp.matched_normal_fraction:.0%})"
+        )
+    if uncertainty:
+        bullets.append("- **Main uncertainties**: " + "; ".join(dict.fromkeys(uncertainty)) + ".")
+
+    return bullets
+
+
 def _generate_text_reports(
     analysis, embedding_meta, prefix, decomp_results=None, input_path=None,
 ):
@@ -2430,6 +2585,14 @@ def _generate_text_reports(
     # sees the clinical framing before descending into pipeline detail.
     if disease_state_paragraph:
         lines.append(f"**Disease state**: {disease_state_paragraph}\n")
+
+    integrated_bullets = _integrated_evidence_bullets(
+        analysis, decomp_results or [],
+    )
+    if integrated_bullets:
+        lines.append("## Integrated evidence synthesis\n")
+        lines.extend(integrated_bullets)
+        lines.append("")
 
     # Step-0 tissue composition (#149) — same signal that drives the
     # brief banner and the summary top-line, surfaced here with the
@@ -3068,6 +3231,10 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             parts.append(therapies)
         if include_tcga and pd.notna(row.get("tcga_percentile")):
             parts.append(f"TCGA {row['tcga_percentile']:.0%}")
+        reliability_status = target_reliability_status(row)
+        reliability_reasons = target_reliability_reasons(row)
+        if reliability_status == "provisional" and reliability_reasons:
+            parts.append(f"provisional: {reliability_reasons[0]}")
         if row.get("tme_explainable"):
             parts.append("single-tissue-explainable")
         return f"{row['symbol']} ({'; '.join(parts)})"
@@ -3101,21 +3268,37 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             cancer_key_genes_cancer_types,
         )
 
-        if cancer_code in cancer_key_genes_cancer_types():
+        panel_code, panel_subtype = cancer_key_genes_lookup_for_analysis(
+            cancer_code,
+            analysis,
+            ranges_df=ranges_df,
+        )
+        panel_display = (
+            f"{panel_code} ({str(panel_subtype).replace('_', ' ')})"
+            if panel_subtype else panel_code
+        )
+        if panel_code in cancer_key_genes_cancer_types():
             # Build symbol → row lookup from ranges_df for biomarker
             # expression levels.
             sym_to_row = {}
             for _, rrow in ranges_df.iterrows():
                 sym_to_row[str(rrow["symbol"])] = rrow
 
-            lines.append(f"## Biomarker Panel — {cancer_code}\n")
+            lines.append(f"## Biomarker Panel — {panel_display}\n")
             lines.append(
                 "Clinician-relevant biomarkers for this cancer type: "
                 "lineage confirmation, disease-state indicators, and "
                 "diagnostic markers. **Not therapy targets** — see the "
                 "Therapy Landscape below for druggable genes.\n"
             )
-            biomarker_syms = cancer_biomarker_genes(cancer_code)
+            if panel_code != cancer_code or panel_subtype:
+                lines.append(
+                    f"*Subtype-resolved curation:* using the `{panel_display}` panel rather than the umbrella `{cancer_code}` union.\n"
+                )
+            biomarker_syms = (
+                cancer_biomarker_genes(panel_code, subtype=panel_subtype)
+                if panel_subtype else cancer_biomarker_genes(panel_code)
+            )
             if biomarker_syms:
                 lines.append("| Gene | Observed TPM | Tumor-attributed | Attribution |")
                 lines.append("|------|--------------|------------------|-------------|")
@@ -3138,14 +3321,17 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             else:
                 lines.append("*No biomarker genes curated for this cancer type.*\n")
 
-            lines.append(f"## Therapy Target Landscape — {cancer_code}\n")
+            lines.append(f"## Therapy Target Landscape — {panel_display}\n")
             lines.append(
                 "Approved and trialed agents with an indication for this "
                 "cancer type, cross-referenced against sample expression. "
                 "Rows where the target is absent from the sample are "
                 "still shown to make that explicit.\n"
             )
-            targets_df = cancer_therapy_targets(cancer_code)
+            targets_df = (
+                cancer_therapy_targets(panel_code, subtype=panel_subtype)
+                if panel_subtype else cancer_therapy_targets(panel_code)
+            )
             if len(targets_df):
                 lines.append(
                     "| Target | Agent | Class | Phase | Indication | "
@@ -3251,9 +3437,13 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         .copy()
     )
 
-    safe_surface = surface_targets[~_flag_series(surface_targets, "tme_dominant")].head(3)
+    surface_status = _target_reliability_series(surface_targets)
+    cta_status = _target_reliability_series(ctas, category="CTA")
+    intracellular_status = _target_reliability_series(intracellular)
+
+    safe_surface = surface_targets[surface_status == "supported"].head(3)
     best_cta = ctas.head(3)
-    clean_intracellular = intracellular[~_flag_series(intracellular, "tme_explainable")].head(3)
+    clean_intracellular = intracellular[intracellular_status == "supported"].head(3)
 
     lines.append("## Tumor context for interpretation\n")
     if call_summary.get("label_options"):
@@ -3271,7 +3461,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     if fit_quality.get("label"):
         fit_line = f"- **Fit quality**: {fit_quality['label']}"
         if fit_quality.get("message"):
-            fit_line += f" — {fit_quality['message']}"
+            fit_line += f" — {_strip_terminal_punctuation(fit_quality['message'])}"
         lines.append(fit_line + ".")
     if call_summary.get("site_indeterminate"):
         lines.append("- **Context / site template**: indeterminate; treat site-specific decomposition as provisional.")
@@ -3306,6 +3496,11 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         context_cautions.append("active IFN response can inflate HLA/MHC-class and other interferon-stimulated targets")
     if context_cautions:
         lines.append(f"- **Interpretation caveats**: {'; '.join(context_cautions)}.")
+    integrated_bullets = _integrated_evidence_bullets(analysis)
+    if integrated_bullets:
+        lines.append("")
+        lines.append("### Integrated evidence synthesis\n")
+        lines.extend(integrated_bullets)
     lines.append("")
 
     lines.append("## Therapy landscape at a glance\n")
@@ -3318,7 +3513,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     elif len(surface_targets):
         lines.append(
             "- **Surface-directed modalities**: no clean surface target passed the current reliability filter; "
-            "top rows were TME-dominant or otherwise host-explainable."
+            "top rows were provisional or unsupported under the attribution reliability filters."
         )
     else:
         lines.append("- **Surface-directed modalities**: no surface target rose above the reporting threshold.")
@@ -3339,7 +3534,7 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     elif mhc_status_label == "adequate" and len(intracellular):
         lines.append(
             "- **Intracellular / TCR-style ideas**: MHC-I is adequate, but the current intracellular rows are mostly "
-            "explainable by host-lineage/background signal."
+            "provisional or unsupported under the attribution reliability filters."
         )
     elif len(intracellular):
         lines.append(
@@ -3352,6 +3547,8 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     landscape_cautions = []
     if len(surface_targets) and _flag_series(surface_targets.head(10), "tme_dominant").any():
         landscape_cautions.append("some of the numerically highest surface rows are TME-dominant and should not be treated as tumor-cell targets")
+    if len(surface_targets) and (surface_status.head(10) == "provisional").any():
+        landscape_cautions.append("several high-signal surface rows remain provisional because their tumor attribution is not cleanly separated from benign/background signal")
     if matched_normal_summary:
         landscape_cautions.append("benign parent-tissue admixture is active")
     if (
@@ -3375,7 +3572,12 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
                 fn1_blocked.sort_values("observed_tpm", ascending=False).iloc[0]["therapy_support_note"]
             )
     if landscape_cautions:
-        lines.append(f"- **Landscape cautions**: {'; '.join(landscape_cautions)}.")
+        cleaned_cautions = [
+            _strip_terminal_punctuation(str(item))
+            for item in landscape_cautions
+            if str(item).strip()
+        ]
+        lines.append(f"- **Landscape cautions**: {'; '.join(cleaned_cautions)}.")
     lines.append("")
 
     # Metabolic axes (#158): Step-0 already computes proliferation /
@@ -3605,25 +3807,23 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
     lines.append("## Recommended Targets Summary\n")
 
     def _reliability_badge(row):
-        if row.get("tme_dominant"):
-            return "⚠⚠"  # caller filters these out
-        if row.get("tme_explainable"):
+        status = target_reliability_status(row)
+        if status == "unsupported":
+            return "⚠⚠"
+        if status == "provisional":
             return "⚠"
         return ""
 
-    # Best surface — strict filter on ⚠⚠.
-    safe_surface = surface_targets[~surface_targets.get(
-        "tme_dominant",
-        pd.Series(False, index=surface_targets.index),
-    )].head(3)
-    dropped_dominant = int(
-        surface_targets.head(3).get("tme_dominant", pd.Series(False)).sum()
-    )
+    # Best surface — promote only rows that remain supported after the
+    # attribution reliability pass.
+    safe_surface = surface_targets[surface_status == "supported"].head(3)
+    dropped_dominant = int((surface_status.head(10) != "supported").sum())
     if len(safe_surface):
         lines.append("**Best surface targets** (ADC/CAR-T/bispecific):")
         for _, row in safe_surface.iterrows():
             badge = _reliability_badge(row)
-            caveat = f", {badge} single-tissue-explainable" if badge == "⚠" else ""
+            reasons = target_reliability_reasons(row)
+            caveat = f", {badge} {reasons[0]}" if badge == "⚠" and reasons else ""
             therapy_note = f" — active in {row['therapies']}" if row["therapies"] else ""
             lines.append(
                 f"- **{row['symbol']}** ({row['median_est']:.0f} TPM, "
@@ -3634,8 +3834,8 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
             lines.append(
                 f"- *{dropped_dominant} top-ranked row"
                 + ("s" if dropped_dominant != 1 else "")
-                + " excluded from this summary for being TME-dominant"
-                " (⚠⚠, see Surface Protein Targets table).*"
+                + " excluded from this summary because their tumor attribution remained provisional or unsupported"
+                " (see Surface Protein Targets table).*"
             )
         lines.append("")
     elif dropped_dominant:
@@ -3654,7 +3854,8 @@ def _generate_target_report(ranges_df, analysis, prefix, cancer_type, purity_res
         lines.append("**Best CTA targets** (vaccination even without active trials):")
         for _, row in best_cta.iterrows():
             badge = _reliability_badge(row)
-            caveat = f" — {badge} check vs germline" if badge else ""
+            reasons = target_reliability_reasons(row, category="CTA")
+            caveat = f" — {badge} {reasons[0]}" if badge and reasons else ""
             lines.append(f"- **{row['symbol']}** ({row['median_est']:.0f} TPM, "
                          f"TCGA {row['tcga_percentile']:.0%}){caveat}")
         lines.append("")

--- a/pirlygenes/degenerate_subtype.py
+++ b/pirlygenes/degenerate_subtype.py
@@ -250,6 +250,8 @@ def resolve_degenerate_subtype(
         ``reason`` — short human-readable note for the markdown layer.
         ``pair_id`` — identifier of the matched pair (or ``None``).
         ``alternatives`` — list of the other members of the pair.
+        ``rule`` — the tiebreaker family used (or ``None``).
+        ``shared_signature`` — short label for the shared ambiguous signal.
     """
     if not winning_subtype:
         return {
@@ -258,6 +260,8 @@ def resolve_degenerate_subtype(
             "reason": "",
             "pair_id": None,
             "alternatives": [],
+            "rule": None,
+            "shared_signature": None,
         }
 
     pair_row = _find_pair_for_subtype(
@@ -272,6 +276,8 @@ def resolve_degenerate_subtype(
             "reason": "",
             "pair_id": None,
             "alternatives": [],
+            "rule": None,
+            "shared_signature": None,
         }
 
     members = pair_row["members"]
@@ -296,6 +302,8 @@ def resolve_degenerate_subtype(
             ),
             "pair_id": pair_id,
             "alternatives": alternatives,
+            "rule": rule,
+            "shared_signature": pair_row["shared_signature"],
         }
 
     resolved = None
@@ -317,6 +325,8 @@ def resolve_degenerate_subtype(
             ),
             "pair_id": pair_id,
             "alternatives": alternatives,
+            "rule": rule,
+            "shared_signature": pair_row["shared_signature"],
         }
 
     if resolved == winning_subtype:
@@ -329,6 +339,8 @@ def resolve_degenerate_subtype(
             ),
             "pair_id": pair_id,
             "alternatives": alternatives,
+            "rule": rule,
+            "shared_signature": pair_row["shared_signature"],
         }
 
     return {
@@ -340,6 +352,8 @@ def resolve_degenerate_subtype(
         ),
         "pair_id": pair_id,
         "alternatives": [m for m in members if m != resolved],
+        "rule": rule,
+        "shared_signature": pair_row["shared_signature"],
     }
 
 

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -129,6 +129,7 @@ from .plot_target_deep_dive import (  # noqa: F401
     actionable_surface_targets,
     plot_actionable_targets,
     plot_curated_target_evidence,
+    plot_priority_targets,
     plot_tumor_attribution,
     plot_cta_deep_dive,
 )

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -128,6 +128,7 @@ from .plot_embedding import (  # noqa: F401
 from .plot_target_deep_dive import (  # noqa: F401
     actionable_surface_targets,
     plot_actionable_targets,
+    plot_curated_target_evidence,
     plot_tumor_attribution,
     plot_cta_deep_dive,
 )

--- a/pirlygenes/plot_target_deep_dive.py
+++ b/pirlygenes/plot_target_deep_dive.py
@@ -35,6 +35,11 @@ from .gene_sets_cancer import (
     CTA_gene_id_to_name,
 )
 from .plot_scatter import resolve_cancer_type
+from .reporting import (
+    clinical_maturity_summary,
+    normal_expression_context,
+    tumor_attribution_context,
+)
 
 # ── Essential tissues for safety context ─────────────────────────────────
 
@@ -274,7 +279,10 @@ def plot_actionable_targets(
     custom_genes : list[str] or None
         Override the default curated panel.
     """
-    cancer_code = resolve_cancer_type(cancer_type)
+    try:
+        cancer_code = resolve_cancer_type(cancer_type)
+    except Exception:
+        cancer_code = str(cancer_type)
     genes = custom_genes or actionable_surface_targets(cancer_code)
 
     sample_tpm = _get_sample_tpm_by_symbol(df_gene_expr)
@@ -373,7 +381,10 @@ def plot_tumor_attribution(
     tumor_component = purity × tumor_adjusted
     tme_component = (1 - purity) × tme_reference
     """
-    cancer_code = resolve_cancer_type(cancer_type)
+    try:
+        cancer_code = resolve_cancer_type(cancer_type)
+    except Exception:
+        cancer_code = str(cancer_type)
 
     if category == "CTA":
         cta_map = CTA_gene_id_to_name()
@@ -437,6 +448,216 @@ def plot_tumor_attribution(
     ax.legend(loc="lower right", fontsize=8)
     cat_label = "CTAs" if category == "CTA" else "Actionable Targets"
     ax.set_title(f"Tumor vs TME Attribution — {cat_label} — {cancer_code} (purity={purity:.0%})")
+    fig.tight_layout()
+
+    if save_to_filename:
+        fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+    return fig
+
+
+def plot_curated_target_evidence(
+    ranges_df,
+    target_panel,
+    cancer_type,
+    top_n=12,
+    save_to_filename=None,
+    save_dpi=300,
+):
+    """Integrated view for curated targets: tumor band + normal context.
+
+    The existing matched-normal / safety / attribution plots each show
+    one axis of the story. This plot intentionally combines the three
+    questions the markdown now asks for each curated target:
+
+    - how much tumor-core TPM remains across the uncertainty band,
+    - what kind of normal-expression context that target carries, and
+    - how clinically mature the target class is.
+    """
+    import pandas as pd
+    from matplotlib.lines import Line2D
+
+    if (
+        ranges_df is None
+        or target_panel is None
+        or len(ranges_df) == 0
+        or len(target_panel) == 0
+        or "symbol" not in ranges_df.columns
+        or "symbol" not in target_panel.columns
+    ):
+        return None
+
+    try:
+        cancer_code = resolve_cancer_type(cancer_type)
+    except Exception:
+        cancer_code = str(cancer_type)
+    sym_to_expr = {
+        str(row["symbol"]): row
+        for _, row in ranges_df.iterrows()
+        if str(row.get("symbol") or "")
+    }
+    phase_priority = {
+        "approved": 0,
+        "phase_3": 1,
+        "phase_2": 2,
+        "phase_1": 3,
+        "preclinical": 4,
+    }
+    best_by_symbol = {}
+    for _, trow in target_panel.iterrows():
+        sym = str(trow.get("symbol") or "").strip()
+        if not sym or sym.lower() == "nan" or sym not in sym_to_expr:
+            continue
+        expr = sym_to_expr[sym]
+        try:
+            observed = float(expr.get("observed_tpm") or 0.0)
+        except Exception:
+            observed = 0.0
+        if observed < 1.0:
+            continue
+        sort_key = (
+            phase_priority.get(str(trow.get("phase") or ""), 99),
+            -float(expr.get("attr_tumor_tpm") or 0.0),
+            sym,
+        )
+        if sym not in best_by_symbol or sort_key < best_by_symbol[sym]["sort_key"]:
+            best_by_symbol[sym] = {"target": trow, "expr": expr, "sort_key": sort_key}
+
+    if not best_by_symbol:
+        return None
+
+    normal_colors = {
+        "cta_restricted": "#2ca02c",
+        "restricted_outside_lineage": "#2ca02c",
+        "same_lineage_expected": "#1f77b4",
+        "broad_healthy_expression": "#ff7f0e",
+        "vital_tissue_concern": "#d62728",
+    }
+    source_markers = {
+        "tumor_supported": "o",
+        "mixed_source": "D",
+        "background_dominant": "X",
+    }
+    rows = []
+    for sym, payload in best_by_symbol.items():
+        trow = payload["target"]
+        expr = payload["expr"]
+        source = tumor_attribution_context(expr)
+        normal = normal_expression_context(expr)
+        rows.append(
+            {
+                "symbol": sym,
+                "phase_key": phase_priority.get(str(trow.get("phase") or ""), 99),
+                "mid": float(source["attr_tumor_tpm"]),
+                "low": float(source["attr_tumor_tpm_low"]),
+                "high": float(source["attr_tumor_tpm_high"]),
+                "observed": float(expr.get("observed_tpm") or 0.0),
+                "source": source,
+                "normal": normal,
+                "maturity": clinical_maturity_summary(trow, target_panel=target_panel),
+                "color": normal_colors.get(normal["tier"], "#444444"),
+                "marker": source_markers.get(source["tier"], "o"),
+            }
+        )
+
+    rows.sort(
+        key=lambda row: (
+            row["phase_key"],
+            {"tumor_supported": 0, "mixed_source": 1, "background_dominant": 2}.get(
+                row["source"]["tier"], 9
+            ),
+            -row["mid"],
+            row["symbol"],
+        )
+    )
+    rows = rows[:top_n]
+    if not rows:
+        return None
+
+    fig, ax = plt.subplots(figsize=(12, max(4.5, 0.6 * len(rows) + 1.2)))
+    y_pos = np.arange(len(rows))
+    for i, row in enumerate(rows):
+        ax.hlines(i, row["low"], row["high"], color=row["color"], lw=4, alpha=0.75)
+        ax.scatter(
+            row["mid"],
+            i,
+            s=90,
+            marker=row["marker"],
+            color=row["color"],
+            edgecolor="black",
+            linewidth=0.8,
+            zorder=3,
+        )
+        ax.scatter(
+            row["observed"],
+            i,
+            s=45,
+            marker="|",
+            color="black",
+            linewidth=1.2,
+            zorder=4,
+        )
+        note = f"{row['source']['label']} | {row['normal']['label']} | {row['maturity']}"
+        ax.text(
+            max(row["high"], row["observed"]) * 1.08 + 0.5,
+            i,
+            note,
+            va="center",
+            fontsize=8,
+            color="#555555",
+        )
+
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels([row["symbol"] for row in rows], fontsize=9)
+    ax.invert_yaxis()
+    ax.set_xscale("symlog", linthresh=1.0)
+    ax.set_xlabel("Tumor-core TPM band (point = band median, tick = observed bulk TPM)")
+    ax.set_title(f"Curated Target Evidence — {cancer_code}")
+
+    normal_handles = [
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="none",
+            markerfacecolor=color,
+            markeredgecolor="black",
+            markersize=8,
+            label=label,
+        )
+        for label, color in [
+            ("same-lineage expected", normal_colors["same_lineage_expected"]),
+            ("restricted / CTA-like", normal_colors["restricted_outside_lineage"]),
+            ("broad healthy expression", normal_colors["broad_healthy_expression"]),
+            ("vital-tissue concern", normal_colors["vital_tissue_concern"]),
+        ]
+    ]
+    source_handles = [
+        Line2D(
+            [0],
+            [0],
+            marker=marker,
+            color="#444444",
+            markerfacecolor="#dddddd",
+            markeredgecolor="black",
+            linestyle="none",
+            markersize=8,
+            label=label.replace("_", "-"),
+        )
+        for label, marker in source_markers.items()
+    ]
+    legend1 = ax.legend(
+        handles=normal_handles,
+        loc="lower right",
+        fontsize=8,
+        title="Normal-expression context",
+    )
+    ax.add_artist(legend1)
+    ax.legend(
+        handles=source_handles,
+        loc="upper right",
+        fontsize=8,
+        title="Tumor-source support",
+    )
     fig.tight_layout()
 
     if save_to_filename:

--- a/pirlygenes/plot_target_deep_dive.py
+++ b/pirlygenes/plot_target_deep_dive.py
@@ -36,6 +36,7 @@ from .gene_sets_cancer import (
 )
 from .plot_scatter import resolve_cancer_type
 from .reporting import (
+    clinical_maturity_info,
     clinical_maturity_summary,
     normal_expression_context,
     tumor_attribution_context,
@@ -659,6 +660,424 @@ def plot_curated_target_evidence(
         title="Tumor-source support",
     )
     fig.tight_layout()
+
+    if save_to_filename:
+        fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
+    return fig
+
+
+def plot_priority_targets(
+    ranges_df,
+    cancer_type,
+    target_panel=None,
+    df_gene_expr=None,
+    top_n=12,
+    save_to_filename=None,
+    save_dpi=300,
+):
+    """Rank actionable targets by integrated evidence and uncertainty.
+
+    This plot is intentionally opinionated. It combines:
+
+    - tumor-source support under the purity / background uncertainty band,
+    - actionability / clinical maturity,
+    - normal-expression context, and
+    - tumor-core expression strength.
+
+    Unlike ``plot_curated_target_evidence()``, this view is allowed to pull
+    in strong non-panel therapy-linked targets so sample-specific hits such
+    as FAP are not hidden just because they sit outside the disease-matched
+    curation table.
+    """
+    import pandas as pd
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+
+    if (
+        ranges_df is None
+        or len(ranges_df) == 0
+        or "symbol" not in ranges_df.columns
+    ):
+        return None
+
+    from .plot_therapy import _collect_ranked_therapy_targets
+
+    try:
+        cancer_code = resolve_cancer_type(cancer_type)
+    except Exception:
+        cancer_code = str(cancer_type)
+
+    phase_priority = {
+        "approved": 0,
+        "phase_3": 1,
+        "phase_2": 2,
+        "phase_1": 3,
+        "preclinical": 4,
+    }
+    phase_points = {
+        "approved": 3.0,
+        "phase_3": 2.6,
+        "phase_2": 2.2,
+        "phase_1": 1.7,
+        "preclinical": 1.0,
+    }
+    source_rank = {
+        "tumor_supported": 0,
+        "mixed_source": 1,
+        "background_dominant": 2,
+    }
+    source_markers = {
+        "tumor_supported": "o",
+        "mixed_source": "D",
+        "background_dominant": "X",
+    }
+    normal_colors = {
+        "cta_restricted": "#2ca02c",
+        "restricted_outside_lineage": "#2ca02c",
+        "same_lineage_expected": "#1f77b4",
+        "broad_healthy_expression": "#ff7f0e",
+        "vital_tissue_concern": "#d62728",
+    }
+    source_colors = {
+        "tumor_supported": "#2e8b57",
+        "mixed_source": "#c28f2c",
+        "background_dominant": "#c44e52",
+    }
+
+    curated_by_symbol = {}
+    if target_panel is not None and len(target_panel) and "symbol" in target_panel.columns:
+        for _, trow in target_panel.iterrows():
+            sym = str(trow.get("symbol") or "").strip()
+            if not sym or sym.lower() == "nan":
+                continue
+            sort_key = (
+                phase_priority.get(str(trow.get("phase") or ""), 99),
+                str(trow.get("agent") or ""),
+            )
+            if sym not in curated_by_symbol or sort_key < curated_by_symbol[sym]["sort_key"]:
+                curated_by_symbol[sym] = {"target": trow, "sort_key": sort_key}
+
+    generic_by_symbol = {}
+    if df_gene_expr is not None:
+        try:
+            generic_records = _collect_ranked_therapy_targets(
+                df_gene_expr,
+                top_k=max(int(top_n) * 4, 30),
+                tpm_threshold=1.0,
+            )
+        except Exception:
+            generic_records = []
+        for record in generic_records:
+            sym = str(record.get("symbol") or "").strip()
+            if sym:
+                generic_by_symbol[sym] = record
+
+    def _therapy_list(row):
+        raw = str(row.get("therapies") or "").strip()
+        if not raw:
+            return []
+        return [piece.strip() for piece in raw.split(",") if piece.strip()]
+
+    def _normal_component(normal):
+        base = {
+            "cta_restricted": 2.2,
+            "restricted_outside_lineage": 2.0,
+            "same_lineage_expected": 1.7,
+            "broad_healthy_expression": 0.9,
+            "vital_tissue_concern": 0.6,
+        }.get(normal["tier"], 1.0)
+        for detail in normal.get("details") or []:
+            text = str(detail)
+            if "broader healthy-tissue signal" in text:
+                base -= 0.45
+            elif "expression is appreciable" in text:
+                base -= 0.20
+        return max(0.25, base)
+
+    def _source_component(source, row):
+        score = {
+            "tumor_supported": 4.0,
+            "mixed_source": 2.6,
+            "background_dominant": 0.5,
+        }.get(source["tier"], 1.0)
+        score += 1.4 * float(source.get("attr_support_fraction") or 0.0)
+        score += 1.1 * min(1.0, float(source.get("attr_tumor_fraction_low") or 0.0) / 0.5)
+        if bool(row.get("matched_normal_over_predicted")):
+            score -= 0.8
+        if bool(row.get("tme_dominant")):
+            score -= 1.0
+        return max(0.1, score)
+
+    def _strength_component(source, row):
+        tcga_percentile = 0.0
+        try:
+            tcga_percentile = float(row.get("tcga_percentile") or 0.0)
+        except Exception:
+            tcga_percentile = 0.0
+        tcga_percentile = min(1.0, max(0.0, tcga_percentile))
+        return min(
+            3.0,
+            0.9 * np.log10(float(source["attr_tumor_tpm"]) + 1.0)
+            + 0.8 * tcga_percentile,
+        )
+
+    def _actionability_components(sym, row):
+        curated = curated_by_symbol.get(sym, {}).get("target")
+        generic = generic_by_symbol.get(sym)
+        therapies = _therapy_list(row)
+        if curated is not None:
+            maturity = clinical_maturity_info(curated, target_panel=target_panel)
+            phase = str(curated.get("phase") or "")
+            points = phase_points.get(phase, 0.8)
+            points += 0.8  # disease-matched curated indication bonus
+            points += min(0.4, 0.15 * max(0, maturity.get("n_modalities", 0) - 1))
+            points += min(0.3, 0.05 * max(0, maturity.get("n_agents", 0) - 1))
+            label = maturity["summary"]
+            matched_panel = True
+        elif generic is not None and generic.get("has_approved"):
+            approved_therapies = generic.get("approved_therapies") or ()
+            points = 1.9 + min(0.4, 0.15 * max(0, len(approved_therapies) - 1))
+            label = f"generic approved {str(generic.get('approved_label') or '').lower()}"
+            matched_panel = False
+        else:
+            points = 1.1 + min(0.4, 0.15 * max(0, len(therapies) - 1))
+            if therapies:
+                label = f"generic {' + '.join(therapies).lower()}"
+            else:
+                label = "generic therapy-linked"
+            matched_panel = False
+        return points, label.strip(), matched_panel
+
+    rows = []
+    for _, row in ranges_df.iterrows():
+        sym = str(row.get("symbol") or "").strip()
+        if not sym or sym.lower() == "nan":
+            continue
+        therapies = _therapy_list(row)
+        curated = curated_by_symbol.get(sym, {}).get("target")
+        generic = generic_by_symbol.get(sym)
+        if curated is None and not therapies and generic is None:
+            continue
+        try:
+            observed = float(row.get("observed_tpm") or 0.0)
+        except Exception:
+            observed = 0.0
+        if observed < 1.0:
+            continue
+        therapy_supported = row.get("therapy_supported")
+        if therapy_supported is False and curated is None:
+            continue
+
+        source = tumor_attribution_context(row)
+        normal = normal_expression_context(row)
+        actionability_points, actionability_label, matched_panel = _actionability_components(sym, row)
+        source_points = _source_component(source, row)
+        normal_points = _normal_component(normal)
+        strength_points = _strength_component(source, row)
+        total_score = source_points + actionability_points + normal_points + strength_points
+
+        note_parts = []
+        if matched_panel:
+            note_parts.append("panel-matched")
+        note_parts.extend(
+            [
+                source["label"],
+                normal["label"],
+                actionability_label,
+            ]
+        )
+        if source.get("notes"):
+            note_parts.append(source["notes"][0])
+        elif normal.get("details"):
+            note_parts.append(normal["details"][0])
+
+        rows.append(
+            {
+                "symbol": sym,
+                "observed": observed,
+                "low": float(source["attr_tumor_tpm_low"]),
+                "mid": float(source["attr_tumor_tpm"]),
+                "high": float(source["attr_tumor_tpm_high"]),
+                "source": source,
+                "normal": normal,
+                "matched_panel": matched_panel,
+                "note": " | ".join(part for part in note_parts if part),
+                "source_points": source_points,
+                "actionability_points": actionability_points,
+                "normal_points": normal_points,
+                "strength_points": strength_points,
+                "total_score": total_score,
+                "phase_key": phase_priority.get(
+                    str(curated.get("phase") or "") if curated is not None else "",
+                    99 if curated is None else 9,
+                ),
+                "source_key": source_rank.get(source["tier"], 9),
+                "color": normal_colors.get(normal["tier"], "#444444"),
+                "marker": source_markers.get(source["tier"], "o"),
+            }
+        )
+
+    if not rows:
+        return None
+
+    rows.sort(
+        key=lambda row: (
+            -row["total_score"],
+            row["source_key"],
+            row["phase_key"],
+            -row["mid"],
+            row["symbol"],
+        )
+    )
+    rows = rows[:top_n]
+
+    fig, (ax_score, ax_expr) = plt.subplots(
+        1,
+        2,
+        figsize=(16, max(5.0, 0.72 * len(rows) + 1.8)),
+        gridspec_kw={"width_ratios": [1.0, 1.55]},
+    )
+    y_pos = np.arange(len(rows))
+
+    score_parts = [
+        ("Tumor-source", "source_points", "#2e8b57"),
+        ("Actionability", "actionability_points", "#4a90d9"),
+        ("Normal-context fit", "normal_points", "#9b59b6"),
+        ("Tumor-core strength", "strength_points", "#8c8c8c"),
+    ]
+    left = np.zeros(len(rows))
+    for label, key, color in score_parts:
+        values = [row[key] for row in rows]
+        ax_score.barh(
+            y_pos,
+            values,
+            left=left,
+            color=color,
+            edgecolor="white",
+            linewidth=0.5,
+            height=0.7,
+            label=label,
+        )
+        left += np.array(values)
+
+    for i, row in enumerate(rows):
+        ax_score.text(
+            row["total_score"] + 0.12,
+            i,
+            f"{row['total_score']:.1f}",
+            va="center",
+            fontsize=8,
+            color="#444444",
+        )
+        ax_expr.hlines(i, row["low"], row["high"], color=row["color"], lw=5, alpha=0.78)
+        ax_expr.scatter(
+            row["mid"],
+            i,
+            s=95,
+            marker=row["marker"],
+            color=row["color"],
+            edgecolor="black",
+            linewidth=0.8,
+            zorder=3,
+        )
+        ax_expr.scatter(
+            row["observed"],
+            i,
+            s=55,
+            marker="|",
+            color="black",
+            linewidth=1.3,
+            zorder=4,
+        )
+        ax_expr.text(
+            max(row["high"], row["observed"]) * 1.07 + 0.5,
+            i,
+            row["note"],
+            va="center",
+            fontsize=8,
+            color="#555555",
+        )
+
+    labels = [
+        f"{row['symbol']}{'*' if row['matched_panel'] else ''}"
+        for row in rows
+    ]
+    for ax in (ax_score, ax_expr):
+        ax.set_yticks(y_pos)
+        ax.set_yticklabels(labels, fontsize=9)
+        ax.invert_yaxis()
+        ax.grid(axis="x", color="#dddddd", linewidth=0.6, alpha=0.7)
+        ax.set_axisbelow(True)
+
+    ax_score.set_xlabel("Integrated priority score")
+    ax_score.set_title("Ranked Priority", fontsize=11)
+    ax_score.legend(loc="lower right", fontsize=8)
+
+    ax_expr.set_xscale("symlog", linthresh=1.0)
+    ax_expr.set_xlabel("Tumor-core TPM band (point = band median, tick = observed bulk TPM)")
+    ax_expr.set_title("Tumor-Core Band + Context", fontsize=11)
+
+    normal_handles = [
+        Patch(
+            facecolor=color,
+            edgecolor="black",
+            label=label,
+        )
+        for label, color in [
+            ("same-lineage expected", normal_colors["same_lineage_expected"]),
+            ("restricted / CTA-like", normal_colors["restricted_outside_lineage"]),
+            ("broad healthy expression", normal_colors["broad_healthy_expression"]),
+            ("vital-tissue concern", normal_colors["vital_tissue_concern"]),
+        ]
+    ]
+    source_handles = [
+        Line2D(
+            [0],
+            [0],
+            marker=marker,
+            color="none",
+            markerfacecolor=source_colors.get(label, "#dddddd"),
+            markeredgecolor="black",
+            linestyle="none",
+            markersize=8,
+            label=label.replace("_", "-"),
+        )
+        for label, marker in source_markers.items()
+    ]
+    panel_handle = Line2D(
+        [0],
+        [0],
+        marker=None,
+        color="none",
+        linestyle="none",
+        label="* panel-matched curated target",
+    )
+    legend1 = ax_expr.legend(
+        handles=normal_handles,
+        loc="lower right",
+        fontsize=8,
+        title="Normal-expression context",
+    )
+    ax_expr.add_artist(legend1)
+    ax_expr.legend(
+        handles=source_handles + [panel_handle],
+        loc="upper right",
+        fontsize=8,
+        title="Tumor-source support",
+    )
+
+    fig.suptitle(f"Priority Targets — Integrated Evidence — {cancer_code}", fontsize=13, y=0.985)
+    fig.text(
+        0.5,
+        0.955,
+        "Score combines tumor-source support, actionability / maturity, normal-expression context, and tumor-core strength. "
+        "Bands show uncertainty across purity / background assumptions.",
+        ha="center",
+        va="top",
+        fontsize=9,
+        color="#555555",
+    )
+    fig.tight_layout(rect=[0.0, 0.0, 1.0, 0.93])
 
     if save_to_filename:
         fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -555,6 +555,7 @@ def estimate_tumor_expression_ranges(
     matched_normal_tissue = None
     matched_normal_fraction_global = 0.0
     per_compartment_tpm_by_symbol = None  # #108: per-gene per-compartment TPM
+    top_fractions = {}
     if decomposition_results:
         top_result = decomposition_results[0]
         top_fractions = getattr(top_result, "fractions", None) or {}
@@ -671,6 +672,23 @@ def estimate_tumor_expression_ranges(
     p_med = max(purity_result.get("overall_estimate") or 0.05, 0.01)
     p_hi = max(purity_result.get("overall_upper") or p_med, 0.01)
     p_lo, p_med, p_hi = sorted([p_lo, p_med, p_hi])
+
+    LOW_PURITY_THRESHOLD = 0.25
+    LOW_PURITY_HEADROOM = 3.0
+
+    def _scale_non_tumor_tpm(base_tpm, purity_used):
+        denom = max(1.0 - float(p_med), 1e-3)
+        numer = max(0.0, 1.0 - float(purity_used))
+        return float(base_tpm) * (numer / denom)
+
+    def _tumor_fraction_for_purity(purity_used):
+        tumor_fraction_fit = float(top_fractions.get("tumor", 0.0) or 0.0)
+        if tumor_fraction_fit <= 0 or p_med <= 0:
+            return max(0.0, min(1.0, float(purity_used)))
+        return max(
+            0.0,
+            min(1.0, tumor_fraction_fit * float(purity_used) / float(p_med)),
+        )
 
     # --- Gene category lookups ---
     cta_symbols = set(CTA_gene_id_to_name().values())
@@ -1061,6 +1079,54 @@ def estimate_tumor_expression_ranges(
         non_tumor_frac = max(0.0, min(1.0, 1.0 - p_med))
         breadth_floor = non_tumor_frac * mean_top_healthy_tpm
 
+        def _attribution_candidate(purity_used):
+            scaled_attr = {
+                comp: _scale_non_tumor_tpm(val, purity_used)
+                for comp, val in attribution.items()
+            }
+            attr_total_candidate = sum(scaled_attr.values())
+            breadth_floor_candidate = (
+                max(0.0, min(1.0, 1.0 - float(purity_used)))
+                * mean_top_healthy_tpm
+            )
+            over_predicted_candidate = observed > 0 and attr_total_candidate > observed
+            if over_predicted_candidate:
+                tumor_fraction_fit = _tumor_fraction_for_purity(purity_used)
+                tumor_candidate = max(
+                    0.0,
+                    min(
+                        observed * tumor_fraction_fit,
+                        observed - breadth_floor_candidate,
+                    ),
+                )
+            else:
+                tumor_candidate = max(
+                    0.0,
+                    observed - max(attr_total_candidate, breadth_floor_candidate),
+                )
+
+            capped = False
+            if (
+                purity_used is not None
+                and float(purity_used) < LOW_PURITY_THRESHOLD
+                and not over_predicted_candidate
+                and observed > 0
+            ):
+                purity_cap = observed * float(purity_used) * LOW_PURITY_HEADROOM
+                if tumor_candidate > purity_cap:
+                    tumor_candidate = purity_cap
+                    capped = True
+
+            tumor_fraction_candidate = (
+                float(tumor_candidate / observed) if observed > 0 else 0.0
+            )
+            return (
+                tumor_candidate,
+                tumor_fraction_candidate,
+                over_predicted_candidate,
+                capped,
+            )
+
         # Effective non-tumor attribution = max of
         # (per-compartment fit, breadth baseline). For gene-sparse
         # cases where the compartment fit is tiny but healthy cells
@@ -1100,8 +1166,6 @@ def estimate_tumor_expression_ranges(
         # 0.16 * 279 * 3 = 134 → dropped to 134 (the tumor share this
         # compartment pattern + purity can plausibly support).
         low_purity_cap_applied = False
-        LOW_PURITY_THRESHOLD = 0.25
-        LOW_PURITY_HEADROOM = 3.0
         if (
             p_med is not None
             and p_med < LOW_PURITY_THRESHOLD
@@ -1112,9 +1176,51 @@ def estimate_tumor_expression_ranges(
             if attr_tumor_tpm > purity_cap:
                 attr_tumor_tpm = purity_cap
                 low_purity_cap_applied = True
+
+        attr_estimates = []
+        attr_fraction_estimates = []
+        attr_over_predicted_flags = []
+        attr_capped_flags = []
+        for purity_used in [p_lo, p_med, p_hi]:
+            tumor_candidate, fraction_candidate, over_flag, capped_flag = _attribution_candidate(
+                purity_used
+            )
+            attr_estimates.append(float(tumor_candidate))
+            attr_fraction_estimates.append(float(fraction_candidate))
+            attr_over_predicted_flags.append(bool(over_flag))
+            attr_capped_flags.append(bool(capped_flag))
+        attr_tumor_tpm = float(np.median(attr_estimates))
         attr_tumor_fraction = (
-            float(attr_tumor_tpm / observed) if observed > 0 else 0.0
+            float(np.median(attr_fraction_estimates))
+            if attr_fraction_estimates else 0.0
         )
+        attr_tumor_tpm_low = float(min(attr_estimates)) if attr_estimates else attr_tumor_tpm
+        attr_tumor_tpm_high = float(max(attr_estimates)) if attr_estimates else attr_tumor_tpm
+        attr_tumor_fraction_low = (
+            float(min(attr_fraction_estimates))
+            if attr_fraction_estimates else attr_tumor_fraction
+        )
+        attr_tumor_fraction_high = (
+            float(max(attr_fraction_estimates))
+            if attr_fraction_estimates else attr_tumor_fraction
+        )
+        attr_support_fraction = (
+            float(
+                np.mean(
+                    [
+                        1.0
+                        if (tpm >= 1.0 and frac >= 0.30) else 0.0
+                        for tpm, frac in zip(attr_estimates, attr_fraction_estimates)
+                    ]
+                )
+            )
+            if attr_estimates else 0.0
+        )
+        low_purity_cap_applied = bool(low_purity_cap_applied or any(attr_capped_flags))
+        matched_normal_over_predicted = bool(
+            matched_normal_over_predicted or any(attr_over_predicted_flags)
+        )
+
         if attribution:
             attr_top_comp, attr_top_tpm = max(
                 attribution.items(), key=lambda kv: kv[1]
@@ -1165,6 +1271,11 @@ def estimate_tumor_expression_ranges(
             "attribution": attribution,
             "attr_tumor_tpm": round(attr_tumor_tpm, 2),
             "attr_tumor_fraction": round(attr_tumor_fraction, 4),
+            "attr_tumor_tpm_low": round(attr_tumor_tpm_low, 2),
+            "attr_tumor_tpm_high": round(attr_tumor_tpm_high, 2),
+            "attr_tumor_fraction_low": round(attr_tumor_fraction_low, 4),
+            "attr_tumor_fraction_high": round(attr_tumor_fraction_high, 4),
+            "attr_support_fraction": round(attr_support_fraction, 4),
             "attr_top_compartment": attr_top_comp,
             "attr_top_compartment_tpm": round(float(attr_top_tpm), 2),
             # #204: True when the low-purity cap damped attr_tumor_tpm

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -200,14 +200,14 @@ def build_provenance_md(
             n_core = int(len(supported_core))
             lines.append(
                 f"After subtracting the fitted non-tumor compartments, "
-                f"**{n_core} genes** retain ≥1 TPM of supported "
+                f"**{n_core} genes** retain ≥1 TPM of tumor-supported "
                 "tumor-attributed expression."
             )
             if len(provisional_core):
                 reason_summary = summarize_reliability_reasons(provisional_core)
                 lines.append(
                     f"\nAn additional **{len(provisional_core)} genes** retain residual "
-                    "tumor-attributed TPM but stay provisional in the markdown layer"
+                    "tumor-attributed TPM but remain mixed-source in the markdown layer"
                     + (
                         f" ({reason_summary})."
                         if reason_summary else "."
@@ -223,8 +223,8 @@ def build_provenance_md(
                 lines.append(f"\nTop tumor-core genes (symbol, tumor TPM): {names}.")
             elif len(provisional_core):
                 lines.append(
-                    "\nNo gene cleared the current high-confidence tumor-core filter; "
-                    "use the provisional rows in `targets.md` and the TSV for manual review."
+                    "\nNo gene cleared the current tumor-supported filter; "
+                    "use the mixed-source rows in `targets.md` and the TSV for manual review."
                 )
     else:
         lines.append("*No target-expression ranges available.*")

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -14,6 +14,7 @@ figure, cross-linked from the other reports.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Optional
 
 import numpy as np
@@ -26,6 +27,17 @@ from .reporting import (
 
 def _compartment_label(comp: str) -> str:
     return comp.replace("matched_normal_", "matched-normal ").replace("_", " ")
+
+
+def _display_sample_id(sample_id: Optional[str]) -> Optional[str]:
+    if sample_id is None:
+        return None
+    text = str(sample_id).strip()
+    if not text:
+        return None
+    if "/" in text or "\\" in text:
+        text = Path(text).name.strip()
+    return text or None
 
 
 def build_provenance_md(
@@ -44,6 +56,7 @@ def build_provenance_md(
     sample_context = analysis.get("sample_context")
     purity = analysis.get("purity") or {}
     lines: List[str] = []
+    sample_id = _display_sample_id(sample_id)
     header_id = f": {sample_id}" if sample_id else ""
     lines.append(f"# Sample provenance{header_id}\n")
     lines.append(

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -18,6 +18,11 @@ from typing import List, Optional
 
 import numpy as np
 
+from .reporting import (
+    partition_tumor_core_rows,
+    summarize_reliability_reasons,
+)
+
 
 def _compartment_label(comp: str) -> str:
     return comp.replace("matched_normal_", "matched-normal ").replace("_", " ")
@@ -189,24 +194,38 @@ def build_provenance_md(
     lines.append("## 5. Tumor-specific core\n")
     if ranges_df is not None and len(ranges_df):
         if "attribution" in ranges_df.columns:
-            has_attr = ranges_df["attribution"].apply(
-                lambda v: isinstance(v, dict) and len(v) > 0
+            supported_core, provisional_core, _ = partition_tumor_core_rows(
+                ranges_df, min_tumor_tpm=1.0,
             )
-            core = ranges_df[has_attr & (ranges_df["attr_tumor_tpm"].astype(float) > 1.0)]
-            n_core = int(len(core))
+            n_core = int(len(supported_core))
             lines.append(
                 f"After subtracting the fitted non-tumor compartments, "
-                f"**{n_core} genes** retain ≥1 TPM of tumor-attributed "
-                "expression."
+                f"**{n_core} genes** retain ≥1 TPM of supported "
+                "tumor-attributed expression."
             )
-            # Top 5 tumor-core genes.
-            top = core.sort_values("attr_tumor_tpm", ascending=False).head(5)
+            if len(provisional_core):
+                reason_summary = summarize_reliability_reasons(provisional_core)
+                lines.append(
+                    f"\nAn additional **{len(provisional_core)} genes** retain residual "
+                    "tumor-attributed TPM but stay provisional in the markdown layer"
+                    + (
+                        f" ({reason_summary})."
+                        if reason_summary else "."
+                    )
+                )
+            # Top 5 supported tumor-core genes.
+            top = supported_core.sort_values("attr_tumor_tpm", ascending=False).head(5)
             if len(top):
                 names = ", ".join(
                     f"{str(r['symbol'])} ({float(r['attr_tumor_tpm']):.0f})"
                     for _, r in top.iterrows()
                 )
                 lines.append(f"\nTop tumor-core genes (symbol, tumor TPM): {names}.")
+            elif len(provisional_core):
+                lines.append(
+                    "\nNo gene cleared the current high-confidence tumor-core filter; "
+                    "use the provisional rows in `targets.md` and the TSV for manual review."
+                )
     else:
         lines.append("*No target-expression ranges available.*")
     lines.append("")

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -130,6 +130,35 @@ def tumor_attribution_band_text(row):
     return tumor_attribution_context(row)["band"]
 
 
+def tumor_band_available(row):
+    """Whether a row carries a usable tumor-core uncertainty band."""
+    for key in (
+        "attr_tumor_tpm",
+        "attr_tumor_tpm_low",
+        "attr_tumor_tpm_high",
+        "attr_tumor_fraction",
+        "attr_tumor_fraction_high",
+    ):
+        value = row.get(key)
+        if value is None:
+            continue
+        text = _clean_text(value)
+        if text:
+            return True
+    return False
+
+
+def tumor_band_cell(row):
+    """Compact ``mid (low-high)`` cell for markdown tables."""
+    if not tumor_band_available(row):
+        return "—"
+    ctx = tumor_attribution_context(row)
+    return (
+        f"{ctx['attr_tumor_tpm']:.0f} "
+        f"({ctx['attr_tumor_tpm_low']:.0f}-{ctx['attr_tumor_tpm_high']:.0f})"
+    )
+
+
 def target_reliability_reasons(row, *, category=None):
     """Return ordered reader-facing caveats for a target/expression row."""
     source = tumor_attribution_context(row)

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -53,6 +53,62 @@ def _safe_int(value, default=0) -> int:
         return int(default)
 
 
+@lru_cache(maxsize=1)
+def _cancer_registry_display_names():
+    try:
+        from .gene_sets_cancer import cancer_type_registry
+
+        df = cancer_type_registry()
+    except Exception:
+        return {}
+
+    mapping = {}
+    for _, row in df.iterrows():
+        code = _clean_text(row.get("code"))
+        if not code:
+            continue
+        name = _clean_text(row.get("name"))
+        subtype_key = _clean_text(row.get("subtype_key"))
+        if name:
+            mapping[code] = name.split("(")[0].strip()
+        elif subtype_key:
+            mapping[code] = subtype_key.replace("_", " ").strip()
+    return mapping
+
+
+def cancer_code_display_name(code, fallback=None):
+    text = _clean_text(code)
+    if not text:
+        return _clean_text(fallback) or "this cancer type"
+    reg_name = _cancer_registry_display_names().get(text)
+    if reg_name:
+        return reg_name
+    fallback_text = _clean_text(fallback)
+    if fallback_text:
+        return fallback_text
+    return text.replace("_", " ").strip()
+
+
+def subtype_curation_scope_note(
+    panel_code,
+    *,
+    panel_subtype=None,
+    base_code=None,
+    base_name=None,
+    noun="therapy evidence",
+):
+    panel_name = cancer_code_display_name(panel_code).lower()
+    base_label = cancer_code_display_name(base_code, fallback=base_name).lower()
+    subtype_label = _clean_text(panel_subtype).replace("_", " ").lower()
+    if subtype_label:
+        focus = f"{subtype_label} {panel_name}".strip()
+    else:
+        focus = panel_name
+    if not base_label or focus == base_label:
+        return f"Using {focus}-specific {noun}."
+    return f"Using {focus}-specific {noun} rather than the broader {base_label} list."
+
+
 def tumor_attribution_context(row):
     """Summarize how securely a row stays tumor-attributed."""
     observed = _safe_float(row.get("observed_tpm"), 0.0)

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -1,0 +1,280 @@
+"""Shared report-facing helpers for evidence and attribution reliability.
+
+These helpers are intentionally narrow: they do not change the raw
+attribution math, only how downstream markdown decides whether a row is
+safe to summarize as credible tumor-core signal. The goal is to keep the
+headline markdown blocks aligned with the caveats already present in the
+tables and TSVs.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+
+def _truthy(value) -> bool:
+    if value is None:
+        return False
+    try:
+        if value != value:
+            return False
+    except Exception:
+        pass
+    try:
+        return bool(value)
+    except Exception:
+        return False
+
+
+def _clean_text(value) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text.lower() == "nan":
+        return ""
+    return text
+
+
+def target_reliability_reasons(row, *, category=None):
+    """Return ordered reader-facing caveats for a target/expression row."""
+    reasons = []
+    if _truthy(row.get("tme_dominant")):
+        reasons.append("TME-dominant")
+    if _truthy(row.get("matched_normal_over_predicted")):
+        reasons.append("matched-normal over-predicted")
+    if _truthy(row.get("smooth_muscle_stromal_leakage")):
+        reasons.append("possible smooth-muscle stromal leakage")
+    if _truthy(row.get("broadly_expressed")):
+        reasons.append("broadly expressed")
+    if _truthy(row.get("tme_explainable")):
+        reasons.append("single-tissue-explainable")
+    if _truthy(row.get("low_purity_cap_applied")):
+        reasons.append("low-purity capped")
+    return reasons
+
+
+def target_reliability_status(row, *, category=None):
+    """Classify a row as ``supported``, ``provisional``, or ``unsupported``."""
+    category_label = str(category or row.get("category") or "").upper()
+
+    if _truthy(row.get("tme_dominant")):
+        return "unsupported"
+
+    if _truthy(row.get("matched_normal_over_predicted")):
+        return "provisional"
+
+    if _truthy(row.get("smooth_muscle_stromal_leakage")):
+        return "provisional"
+
+    if _truthy(row.get("low_purity_cap_applied")):
+        return "provisional"
+
+    if _truthy(row.get("broadly_expressed")):
+        return "provisional"
+
+    if _truthy(row.get("tme_explainable")):
+        # CTA rows often carry this because cohort medians are near zero
+        # by design; keep them provisional rather than unsupported.
+        return "provisional" if category_label == "CTA" else "provisional"
+
+    return "supported"
+
+
+def partition_tumor_core_rows(ranges_df, min_tumor_tpm=1.0):
+    """Split expression rows by report-facing tumor-core reliability."""
+    if ranges_df is None or len(ranges_df) == 0 or "attr_tumor_tpm" not in ranges_df.columns:
+        empty = ranges_df.iloc[0:0] if ranges_df is not None else None
+        return empty, empty, empty
+
+    eligible = ranges_df[ranges_df["attr_tumor_tpm"].astype(float) >= float(min_tumor_tpm)].copy()
+    if eligible.empty:
+        empty = eligible.iloc[0:0]
+        return empty, empty, empty
+
+    statuses = [
+        target_reliability_status(row)
+        for _, row in eligible.iterrows()
+    ]
+    eligible["_report_reliability"] = statuses
+    supported = eligible[eligible["_report_reliability"] == "supported"].copy()
+    provisional = eligible[eligible["_report_reliability"] == "provisional"].copy()
+    unsupported = eligible[eligible["_report_reliability"] == "unsupported"].copy()
+    return supported, provisional, unsupported
+
+
+def summarize_reliability_reasons(rows, top_n=3):
+    """Summarize the most common reliability caveats in a row set."""
+    if rows is None or len(rows) == 0:
+        return ""
+    counter = Counter()
+    for _, row in rows.iterrows():
+        counter.update(target_reliability_reasons(row))
+    if not counter:
+        return ""
+    return ", ".join(reason for reason, _ in counter.most_common(top_n))
+
+
+def resolved_subtype_code_for_analysis(analysis, ranges_df=None):
+    """Return the final subtype/cancer code implied by the analysis."""
+    candidate_trace = analysis.get("candidate_trace") or []
+    if not candidate_trace:
+        return None
+    winning_subtype = _clean_text(candidate_trace[0].get("winning_subtype"))
+    if not winning_subtype:
+        return None
+
+    tumor_tpm_by_symbol = analysis.get("tumor_tpm_by_symbol")
+    if not tumor_tpm_by_symbol and ranges_df is not None:
+        try:
+            tumor_tpm_by_symbol = {
+                str(row["symbol"]): float(row.get("attr_tumor_tpm") or 0.0)
+                for _, row in ranges_df.iterrows()
+                if str(row.get("symbol") or "")
+            }
+        except Exception:
+            tumor_tpm_by_symbol = None
+
+    try:
+        from .degenerate_subtype import resolve_degenerate_subtype
+
+        decomposition = analysis.get("decomposition") or {}
+        site_template = decomposition.get("best_template")
+        resolution = resolve_degenerate_subtype(
+            winning_subtype,
+            site_template=site_template,
+            tumor_tpm_by_symbol=tumor_tpm_by_symbol,
+        )
+        winning_subtype = _clean_text(
+            resolution.get("final_subtype")
+        ) or winning_subtype
+    except Exception:
+        pass
+    return winning_subtype or None
+
+
+def _match_curated_subtype(parent_code, *candidates):
+    """Return the exact curated subtype string matching any candidate."""
+    if not parent_code:
+        return None
+    try:
+        from .gene_sets_cancer import cancer_key_genes_subtypes
+
+        curated_subtypes = [
+            _clean_text(item)
+            for item in cancer_key_genes_subtypes(parent_code)
+        ]
+    except Exception:
+        return None
+
+    curated_subtypes = [item for item in curated_subtypes if item]
+    if not curated_subtypes:
+        return None
+
+    exact_lookup = {item: item for item in curated_subtypes}
+    lower_lookup = {item.lower(): item for item in curated_subtypes}
+
+    for candidate in candidates:
+        raw = _clean_text(candidate)
+        if not raw:
+            continue
+        normalized = raw.replace("-", "_")
+        variants = (
+            raw,
+            normalized,
+            raw.lower(),
+            normalized.lower(),
+            raw.upper(),
+            normalized.upper(),
+        )
+        for variant in variants:
+            if variant in exact_lookup:
+                return exact_lookup[variant]
+        for variant in variants:
+            match = lower_lookup.get(str(variant).lower())
+            if match:
+                return match
+    return None
+
+
+def cancer_key_genes_lookup_for_analysis(cancer_code, analysis, ranges_df=None):
+    """Return ``(panel_code, panel_subtype)`` for curated report lookups.
+
+    Most samples use their top-level cancer code directly. Some need a
+    subtype-filtered panel (for example ``SARC`` + ``leiomyosarcoma``),
+    while others resolve onto a different curated code entirely (for
+    example a ``SARC`` umbrella call that degeneracy-resolution upgrades
+    to ``OS``).
+    """
+    default_code = _clean_text(cancer_code)
+    resolved_code = resolved_subtype_code_for_analysis(
+        analysis,
+        ranges_df=ranges_df,
+    )
+
+    try:
+        from .gene_sets_cancer import (
+            cancer_key_genes_cancer_types,
+            cancer_type_registry,
+        )
+
+        curated_codes = {
+            _clean_text(code)
+            for code in cancer_key_genes_cancer_types()
+        }
+        if resolved_code and resolved_code in curated_codes:
+            return resolved_code, None
+
+        if resolved_code:
+            reg = cancer_type_registry()
+            match = reg[reg["code"] == resolved_code]
+            if not match.empty:
+                row = match.iloc[0]
+                parent_code = _clean_text(row.get("parent_code"))
+                subtype_key = _clean_text(row.get("subtype_key"))
+                suffix = ""
+                if parent_code and resolved_code.startswith(parent_code + "_"):
+                    suffix = resolved_code[len(parent_code) + 1:]
+                matched_subtype = _match_curated_subtype(
+                    parent_code,
+                    subtype_key,
+                    suffix,
+                )
+                if parent_code and matched_subtype:
+                    return parent_code, matched_subtype
+
+        if default_code and default_code in curated_codes:
+            return default_code, None
+    except Exception:
+        pass
+
+    return default_code or resolved_code, None
+
+
+def subtype_key_for_analysis(analysis, ranges_df=None):
+    """Return the curated subtype key implied by the current analysis."""
+    winning_subtype = resolved_subtype_code_for_analysis(
+        analysis,
+        ranges_df=ranges_df,
+    )
+    if not winning_subtype:
+        return None
+
+    try:
+        from .gene_sets_cancer import cancer_type_registry
+
+        reg = cancer_type_registry()
+        match = reg[reg["code"] == winning_subtype]
+        if match.empty:
+            return None
+        row = match.iloc[0]
+        subtype_key = str(row.get("subtype_key") or "").strip()
+        if subtype_key and subtype_key.lower() != "nan":
+            return subtype_key
+        parent_code = str(row.get("parent_code") or "").strip()
+        code = str(row.get("code") or "").strip()
+        if parent_code and code.startswith(parent_code + "_"):
+            suffix = code[len(parent_code) + 1:].strip().lower()
+            return suffix or None
+    except Exception:
+        return None
+    return None

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -10,6 +10,7 @@ tables and TSVs.
 from __future__ import annotations
 
 from collections import Counter
+from functools import lru_cache
 
 
 def _truthy(value) -> bool:
@@ -35,19 +36,114 @@ def _clean_text(value) -> str:
     return text
 
 
+def _safe_float(value, default=0.0) -> float:
+    try:
+        result = float(value)
+    except Exception:
+        return float(default)
+    if result != result:
+        return float(default)
+    return result
+
+
+def _safe_int(value, default=0) -> int:
+    try:
+        return int(float(value))
+    except Exception:
+        return int(default)
+
+
+def tumor_attribution_context(row):
+    """Summarize how securely a row stays tumor-attributed."""
+    observed = _safe_float(row.get("observed_tpm"), 0.0)
+    mid_tpm = _safe_float(row.get("attr_tumor_tpm"), 0.0)
+    low_tpm = _safe_float(row.get("attr_tumor_tpm_low"), mid_tpm)
+    high_tpm = _safe_float(row.get("attr_tumor_tpm_high"), mid_tpm)
+    mid_frac = _safe_float(row.get("attr_tumor_fraction"), 0.0)
+    low_frac = _safe_float(row.get("attr_tumor_fraction_low"), mid_frac)
+    high_frac = _safe_float(row.get("attr_tumor_fraction_high"), mid_frac)
+    support_fraction = _safe_float(
+        row.get("attr_support_fraction"),
+        1.0 if (mid_tpm >= 1.0 and mid_frac >= 0.30) else 0.0,
+    )
+    low_tpm, mid_tpm, high_tpm = sorted([max(0.0, low_tpm), max(0.0, mid_tpm), max(0.0, high_tpm)])
+    low_frac, mid_frac, high_frac = sorted(
+        [
+            max(0.0, min(1.0, low_frac)),
+            max(0.0, min(1.0, mid_frac)),
+            max(0.0, min(1.0, high_frac)),
+        ]
+    )
+    support_fraction = max(0.0, min(1.0, support_fraction))
+
+    notes = []
+    if _truthy(row.get("matched_normal_over_predicted")):
+        notes.append("matched-normal reference overshoots the sample")
+    if _truthy(row.get("low_purity_cap_applied")):
+        notes.append("low-purity cap is active")
+    if _truthy(row.get("tme_explainable")) and support_fraction < 1.0:
+        notes.append("healthy-tissue-only explanations remain plausible")
+    if _truthy(row.get("tme_dominant")):
+        notes.append("most fitted signal remains non-tumor")
+
+    if high_tpm < 1.0 or high_frac < 0.30 or _truthy(row.get("tme_dominant")):
+        tier = "background_dominant"
+        label = "background-dominant"
+        summary = "non-tumor compartments remain the simpler explanation"
+    elif (
+        low_tpm >= 1.0
+        and low_frac >= 0.30
+        and support_fraction >= 0.67
+        and not _truthy(row.get("matched_normal_over_predicted"))
+    ):
+        tier = "tumor_supported"
+        label = "tumor-supported"
+        summary = "tumor-attributed signal stays material across the uncertainty band"
+    else:
+        tier = "mixed_source"
+        label = "mixed-source"
+        summary = "both tumor and benign/background sources remain plausible"
+
+    if observed > 0:
+        band = f"{mid_tpm:.0f} TPM (band {low_tpm:.0f}-{high_tpm:.0f}; {mid_frac:.0%} tumor, {low_frac:.0%}-{high_frac:.0%} band)"
+    else:
+        band = f"{mid_tpm:.0f} TPM"
+
+    return {
+        "tier": tier,
+        "label": label,
+        "summary": summary,
+        "notes": notes,
+        "band": band,
+        "observed_tpm": observed,
+        "attr_tumor_tpm": mid_tpm,
+        "attr_tumor_tpm_low": low_tpm,
+        "attr_tumor_tpm_high": high_tpm,
+        "attr_tumor_fraction": mid_frac,
+        "attr_tumor_fraction_low": low_frac,
+        "attr_tumor_fraction_high": high_frac,
+        "attr_support_fraction": support_fraction,
+    }
+
+
+def tumor_attribution_band_text(row):
+    return tumor_attribution_context(row)["band"]
+
+
 def target_reliability_reasons(row, *, category=None):
     """Return ordered reader-facing caveats for a target/expression row."""
+    source = tumor_attribution_context(row)
     reasons = []
-    if _truthy(row.get("tme_dominant")):
-        reasons.append("TME-dominant")
+    if source["tier"] == "background_dominant":
+        reasons.append("background-dominant")
+    elif source["tier"] == "mixed_source":
+        reasons.append("mixed-source")
     if _truthy(row.get("matched_normal_over_predicted")):
         reasons.append("matched-normal over-predicted")
     if _truthy(row.get("smooth_muscle_stromal_leakage")):
         reasons.append("possible smooth-muscle stromal leakage")
-    if _truthy(row.get("broadly_expressed")):
-        reasons.append("broadly expressed")
-    if _truthy(row.get("tme_explainable")):
-        reasons.append("single-tissue-explainable")
+    if _truthy(row.get("tme_explainable")) and source["tier"] != "tumor_supported":
+        reasons.append("healthy-tissue-explainable")
     if _truthy(row.get("low_purity_cap_applied")):
         reasons.append("low-purity capped")
     return reasons
@@ -55,29 +151,233 @@ def target_reliability_reasons(row, *, category=None):
 
 def target_reliability_status(row, *, category=None):
     """Classify a row as ``supported``, ``provisional``, or ``unsupported``."""
-    category_label = str(category or row.get("category") or "").upper()
-
-    if _truthy(row.get("tme_dominant")):
+    source = tumor_attribution_context(row)
+    if source["tier"] == "background_dominant":
         return "unsupported"
-
     if _truthy(row.get("matched_normal_over_predicted")):
         return "provisional"
-
     if _truthy(row.get("smooth_muscle_stromal_leakage")):
         return "provisional"
-
-    if _truthy(row.get("low_purity_cap_applied")):
+    if source["tier"] == "mixed_source":
         return "provisional"
-
-    if _truthy(row.get("broadly_expressed")):
-        return "provisional"
-
-    if _truthy(row.get("tme_explainable")):
-        # CTA rows often carry this because cohort medians are near zero
-        # by design; keep them provisional rather than unsupported.
-        return "provisional" if category_label == "CTA" else "provisional"
-
     return "supported"
+
+
+_ESSENTIAL_TISSUE_COLS = {
+    "brain": [
+        "nTPM_cerebral_cortex", "nTPM_cerebellum", "nTPM_basal_ganglia",
+        "nTPM_hippocampal_formation", "nTPM_amygdala", "nTPM_midbrain",
+        "nTPM_hypothalamus", "nTPM_spinal_cord", "nTPM_choroid_plexus",
+    ],
+    "heart": ["nTPM_heart_muscle"],
+    "liver": ["nTPM_liver"],
+    "lung": ["nTPM_lung"],
+    "kidney": ["nTPM_kidney"],
+    "bone_marrow": ["nTPM_bone_marrow"],
+    "spleen": ["nTPM_spleen"],
+    "pancreas": ["nTPM_pancreas"],
+    "colon": ["nTPM_colon", "nTPM_rectum", "nTPM_duodenum", "nTPM_small_intestine"],
+    "stomach": ["nTPM_stomach"],
+}
+
+
+@lru_cache(maxsize=1)
+def _pan_cancer_normal_expression_index():
+    try:
+        from .gene_sets_cancer import pan_cancer_expression
+
+        df = pan_cancer_expression().copy()
+        if "Ensembl_Gene_ID" not in df.columns:
+            return None
+        df["Ensembl_Gene_ID"] = df["Ensembl_Gene_ID"].astype(str).str.split(".", n=1).str[0]
+        df = df.drop_duplicates(subset="Ensembl_Gene_ID").set_index("Ensembl_Gene_ID")
+        return df
+    except Exception:
+        return None
+
+
+def _healthy_expression_profile(gene_id):
+    gene_id = _clean_text(gene_id).split(".", 1)[0]
+    if not gene_id:
+        return {}
+    ref = _pan_cancer_normal_expression_index()
+    if ref is None or gene_id not in ref.index:
+        return {}
+    row = ref.loc[gene_id]
+    profile = {}
+    for tissue, columns in _ESSENTIAL_TISSUE_COLS.items():
+        values = []
+        for column in columns:
+            if column not in row.index:
+                continue
+            try:
+                value = float(row[column])
+            except Exception:
+                continue
+            if value == value:
+                values.append(value)
+        if values:
+            profile[tissue] = max(values)
+    return profile
+
+
+def normal_expression_context(row):
+    """Return a coarse reader-facing normal-expression context label."""
+    category_label = str(row.get("category") or "").upper()
+    if _truthy(row.get("is_cta")) or category_label == "CTA":
+        return {
+            "tier": "cta_restricted",
+            "label": "CTA / immune-privileged",
+            "summary": "CTA-style restricted normal expression",
+            "details": [],
+        }
+
+    matched_tissue = _clean_text(row.get("matched_normal_tissue")).replace("_", " ")
+    matched_normal_tpm = _safe_float(row.get("matched_normal_tpm"), 0.0)
+    tumor_tpm = _safe_float(row.get("attr_tumor_tpm"), 0.0)
+    attr_top = _clean_text(row.get("attr_top_compartment")).replace("_", " ")
+    details = []
+    same_lineage = False
+    if matched_tissue:
+        same_lineage = (
+            attr_top == f"matched normal {matched_tissue}"
+            or _truthy(row.get("matched_normal_over_predicted"))
+            or matched_normal_tpm >= max(1.0, tumor_tpm * 0.5)
+        )
+
+    healthy_profile = _healthy_expression_profile(row.get("gene_id"))
+    vital_detail = ""
+    if healthy_profile:
+        top_tissue, top_value = max(healthy_profile.items(), key=lambda item: item[1])
+        if top_value >= 10.0:
+            vital_detail = f"{top_tissue.replace('_', ' ')} expression is appreciable"
+
+    if _truthy(row.get("broadly_expressed")) or _safe_int(row.get("n_healthy_tissues_expressed"), 0) >= 15:
+        details.append("broader healthy-tissue signal is present outside the matched lineage")
+    if vital_detail:
+        details.append(vital_detail)
+
+    if same_lineage:
+        return {
+            "tier": "same_lineage_expected",
+            "label": "same-lineage expected",
+            "summary": f"benign {matched_tissue} lineage expression is expected",
+            "details": details,
+        }
+
+    if vital_detail:
+        return {
+            "tier": "vital_tissue_concern",
+            "label": "vital-tissue concern",
+            "summary": vital_detail,
+            "details": details[1:] if details else [],
+        }
+
+    if details:
+        return {
+            "tier": "broad_healthy_expression",
+            "label": "broad healthy expression",
+            "summary": details[0],
+            "details": details[1:],
+        }
+
+    return {
+        "tier": "restricted_outside_lineage",
+        "label": "restricted outside matched lineage",
+        "summary": "limited healthy-tissue signal outside the matched lineage",
+        "details": [],
+    }
+
+
+def clinical_maturity_info(target_row, target_panel=None):
+    """Summarize maturity from the current row and its curated siblings."""
+    phase = _clean_text(target_row.get("phase"))
+    phase_label = {
+        "approved": "approved",
+        "phase_3": "late clinical",
+        "phase_2": "mid-clinical",
+        "phase_1": "early clinical",
+        "preclinical": "preclinical",
+    }.get(phase, phase or "curated")
+    agent_class = _clean_text(target_row.get("agent_class")).replace("_", " ")
+    summary = phase_label
+    if agent_class:
+        summary += f" {agent_class}"
+
+    if target_panel is None or len(target_panel) == 0:
+        return {
+            "tier": phase_label,
+            "summary": summary,
+            "n_agents": 0,
+            "n_modalities": 0,
+        }
+
+    symbol = _clean_text(target_row.get("symbol"))
+    if not symbol or "symbol" not in target_panel.columns:
+        return {
+            "tier": phase_label,
+            "summary": summary,
+            "n_agents": 0,
+            "n_modalities": 0,
+        }
+
+    try:
+        sub = target_panel[target_panel["symbol"].astype(str) == symbol]
+    except Exception:
+        sub = None
+
+    if sub is None or len(sub) <= 1:
+        return {
+            "tier": phase_label,
+            "summary": summary,
+            "n_agents": 1 if sub is not None and len(sub) == 1 else 0,
+            "n_modalities": 1 if sub is not None and len(sub) == 1 else 0,
+        }
+
+    n_agents = (
+        sub["agent"].fillna("").astype(str).str.strip()
+        .replace("nan", "").loc[lambda s: s.ne("")].nunique()
+        if "agent" in sub.columns else 0
+    )
+    n_modalities = (
+        sub["agent_class"].fillna("").astype(str).str.strip()
+        .replace("nan", "").loc[lambda s: s.ne("")].nunique()
+        if "agent_class" in sub.columns else 0
+    )
+    extras = []
+    if n_agents > 1:
+        extras.append(f"{n_agents} curated agents")
+    if n_modalities > 1:
+        extras.append(f"{n_modalities} modalities")
+    if extras:
+        summary += f" ({', '.join(extras)})"
+    return {
+        "tier": phase_label,
+        "summary": summary,
+        "n_agents": int(n_agents),
+        "n_modalities": int(n_modalities),
+    }
+
+
+def clinical_maturity_summary(target_row, target_panel=None):
+    return clinical_maturity_info(target_row, target_panel=target_panel)["summary"]
+
+
+def target_interpretation_summary(target_row, expression_row, target_panel=None):
+    """Return a compact integrated summary for a curated target row."""
+    source = tumor_attribution_context(expression_row)
+    normal = normal_expression_context(expression_row)
+    maturity = (
+        clinical_maturity_summary(target_row, target_panel=target_panel)
+        if target_row is not None else ""
+    )
+    parts = [source["label"], source["band"], normal["label"]]
+    details = list(normal.get("details") or [])
+    if details:
+        parts.append(details[0])
+    if maturity:
+        parts.append(maturity)
+    return "; ".join(part for part in parts if part)
 
 
 def partition_tumor_core_rows(ranges_df, min_tumor_tpm=1.0):

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -172,3 +172,45 @@ def test_actionable_is_longer_but_structured():
     assert "*-targets.md*" in md or "`*-targets.md`" in md, (
         "actionable should link to targets.md as the biomarker-panel source"
     )
+
+
+def test_brief_normalizes_path_like_sample_id():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis,
+        ranges_df,
+        cancer_code="PRAD",
+        disease_state="",
+        sample_id="/tmp/run-123/rs",
+    )
+    assert md.splitlines()[0] == "# Summary: rs"
+
+
+def test_brief_uses_tumor_band_without_attribution_dict():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    idx = ranges_df.index[ranges_df["symbol"] == "FOLH1"][0]
+    ranges_df.at[idx, "attribution"] = {}
+    md = build_brief(
+        analysis,
+        ranges_df,
+        cancer_code="PRAD",
+        disease_state="",
+    )
+    assert "tumor-specific decomposition was unavailable" not in md
+    assert "128 TPM (band 128-128" in md
+
+
+def test_actionable_renders_tumor_band_without_attribution_dict():
+    analysis = _make_analysis()
+    ranges_df = _make_ranges_df()
+    idx = ranges_df.index[ranges_df["symbol"] == "FOLH1"][0]
+    ranges_df.at[idx, "attribution"] = {}
+    md = build_actionable(
+        analysis,
+        ranges_df,
+        cancer_code="PRAD",
+        disease_state="",
+    )
+    assert "| **FOLH1** | 177Lu-PSMA-617 | radioligand | Approved | mCRPC | 142.0 | 128 (128-128) |" in md

--- a/tests/test_cli_output_cleanup.py
+++ b/tests/test_cli_output_cleanup.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
-from pirlygenes.cli import _clean_prefix_outputs
+from types import SimpleNamespace
+
+from pirlygenes.cli import (
+    _clean_prefix_outputs,
+    _derive_sample_display_id,
+    _matched_normal_split_summary,
+    _summarize_sample_call,
+)
 
 
 def _touch(p: Path, text: str = "") -> Path:
@@ -59,3 +66,59 @@ def test_clean_prefix_empty_or_missing_dir(tmp_path):
     # Calling on an empty / nonexistent dir should be a no-op
     assert _clean_prefix_outputs(tmp_path, str(tmp_path / "sample")) == 0
     assert _clean_prefix_outputs(tmp_path / "doesnotexist", str(tmp_path / "doesnotexist" / "sample")) == 0
+
+
+def test_derive_sample_display_id_prefers_case_like_path_tokens():
+    assert (
+        _derive_sample_display_id("/Users/me/data/rs/gene_expression_salmon.tsv")
+        == "rs"
+    )
+    assert (
+        _derive_sample_display_id(
+            "/Users/me/data/pathfinder/pfo002/WashU/run/rna_stringtie_gene_expression.tsv"
+        )
+        == "pfo002"
+    )
+
+
+def test_matched_normal_split_summary_omits_zero_fraction():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {
+                "matched_normal_tissue": "breast",
+                "matched_normal_fraction": 0.0,
+            }
+        ]
+    )
+    assert _matched_normal_split_summary(df) is None
+
+
+def test_summarize_sample_call_humanizes_hypotheses():
+    top = SimpleNamespace(
+        cancer_type="BRCA",
+        template="solid_primary",
+        score=1.0,
+        warnings=[],
+        template_site_factor=1.0,
+        template_tissue_score=1.0,
+    )
+    runner = SimpleNamespace(
+        cancer_type="READ",
+        template="met_peritoneal",
+        score=0.95,
+        warnings=[],
+        template_site_factor=1.0,
+        template_tissue_score=1.0,
+    )
+    analysis = {
+        "cancer_type": "READ",
+        "candidate_trace": [{"code": "READ"}],
+        "fit_quality": {"label": "ambiguous"},
+    }
+    summary = _summarize_sample_call(analysis, [top, runner], sample_mode="solid")
+    assert summary["hypothesis_display"] == [
+        "BRCA-like primary-site pattern",
+        "READ peritoneum pattern",
+    ]

--- a/tests/test_degenerate_subtype.py
+++ b/tests/test_degenerate_subtype.py
@@ -421,6 +421,130 @@ def test_brief_renders_corrected_subtype():
     assert "OS" in summary
 
 
+def test_key_genes_lookup_switches_to_direct_os_panel():
+    """Degenerate resolution can land on a standalone cancer code.
+
+    When that happens, report curation must use the resolved code's
+    panel directly instead of the umbrella parent union.
+    """
+    import pandas as pd
+
+    from pirlygenes.reporting import cancer_key_genes_lookup_for_analysis
+
+    analysis = {
+        "candidate_trace": [
+            {"code": "SARC", "winning_subtype": "SARC_LPS_UNSPEC"},
+        ],
+        "decomposition": {
+            "best_template": "met_bone",
+            "best_cancer_type": "SARC",
+        },
+    }
+    ranges_df = pd.DataFrame([
+        {"symbol": "MDM2", "attr_tumor_tpm": 877.0},
+        {"symbol": "CDK4", "attr_tumor_tpm": 73.0},
+        {"symbol": "FRS2", "attr_tumor_tpm": 137.0},
+    ])
+    assert cancer_key_genes_lookup_for_analysis(
+        "SARC",
+        analysis,
+        ranges_df=ranges_df,
+    ) == ("OS", None)
+
+
+def test_key_genes_lookup_matches_uppercase_parent_subtype_rows():
+    """Key-genes subtype matching should be case-tolerant.
+
+    Registry codes like ``SARC_MPNST`` should recover the curated
+    uppercase subtype value ``MPNST`` rather than falling back to the
+    umbrella SARC union.
+    """
+    from pirlygenes.reporting import cancer_key_genes_lookup_for_analysis
+
+    analysis = {
+        "candidate_trace": [
+            {"code": "SARC", "winning_subtype": "SARC_MPNST"},
+        ],
+        "decomposition": {
+            "best_template": "primary_nerve_sheath",
+            "best_cancer_type": "SARC",
+        },
+    }
+    assert cancer_key_genes_lookup_for_analysis(
+        "SARC",
+        analysis,
+    ) == ("SARC", "MPNST")
+
+
+def test_brief_uses_os_therapy_panel_after_corrected_subtype():
+    """User-facing pin for the pfo004 failure mode.
+
+    The summary should stop surfacing DDLPS-only therapies once the
+    bone-site tiebreaker resolves the sample to osteosarcoma.
+    """
+    import pandas as pd
+
+    from pirlygenes.brief import build_summary
+
+    analysis = {
+        "purity": {
+            "overall_estimate": 0.74,
+            "overall_lower": 0.42,
+            "overall_upper": 1.0,
+        },
+        "purity_confidence": type("PT", (), {"tier": "low"})(),
+        "sample_context": None,
+        "cancer_name": "Sarcoma",
+        "candidate_trace": [
+            {"code": "SARC", "winning_subtype": "SARC_LPS_UNSPEC"},
+        ],
+        "decomposition": {
+            "best_template": "met_bone",
+            "best_cancer_type": "SARC",
+        },
+    }
+    ranges_df = pd.DataFrame([
+        {
+            "symbol": "MDM2",
+            "observed_tpm": 1180.4,
+            "attr_tumor_tpm": 1176.0,
+            "attr_tumor_fraction": 0.99,
+            "attribution": "tumor",
+        },
+        {
+            "symbol": "CDK4",
+            "observed_tpm": 112.8,
+            "attr_tumor_tpm": 90.0,
+            "attr_tumor_fraction": 0.80,
+            "attribution": "tumor",
+        },
+        {
+            "symbol": "FRS2",
+            "observed_tpm": 140.0,
+            "attr_tumor_tpm": 137.0,
+            "attr_tumor_fraction": 0.96,
+            "attribution": "tumor",
+        },
+        {
+            "symbol": "IGF1R",
+            "observed_tpm": 125.0,
+            "attr_tumor_tpm": 120.0,
+            "attr_tumor_fraction": 0.96,
+            "attribution": "tumor",
+        },
+    ])
+    summary = build_summary(
+        analysis,
+        ranges_df=ranges_df,
+        cancer_code="SARC",
+        disease_state="",
+        sample_id="synthetic-bone-os-panel",
+    )
+    assert "Subtype-resolved therapy curation" in summary, summary
+    assert "ganitumab + chemo" in summary, summary
+    assert "brigimadlin" not in summary, summary
+
+
 def test_brief_lusc_with_high_prame_mage_does_not_flag_nutm():
     """Pin the squamous-vs-NUTM correctness case: a LUSC sample with
     high PRAME + MAGEA3 (typical of LUSC) but silent NUTM1 should NOT

--- a/tests/test_degenerate_subtype.py
+++ b/tests/test_degenerate_subtype.py
@@ -417,8 +417,9 @@ def test_brief_renders_corrected_subtype():
         sample_id="synthetic-bone-mdm2",
     )
     assert "osteosarcoma-consistent" in summary, summary
-    assert "site_template tiebreaker swapped" in summary, summary
-    assert "OS" in summary
+    assert "Bone-site context favors osteosarcoma over liposarcoma" in summary, summary
+    assert "MDM2 / CDK4 / FRS2 amplification" in summary, summary
+    assert "site_template tiebreaker swapped" not in summary
 
 
 def test_key_genes_lookup_switches_to_direct_os_panel():

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -738,7 +738,7 @@ def test_generate_target_report_adds_tumor_context_and_landscape_summary(tmp_pat
     assert "## Tumor context for interpretation" in text
     assert "## Therapy landscape at a glance" in text
     assert "provisional between **COAD** and **READ**" in text
-    assert "matched_normal_colon" in text
+    assert "colon-like matched-normal reference" in text
     assert "CEACAM5" in text
     assert "MAGEA4" in text
     assert "WT1" in text

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -321,6 +321,8 @@ def test_generate_text_reports_uses_family_and_background_language(tmp_path):
     assert "Possible labels" in detailed
     assert "Family-level call" in detailed
     assert "Fit quality" in detailed
+    assert "Integrated evidence synthesis" in detailed
+    assert "Parallel hypotheses still alive" in detailed
     assert "Top broad possibilities" in detailed
     assert "Background Tissue Signatures" in detailed
 
@@ -740,6 +742,152 @@ def test_generate_target_report_adds_tumor_context_and_landscape_summary(tmp_pat
     assert "CEACAM5" in text
     assert "MAGEA4" in text
     assert "WT1" in text
+
+
+def test_generate_target_report_filters_unreliable_rows_from_headlines(tmp_path):
+    ranges_df = pd.DataFrame(
+        [
+            {
+                "symbol": "BAD_TME",
+                "median_est": 500.0,
+                "est_1": 300.0,
+                "est_9": 700.0,
+                "observed_tpm": 200.0,
+                "pct_cancer_median": 8.0,
+                "tcga_percentile": 0.99,
+                "is_surface": True,
+                "is_cta": False,
+                "therapies": "ADC",
+                "tme_explainable": False,
+                "tme_dominant": True,
+                "excluded_from_ranking": False,
+                "category": "therapy_target",
+                "matched_normal_tpm": 0.0,
+                "matched_normal_tissue": "colon",
+                "matched_normal_fraction": 0.12,
+                "attr_tumor_tpm": 15.0,
+                "attr_tumor_fraction": 0.08,
+                "attr_top_compartment": "fibroblast",
+                "attr_top_compartment_tpm": 130.0,
+                "attribution": {"fibroblast": 130.0},
+                "broadly_expressed": False,
+                "matched_normal_over_predicted": False,
+                "smooth_muscle_stromal_leakage": False,
+                "low_purity_cap_applied": False,
+            },
+            {
+                "symbol": "BAD_BROAD",
+                "median_est": 320.0,
+                "est_1": 220.0,
+                "est_9": 430.0,
+                "observed_tpm": 180.0,
+                "pct_cancer_median": 5.0,
+                "tcga_percentile": 0.98,
+                "is_surface": True,
+                "is_cta": False,
+                "therapies": "",
+                "tme_explainable": False,
+                "tme_dominant": False,
+                "excluded_from_ranking": False,
+                "category": "therapy_target",
+                "matched_normal_tpm": 10.0,
+                "matched_normal_tissue": "colon",
+                "matched_normal_fraction": 0.12,
+                "attr_tumor_tpm": 120.0,
+                "attr_tumor_fraction": 0.67,
+                "attr_top_compartment": "matched_normal_colon",
+                "attr_top_compartment_tpm": 40.0,
+                "attribution": {"matched_normal_colon": 40.0},
+                "broadly_expressed": True,
+                "matched_normal_over_predicted": False,
+                "smooth_muscle_stromal_leakage": False,
+                "low_purity_cap_applied": False,
+            },
+            {
+                "symbol": "GOOD1",
+                "median_est": 120.0,
+                "est_1": 90.0,
+                "est_9": 150.0,
+                "observed_tpm": 95.0,
+                "pct_cancer_median": 3.0,
+                "tcga_percentile": 0.95,
+                "is_surface": True,
+                "is_cta": False,
+                "therapies": "ADC",
+                "tme_explainable": False,
+                "tme_dominant": False,
+                "excluded_from_ranking": False,
+                "category": "therapy_target",
+                "matched_normal_tpm": 6.0,
+                "matched_normal_tissue": "colon",
+                "matched_normal_fraction": 0.12,
+                "attr_tumor_tpm": 80.0,
+                "attr_tumor_fraction": 0.84,
+                "attr_top_compartment": "matched_normal_colon",
+                "attr_top_compartment_tpm": 6.0,
+                "attribution": {"matched_normal_colon": 6.0},
+                "broadly_expressed": False,
+                "matched_normal_over_predicted": False,
+                "smooth_muscle_stromal_leakage": False,
+                "low_purity_cap_applied": False,
+            },
+        ]
+    )
+    analysis = {
+        "sample_mode": "solid",
+        "cancer_type": "COAD",
+        "candidate_trace": [
+            {
+                "code": "COAD",
+                "support_norm": 1.0,
+                "support_score": 0.4,
+                "signature_score": 0.82,
+                "lineage_concordance": 0.76,
+            },
+            {
+                "code": "READ",
+                "support_norm": 0.7,
+                "support_score": 0.28,
+                "signature_score": 0.79,
+                "lineage_concordance": 0.74,
+            },
+        ],
+        "fit_quality": {
+            "label": "ambiguous",
+            "message": "Top subtype candidates remain close; treat the leading label as provisional.",
+        },
+        "call_summary": {
+            "label_options": ["COAD", "READ"],
+            "label_display": "COAD or READ",
+            "reported_context": "primary",
+            "reported_site": "primary site",
+            "site_indeterminate": False,
+            "site_note": None,
+            "hypothesis_display": ["COAD / solid_primary", "READ / solid_primary"],
+        },
+        "purity": {
+            "overall_lower": 0.32,
+            "overall_estimate": 0.41,
+            "overall_upper": 0.52,
+            "components": {"integration": {}},
+        },
+        "mhc1": {"HLA-A": 80, "HLA-B": 75, "HLA-C": 70, "B2M": 400},
+    }
+    prefix = str(tmp_path / "filtered")
+    cli_mod._generate_target_report(
+        ranges_df,
+        analysis,
+        prefix,
+        "COAD",
+        analysis["purity"],
+    )
+
+    text = (tmp_path / "filtered-targets.md").read_text()
+    context_section = text.split("## Therapy landscape at a glance", 1)[1].split("##", 1)[0]
+    assert "GOOD1" in context_section
+    assert "BAD_TME" not in context_section
+    assert "BAD_BROAD" not in context_section
+    assert "Integrated evidence synthesis" in text
 
 
 def _tcga_sample(cancer_code):

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -78,6 +78,49 @@ def test_provenance_handles_missing_decomposition():
     assert "No decomposition result" in md
 
 
+def test_provenance_distinguishes_supported_from_provisional_tumor_core():
+    analysis = {
+        "sample_context": _Ctx(),
+        "purity": {"overall_estimate": 0.28, "overall_lower": 0.19, "overall_upper": 0.40},
+    }
+    ranges_df = pd.DataFrame([
+        {
+            "symbol": "SAFE",
+            "observed_tpm": 142.0,
+            "attribution": {"endothelial": 12.0},
+            "attr_tumor_tpm": 128.0,
+            "attr_tumor_fraction": 0.90,
+            "tme_dominant": False,
+            "matched_normal_over_predicted": False,
+            "smooth_muscle_stromal_leakage": False,
+            "broadly_expressed": False,
+            "tme_explainable": False,
+            "low_purity_cap_applied": False,
+        },
+        {
+            "symbol": "BROAD",
+            "observed_tpm": 78.0,
+            "attribution": {"fibroblast": 10.0},
+            "attr_tumor_tpm": 62.0,
+            "attr_tumor_fraction": 0.79,
+            "tme_dominant": False,
+            "matched_normal_over_predicted": False,
+            "smooth_muscle_stromal_leakage": False,
+            "broadly_expressed": True,
+            "tme_explainable": False,
+            "low_purity_cap_applied": False,
+        },
+    ])
+    md = build_provenance_md(
+        analysis, ranges_df, [_Decomp()],
+        cancer_code="PRAD", sample_id="sample_X",
+    )
+    assert "**1 genes** retain ≥1 TPM of supported tumor-attributed expression." in md
+    assert "additional **1 genes** retain residual tumor-attributed TPM" in md
+    assert "SAFE (128)" in md
+    assert "BROAD (62)" not in md
+
+
 def test_provenance_funnel_renders_png(tmp_path):
     analysis = {
         "sample_context": _Ctx(),

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -78,7 +78,7 @@ def test_provenance_handles_missing_decomposition():
     assert "No decomposition result" in md
 
 
-def test_provenance_distinguishes_supported_from_provisional_tumor_core():
+def test_provenance_distinguishes_tumor_supported_from_mixed_source_core():
     analysis = {
         "sample_context": _Ctx(),
         "purity": {"overall_estimate": 0.28, "overall_lower": 0.19, "overall_upper": 0.40},
@@ -98,16 +98,21 @@ def test_provenance_distinguishes_supported_from_provisional_tumor_core():
             "low_purity_cap_applied": False,
         },
         {
-            "symbol": "BROAD",
+            "symbol": "MIXED",
             "observed_tpm": 78.0,
-            "attribution": {"fibroblast": 10.0},
-            "attr_tumor_tpm": 62.0,
-            "attr_tumor_fraction": 0.79,
+            "attribution": {"matched_normal_prostate": 48.0},
+            "attr_tumor_tpm": 26.0,
+            "attr_tumor_fraction": 0.33,
+            "attr_tumor_tpm_low": 8.0,
+            "attr_tumor_tpm_high": 36.0,
+            "attr_tumor_fraction_low": 0.10,
+            "attr_tumor_fraction_high": 0.46,
+            "attr_support_fraction": 0.33,
             "tme_dominant": False,
-            "matched_normal_over_predicted": False,
+            "matched_normal_over_predicted": True,
             "smooth_muscle_stromal_leakage": False,
-            "broadly_expressed": True,
-            "tme_explainable": False,
+            "broadly_expressed": False,
+            "tme_explainable": True,
             "low_purity_cap_applied": False,
         },
     ])
@@ -115,10 +120,10 @@ def test_provenance_distinguishes_supported_from_provisional_tumor_core():
         analysis, ranges_df, [_Decomp()],
         cancer_code="PRAD", sample_id="sample_X",
     )
-    assert "**1 genes** retain ≥1 TPM of supported tumor-attributed expression." in md
+    assert "**1 genes** retain ≥1 TPM of tumor-supported tumor-attributed expression." in md
     assert "additional **1 genes** retain residual tumor-attributed TPM" in md
     assert "SAFE (128)" in md
-    assert "BROAD (62)" not in md
+    assert "MIXED (26)" not in md
 
 
 def test_provenance_funnel_renders_png(tmp_path):

--- a/tests/test_report_clarity_and_met_site.py
+++ b/tests/test_report_clarity_and_met_site.py
@@ -387,6 +387,12 @@ def test_recommended_targets_skips_tme_dominant_rows():
          "tcga_percentile": 0.94, "is_surface": True, "is_cta": False,
          "tme_explainable": True, "tme_dominant": True,
          "excluded_from_ranking": False, "therapies": "",
+         "attr_tumor_tpm": 180.0, "attr_tumor_tpm_low": 80.0,
+         "attr_tumor_tpm_high": 240.0, "attr_tumor_fraction": 0.11,
+         "attr_tumor_fraction_low": 0.05, "attr_tumor_fraction_high": 0.16,
+         "attr_support_fraction": 0.0,
+         "attr_top_compartment": "myeloid",
+         "attr_top_compartment_tpm": 1100.0,
          "max_healthy_tpm": 2000, "tme_fold_lo": 0.1, "tme_fold_med": 0.2,
          "tme_fold_hi": 0.3, "cohort_prior_tpm": 1400, "tme_only_tpm": 1100,
          "matched_normal_tpm": 0, "matched_normal_tissue": "",
@@ -400,6 +406,12 @@ def test_recommended_targets_skips_tme_dominant_rows():
          "tcga_percentile": 1.0, "is_surface": True, "is_cta": False,
          "tme_explainable": False, "tme_dominant": False,
          "excluded_from_ranking": False, "therapies": "ADC",
+         "attr_tumor_tpm": 150.0, "attr_tumor_tpm_low": 130.0,
+         "attr_tumor_tpm_high": 175.0, "attr_tumor_fraction": 0.62,
+         "attr_tumor_fraction_low": 0.54, "attr_tumor_fraction_high": 0.69,
+         "attr_support_fraction": 1.0,
+         "attr_top_compartment": "tumor",
+         "attr_top_compartment_tpm": 150.0,
          "max_healthy_tpm": 300, "tme_fold_lo": 0.1, "tme_fold_med": 0.2,
          "tme_fold_hi": 0.3, "cohort_prior_tpm": 100, "tme_only_tpm": 150,
          "matched_normal_tpm": 0, "matched_normal_tissue": "",
@@ -489,6 +501,79 @@ def test_target_report_explains_blocked_fn1_pyx201_call():
 
     assert "PYX-201 (NCT05720117) targets EDB+ FN1" in targets
     assert "Landscape cautions" in targets
+
+
+def test_target_report_falls_back_to_mixed_source_surface_targets(tmp_path):
+    """If no surface row stays tumor-supported, keep the best mixed-source
+    options visible with explicit caveats."""
+    from pirlygenes.cli import _generate_target_report
+
+    purity = {
+        "overall_estimate": 0.16,
+        "overall_lower": 0.07,
+        "overall_upper": 0.24,
+    }
+    analysis = {
+        "sample_mode": "solid",
+        "cancer_type": "PRAD",
+        "mhc1": {"HLA-A": 100, "HLA-B": 200, "HLA-C": 80, "B2M": 300},
+    }
+    ranges_df = pd.DataFrame(
+        [
+            {
+                "symbol": "FOLH1",
+                "median_est": 87.0,
+                "observed_tpm": 87.0,
+                "est_1": 60.0,
+                "est_9": 100.0,
+                "pct_cancer_median": 6.5,
+                "tcga_percentile": 1.0,
+                "is_surface": True,
+                "is_cta": False,
+                "tme_explainable": True,
+                "tme_dominant": False,
+                "excluded_from_ranking": False,
+                "therapies": "radioligand",
+                "max_healthy_tpm": 46.0,
+                "tme_fold_lo": 0.1,
+                "tme_fold_med": 0.2,
+                "tme_fold_hi": 0.3,
+                "cohort_prior_tpm": 10.0,
+                "tme_only_tpm": 12.0,
+                "matched_normal_tpm": 46.0,
+                "matched_normal_tissue": "prostate",
+                "matched_normal_fraction": 0.53,
+                "estimation_path": "matched_normal_split",
+                "low_confidence_tumor": False,
+                "category": "therapy_target",
+                "attr_tumor_tpm": 34.0,
+                "attr_tumor_tpm_low": 18.0,
+                "attr_tumor_tpm_high": 40.0,
+                "attr_tumor_fraction": 0.39,
+                "attr_tumor_fraction_low": 0.21,
+                "attr_tumor_fraction_high": 0.45,
+                "attr_support_fraction": 0.33,
+                "attr_top_compartment": "matched_normal_prostate",
+                "attr_top_compartment_tpm": 46.0,
+                "matched_normal_over_predicted": False,
+                "broadly_expressed": False,
+                "n_healthy_tissues_expressed": 0,
+                **{f"est_{i+1}": 60.0 + i * 5.0 for i in range(9)},
+            }
+        ]
+    )
+
+    prefix = str(tmp_path / "sample")
+    _generate_target_report(
+        ranges_df, analysis, prefix, cancer_type="PRAD", purity_result=purity
+    )
+    targets = (tmp_path / "sample-targets.md").read_text()
+    recs_block = targets.split("## Recommended Targets Summary")[-1]
+
+    assert "no surface target stayed tumor-supported" in targets
+    assert "**Best surface targets**" in recs_block
+    assert "FOLH1" in recs_block
+    assert "mixed-source rather than tumor-supported" in recs_block
 
 
 def test_ci_confidence_tier_buckets():

--- a/tests/test_robust_attribution.py
+++ b/tests/test_robust_attribution.py
@@ -421,6 +421,92 @@ def test_brief_trusts_curation_over_broadly_expressed_flag():
     assert "FOLH1" in symbols
 
 
+def test_brief_keeps_same_lineage_targets_but_skips_background_dominant_rows():
+    from pirlygenes.brief import _format_therapy_bullet, _top_therapies
+
+    targets_df = pd.DataFrame([
+        {
+            "symbol": "FOLH1", "agent": "177Lu-PSMA-617",
+            "agent_class": "radioligand", "phase": "approved",
+            "indication": "mCRPC",
+        },
+        {
+            "symbol": "STEAP2", "agent": "experimental ADC",
+            "agent_class": "ADC", "phase": "phase_2",
+            "indication": "mCRPC",
+        },
+    ])
+    ranges_df = pd.DataFrame([
+        {
+            "symbol": "FOLH1", "observed_tpm": 87.0,
+            "attribution": {"matched_normal_prostate": 46.0},
+            "attr_tumor_tpm": 34.0, "attr_tumor_fraction": 0.39,
+            "attr_tumor_tpm_low": 28.0, "attr_tumor_tpm_high": 39.0,
+            "attr_tumor_fraction_low": 0.32, "attr_tumor_fraction_high": 0.45,
+            "attr_support_fraction": 1.0,
+            "attr_top_compartment": "matched_normal_prostate",
+            "attr_top_compartment_tpm": 46.0,
+            "tme_dominant": False, "tme_explainable": True,
+            "matched_normal_over_predicted": False,
+            "broadly_expressed": False,
+            "matched_normal_tissue": "prostate",
+            "matched_normal_tpm": 46.0,
+        },
+        {
+            "symbol": "STEAP2", "observed_tpm": 90.0,
+            "attribution": {"matched_normal_prostate": 78.0},
+            "attr_tumor_tpm": 13.0, "attr_tumor_fraction": 0.14,
+            "attr_tumor_tpm_low": 8.0, "attr_tumor_tpm_high": 17.0,
+            "attr_tumor_fraction_low": 0.09, "attr_tumor_fraction_high": 0.19,
+            "attr_support_fraction": 0.0,
+            "attr_top_compartment": "matched_normal_prostate",
+            "attr_top_compartment_tpm": 78.0,
+            "tme_dominant": True, "tme_explainable": True,
+            "matched_normal_over_predicted": False,
+            "broadly_expressed": False,
+        },
+    ])
+
+    top = _top_therapies(targets_df, ranges_df, limit=3)
+    symbols = [t["symbol"] for t, _ in top]
+    assert symbols == ["FOLH1"]
+
+    bullet = _format_therapy_bullet(top[0][0], top[0][1], target_panel=targets_df)
+    assert "same-lineage expected" in bullet
+    assert "tumor-supported" in bullet
+    assert "Provisional:" not in bullet
+
+
+def test_same_lineage_target_can_stay_supported_when_band_remains_material():
+    from pirlygenes.reporting import (
+        normal_expression_context,
+        target_reliability_status,
+        tumor_attribution_context,
+    )
+
+    row = {
+        "observed_tpm": 87.0,
+        "attr_tumor_tpm": 34.0,
+        "attr_tumor_tpm_low": 28.0,
+        "attr_tumor_tpm_high": 39.0,
+        "attr_tumor_fraction": 0.39,
+        "attr_tumor_fraction_low": 0.32,
+        "attr_tumor_fraction_high": 0.45,
+        "attr_support_fraction": 1.0,
+        "matched_normal_tissue": "prostate",
+        "matched_normal_tpm": 46.0,
+        "attr_top_compartment": "matched_normal_prostate",
+        "tme_explainable": True,
+        "tme_dominant": False,
+        "matched_normal_over_predicted": False,
+    }
+    source = tumor_attribution_context(row)
+    normal = normal_expression_context(row)
+    assert source["tier"] == "tumor_supported"
+    assert normal["tier"] == "same_lineage_expected"
+    assert target_reliability_status(row) == "supported"
+
+
 # ── attribution cell rendering ──────────────────────────────────────────
 
 

--- a/tests/test_target_deep_dive.py
+++ b/tests/test_target_deep_dive.py
@@ -9,6 +9,7 @@ from pirlygenes.gene_sets_cancer import pan_cancer_expression
 from pirlygenes.plot_target_deep_dive import (
     actionable_surface_targets,
     plot_actionable_targets,
+    plot_curated_target_evidence,
     plot_tumor_attribution,
     plot_cta_deep_dive,
     _CANCER_SURFACE_TARGETS,
@@ -102,6 +103,76 @@ def test_plot_cta_deep_dive_saves_png(tmp_path):
     out = tmp_path / "cta.png"
     fig = plot_cta_deep_dive(df, "SKCM", purity_estimate=0.65,
                               save_to_filename=str(out))
+    assert fig is not None
+    assert out.exists()
+
+
+def test_plot_curated_target_evidence_saves_png(tmp_path):
+    ranges_df = pd.DataFrame(
+        [
+            {
+                "symbol": "FOLH1",
+                "observed_tpm": 87.0,
+                "attr_tumor_tpm": 34.0,
+                "attr_tumor_tpm_low": 28.0,
+                "attr_tumor_tpm_high": 39.0,
+                "attr_tumor_fraction": 0.39,
+                "attr_tumor_fraction_low": 0.32,
+                "attr_tumor_fraction_high": 0.45,
+                "attr_support_fraction": 1.0,
+                "matched_normal_tissue": "prostate",
+                "matched_normal_tpm": 46.0,
+                "attr_top_compartment": "matched_normal_prostate",
+                "tme_explainable": True,
+                "tme_dominant": False,
+                "matched_normal_over_predicted": False,
+                "category": "therapy_target",
+            },
+            {
+                "symbol": "STEAP2",
+                "observed_tpm": 90.0,
+                "attr_tumor_tpm": 13.0,
+                "attr_tumor_tpm_low": 8.0,
+                "attr_tumor_tpm_high": 17.0,
+                "attr_tumor_fraction": 0.14,
+                "attr_tumor_fraction_low": 0.09,
+                "attr_tumor_fraction_high": 0.19,
+                "attr_support_fraction": 0.0,
+                "matched_normal_tissue": "prostate",
+                "matched_normal_tpm": 78.0,
+                "attr_top_compartment": "matched_normal_prostate",
+                "tme_explainable": True,
+                "tme_dominant": True,
+                "matched_normal_over_predicted": False,
+                "category": "therapy_target",
+            },
+        ]
+    )
+    target_panel = pd.DataFrame(
+        [
+            {
+                "symbol": "FOLH1",
+                "agent": "177Lu-PSMA-617",
+                "agent_class": "radioligand",
+                "phase": "approved",
+                "indication": "mCRPC",
+            },
+            {
+                "symbol": "STEAP2",
+                "agent": "experimental ADC",
+                "agent_class": "ADC",
+                "phase": "phase_2",
+                "indication": "mCRPC",
+            },
+        ]
+    )
+    out = tmp_path / "curated-evidence.png"
+    fig = plot_curated_target_evidence(
+        ranges_df,
+        target_panel,
+        "PRAD",
+        save_to_filename=str(out),
+    )
     assert fig is not None
     assert out.exists()
 

--- a/tests/test_target_deep_dive.py
+++ b/tests/test_target_deep_dive.py
@@ -10,6 +10,7 @@ from pirlygenes.plot_target_deep_dive import (
     actionable_surface_targets,
     plot_actionable_targets,
     plot_curated_target_evidence,
+    plot_priority_targets,
     plot_tumor_attribution,
     plot_cta_deep_dive,
     _CANCER_SURFACE_TARGETS,
@@ -171,6 +172,75 @@ def test_plot_curated_target_evidence_saves_png(tmp_path):
         ranges_df,
         target_panel,
         "PRAD",
+        save_to_filename=str(out),
+    )
+    assert fig is not None
+    assert out.exists()
+
+
+def test_plot_priority_targets_saves_png(tmp_path):
+    ranges_df = pd.DataFrame(
+        [
+            {
+                "symbol": "FOLH1",
+                "observed_tpm": 87.0,
+                "attr_tumor_tpm": 34.0,
+                "attr_tumor_tpm_low": 18.0,
+                "attr_tumor_tpm_high": 40.0,
+                "attr_tumor_fraction": 0.39,
+                "attr_tumor_fraction_low": 0.21,
+                "attr_tumor_fraction_high": 0.45,
+                "attr_support_fraction": 0.67,
+                "matched_normal_tissue": "prostate",
+                "matched_normal_tpm": 46.0,
+                "attr_top_compartment": "matched_normal_prostate",
+                "tme_explainable": True,
+                "tme_dominant": False,
+                "matched_normal_over_predicted": False,
+                "therapy_supported": True,
+                "therapies": "ADC, radioligand",
+                "tcga_percentile": 0.97,
+                "category": "therapy_target",
+            },
+            {
+                "symbol": "FAP",
+                "observed_tpm": 44.0,
+                "attr_tumor_tpm": 41.0,
+                "attr_tumor_tpm_low": 37.0,
+                "attr_tumor_tpm_high": 44.0,
+                "attr_tumor_fraction": 0.94,
+                "attr_tumor_fraction_low": 0.83,
+                "attr_tumor_fraction_high": 1.0,
+                "attr_support_fraction": 1.0,
+                "matched_normal_tissue": "",
+                "matched_normal_tpm": 0.0,
+                "attr_top_compartment": "endothelial",
+                "tme_explainable": True,
+                "tme_dominant": False,
+                "matched_normal_over_predicted": False,
+                "therapy_supported": True,
+                "therapies": "ADC, radioligand",
+                "tcga_percentile": 1.0,
+                "category": "therapy_target",
+            },
+        ]
+    )
+    target_panel = pd.DataFrame(
+        [
+            {
+                "symbol": "FOLH1",
+                "agent": "177Lu-PSMA-617",
+                "agent_class": "radioligand",
+                "phase": "approved",
+                "indication": "mCRPC",
+            },
+        ]
+    )
+    out = tmp_path / "priority-targets.png"
+    fig = plot_priority_targets(
+        ranges_df,
+        "PRAD",
+        target_panel=target_panel,
         save_to_filename=str(out),
     )
     assert fig is not None


### PR DESCRIPTION
## Summary

This PR extends the earlier report-synthesis/subtype-curation pass with a second layer focused on target evidence quality and figure auditability.

It now does five concrete things:

- makes tumor-attribution reporting uncertainty-aware instead of treating `attr_tumor_tpm` as a single point estimate while `median_est` already carried a purity band
- separates **tumor-source support** from **normal-expression concern** so lineage markers are not automatically demoted just because benign parent tissue is present
- makes the markdown more integrative and explicit about mixed-source versus tumor-supported targets, normal-tissue concern tiers, and clinical maturity
- adds a new curated target evidence figure plus a `*-figure-audit.pdf` packet that groups redundant / low-value / distinctive figures
- keeps the earlier subtype-resolved curation fix (`SARC` umbrella call correctly switching to `OS`) and validates it on the osteosarcoma sample

## Why

The earlier reporting layer was safer than the pre-fix version, but it still had two important weaknesses:

1. `median_est` already propagated purity/background uncertainty, while `attr_tumor_tpm` remained a single residual estimate. That made the markdown uneven: the tumor-expression table showed a band, but the tumor-specific attribution logic behaved as if the point estimate were exact.
2. The first reliability pass still bundled several distinct ideas into one downgrade bucket. In practice that over-penalized lineage-retained targets such as prostate markers where benign matched-lineage expression is expected and clinically relevant, while not making it clear whether the actual concern was source uncertainty, normal-tissue breadth, or vital-tissue expression.

The user feedback on PRAD lineage targets (`FOLH1`, `STEAP1/2`, `KLK2`) motivated the split: we should distinguish

- is the signal still materially tumor-derived across the uncertainty band?
- what kind of normal-expression context are we worried about?
- how mature is the target clinically?

rather than collapsing all three into “provisional”.

## What Changed

### 1. Shared report-facing evidence helpers

`pirlygenes/reporting.py` now centralizes:

- uncertainty-aware tumor-source summaries (`tumor-supported` / `mixed-source` / `background-dominant`)
- tumor-core band text derived from attribution ranges
- normal-expression context tiers (`same-lineage expected`, `restricted outside matched lineage`, `broad healthy expression`, `vital-tissue concern`, `CTA / immune-privileged`)
- clinical-maturity summaries from the curated panel (phase + modalities / agent counts)
- integrated target interpretation strings for report tables and bullets
- subtype/direct-code-aware curated panel lookup (`SARC -> OS`, etc.)

### 2. Attribution math is now more internally consistent

`pirlygenes/plot_tumor_expr.py` now emits attribution uncertainty columns derived from the purity interval and non-tumor scaling used by the decomposition:

- `attr_tumor_tpm_low`
- `attr_tumor_tpm_high`
- `attr_tumor_fraction_low`
- `attr_tumor_fraction_high`
- `attr_support_fraction`

This means the report can reason over a tumor-attribution band instead of a single residual estimate.

### 3. Markdown now uses the split evidence model

`brief.py`, `cli.py`, and `provenance.py` were updated so that:

- top-therapy bullets carry tumor-source support, tumor-core band, normal-expression context, and clinical maturity
- therapy tables show tumor-core bands plus an interpretation column rather than only raw observed / tumor-attributed point values
- surface headlines no longer hard-filter to only one evidence state; they rank evidence tiers and fall back to mixed-source rows with explicit caveats when needed
- provenance distinguishes tumor-supported core from mixed-source residual rows

### 4. New plot + figure audit

Added a new plot in `plot_target_deep_dive.py`:

- `*-curated-target-evidence.png` — curated target panel with tumor-core band, tumor-source tier, normal-expression tier, and maturity on one figure

Added packet-level figure auditing in `cli.py`:

- `*-figure-audit.pdf` groups emitted figures into potentially redundant clusters, low-value defaults, and distinctive keepers
- README output documentation now includes the audit PDF

### 5. Tests / regressions

Added or updated coverage for:

- lineage-retained targets staying reportable when the tumor band remains material
- background-dominant rows staying out of the brief / headline lists
- provenance tumor-supported vs mixed-source wording
- curated target evidence plotting
- the earlier subtype-resolved curation fix

## Impact

- low-purity / benign-admixed samples now read more honestly without suppressing clinically relevant lineage markers
- report readers can see whether a target is source-uncertain, broad in healthy tissue, or concerning mainly because of vital-tissue expression
- curated therapy panels now align better with how clinicians actually think about lineage-retained targets
- figure packets are easier to audit for redundancy before deciding what to keep or drop

## Validation

Tests:

- `python -m pytest tests/test_robust_attribution.py tests/test_brief.py tests/test_provenance.py tests/test_plot_and_cli.py tests/test_degenerate_subtype.py tests/test_target_deep_dive.py`
  - result: `104 passed`

Real-sample reruns:

- `rs` → `/tmp/pirlygenes-audit-rs-20260423`
  - remains PRAD at low purity (`16%`, CI `7%–24%`)
  - summary now surfaces `FOLH1`, `AR`, and `STEAP1` as mixed-source lineage-relevant targets with tumor-core bands instead of declaring that no clean surface target exists
  - emits `sample-curated-target-evidence.png` and `sample-figure-audit.pdf`
- `pfo002` → `/tmp/pirlygenes-audit-pfo002-20260423`
  - remains coherent as `READ` with the existing STAD-vs-READ tension preserved
  - top therapies remain `ERBB2`, `BRAF`, and `EGFR`, now with tumor-core bands and normal-expression concern tiers
- `pfo004` → `/tmp/pirlygenes-audit-pfo004-20260423d`
  - remains sarcoma-family with osteosarcoma-consistent subtype note
  - therapy panel still switches correctly to `OS`
  - DDLPS-only therapies remain absent
  - curated target evidence plot now renders cleanly for the subtype-resolved `OS` panel
