### PR TITLE
[codex] Structure therapy path curation

### DIFF
--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -40,6 +40,7 @@ from .reporting import (
     expression_independent_indication,
     expression_independent_interpretation,
     normal_expression_context,
+    same_lineage_material_target_candidate,
     subtype_curation_scope_note,
     therapy_path_context,
     therapy_path_rank,
@@ -274,7 +275,7 @@ def _format_therapy_bullet(
     if not tumor_band_available(expression_row):
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-            f"{path_prefix}Bulk TPM {observed:.0f}; a tumor-core model interval "
+            f"{path_prefix}Bulk TPM {observed:.0f}; a tumor-inferred model interval "
             f"was not available for this run.{caution_suffix}"
         )
     source = tumor_attribution_context(expression_row)
@@ -359,9 +360,16 @@ def _top_therapies(
             continue
         attr_tumor = float(expr.get("attr_tumor_tpm") or 0.0)
         attr_fraction = float(expr.get("attr_tumor_fraction") or 1.0)
+        lineage_material = same_lineage_material_target_candidate(
+            expr,
+            target_row=t,
+        )
         # Drop rows that are mostly non-tumor from the top-3 — they
         # don't belong in the clinician handoff per #79 semantics.
-        if attr_fraction < 0.30 and not expr_independent:
+        # Same-lineage clinical targets are a special case: a prostate
+        # lineage marker assigned partly to matched-normal prostate is
+        # source-ambiguous, not equivalent to an immune/stromal target.
+        if attr_fraction < 0.30 and not expr_independent and not lineage_material:
             continue
         reliability_status = target_reliability_status(expr, target_row=t)
         if reliability_status == "unsupported":
@@ -433,8 +441,116 @@ def _brief_truthy(value) -> bool:
     return bool(value)
 
 
+def _format_trace_tpm(value) -> str:
+    value = _brief_float(value, 0.0)
+    if value >= 100:
+        return f"{value:.0f}"
+    if value >= 10:
+        return f"{value:.1f}"
+    return f"{value:.2f}".rstrip("0").rstrip(".")
+
+
+def _format_component_label(value) -> str:
+    text = str(value or "").strip()
+    if not text or text.lower() == "nan":
+        return "—"
+    text = text.replace("_", " ")
+    if text.startswith("matched normal "):
+        text = text.replace("matched normal ", "matched-normal ", 1)
+    return text
+
+
+def _top_non_tumor_attribution(expression_row) -> tuple[str, float]:
+    label = _format_component_label(expression_row.get("attr_top_compartment"))
+    value = _brief_float(expression_row.get("attr_top_compartment_tpm"), 0.0)
+    if label != "—" and label.lower() != "tumor" and value > 0:
+        return label, value
+
+    attribution = expression_row.get("attribution")
+    if isinstance(attribution, str):
+        try:
+            import ast
+
+            attribution = ast.literal_eval(attribution)
+        except Exception:
+            attribution = None
+    if isinstance(attribution, dict):
+        candidates = []
+        for comp, comp_value in attribution.items():
+            comp_label = _format_component_label(comp)
+            if comp_label == "—" or comp_label.lower() == "tumor":
+                continue
+            comp_tpm = _brief_float(comp_value, 0.0)
+            if comp_tpm > 0:
+                candidates.append((comp_label, comp_tpm))
+        if candidates:
+            return max(candidates, key=lambda item: item[1])
+    return "—", 0.0
+
+
+def _trace_phase_label(target_row) -> str:
+    phase = str(target_row.get("phase") or "")
+    return {
+        "approved": "approved",
+        "phase_3": "phase 3",
+        "phase_2": "phase 2",
+        "phase_1": "phase 1 exploratory",
+        "preclinical": "preclinical",
+    }.get(phase, phase.replace("_", " ") or "curated")
+
+
+def _source_trace_reason(target_row, expression_row, *, in_shortlist: bool) -> str:
+    source = tumor_attribution_context(expression_row)
+    reliability = target_reliability_status(expression_row, target_row=target_row)
+    phase = _trace_phase_label(target_row)
+    attr_fraction = _brief_float(expression_row.get("attr_tumor_fraction"), 0.0)
+    comp_label, _comp_tpm = _top_non_tumor_attribution(expression_row)
+    lineage_material = same_lineage_material_target_candidate(
+        expression_row,
+        target_row=target_row,
+    )
+
+    parts = []
+    if phase and phase != "approved":
+        parts.append(phase)
+
+    if in_shortlist:
+        if source["tier"] == "tumor_supported":
+            parts.append("clears source gate")
+        elif lineage_material:
+            parts.append("same-lineage marker, provisional source")
+        else:
+            parts.append(f"{source['label']}, clears source gate")
+    elif lineage_material:
+        parts.append("same-lineage marker, provisional source")
+    elif _brief_truthy(expression_row.get("matched_normal_over_predicted")):
+        if comp_label != "—":
+            parts.append(f"{comp_label} over-predicts / lineage background")
+        else:
+            parts.append("matched-normal over-predicts / lineage background")
+    elif reliability == "unsupported" and attr_fraction < 0.30:
+        if comp_label != "—":
+            parts.append(f"{attr_fraction:.0%} tumor; mostly {comp_label}")
+        else:
+            parts.append(f"{attr_fraction:.0%} tumor fraction")
+    elif reliability == "unsupported":
+        parts.append(
+            f"mostly {comp_label}/background" if comp_label != "—" else "background-dominant"
+        )
+    elif reliability == "provisional":
+        parts.append(source["label"])
+    else:
+        parts.append("ranked below top list")
+
+    deduped = []
+    for part in parts:
+        if part and part not in deduped:
+            deduped.append(part)
+    return "; ".join(deduped)
+
+
 def _shortlist_omission_note(targets_df, ranges_df, top_rows) -> str:
-    """Explain bulk-present curated targets that failed the source gate."""
+    """Trace source attribution for non-clean clinical target decisions."""
     if targets_df is None or ranges_df is None or not top_rows:
         return ""
     top_symbols = {str(t.get("symbol") or "") for t, _ in top_rows}
@@ -454,24 +570,65 @@ def _shortlist_omission_note(targets_df, ranges_df, top_rows) -> str:
             continue
         attr_fraction = _brief_float(expr.get("attr_tumor_fraction"), 1.0)
         reliability_status = target_reliability_status(expr, target_row=target)
-        reason = ""
-        if _brief_truthy(expr.get("matched_normal_over_predicted")):
-            reason = "matched-normal over-predicted"
-        elif reliability_status == "unsupported":
-            reason = "background-dominant"
-        elif attr_fraction < 0.30:
-            reason = f"{attr_fraction:.0%} tumor-core"
-        if reason:
-            omitted.append(f"{sym} ({reason})")
+        phase = str(target.get("phase") or "")
+        if reliability_status != "supported" or phase in {"phase_1", "preclinical"}:
+            comp_label, comp_tpm = _top_non_tumor_attribution(expr)
+            omitted.append(
+                {
+                    "symbol": sym,
+                    "bulk": _brief_float(expr.get("observed_tpm"), 0.0),
+                    "tumor": _brief_float(expr.get("attr_tumor_tpm"), 0.0),
+                    "fraction": attr_fraction,
+                    "component": comp_label,
+                    "component_tpm": comp_tpm,
+                    "reason": _source_trace_reason(target, expr, in_shortlist=False),
+                }
+            )
         if len(omitted) >= 3:
             break
     if not omitted:
         return ""
-    names = ", ".join(omitted)
-    return (
-        f"*Not short-listed despite bulk RNA: {names} did not clear the "
-        "tumor-core/source gate; see `*-evidence.md`.*"
-    )
+
+    shortlist_context = []
+    for target, expr in top_rows:
+        if expr is None:
+            continue
+        phase = str(target.get("phase") or "")
+        source = tumor_attribution_context(expr)
+        if phase == "approved" and source["tier"] == "tumor_supported":
+            continue
+        if phase == "approved":
+            continue
+        comp_label, comp_tpm = _top_non_tumor_attribution(expr)
+        shortlist_context.append(
+            {
+                "symbol": str(target.get("symbol") or ""),
+                "bulk": _brief_float(expr.get("observed_tpm"), 0.0),
+                "tumor": _brief_float(expr.get("attr_tumor_tpm"), 0.0),
+                "fraction": _brief_float(expr.get("attr_tumor_fraction"), 0.0),
+                "component": comp_label,
+                "component_tpm": comp_tpm,
+                "reason": _source_trace_reason(target, expr, in_shortlist=True),
+            }
+        )
+        if len(shortlist_context) >= 2:
+            break
+
+    rows = shortlist_context + omitted
+    lines = [
+        "**Target expression source trace**",
+        "| Gene | Bulk TPM | Tumor-inferred TPM | Tumor fraction | Top non-tumor attribution | Component TPM | Main reason |",
+        "|---|---:|---:|---:|---|---:|---|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row['symbol']} | {_format_trace_tpm(row['bulk'])} | "
+            f"{_format_trace_tpm(row['tumor'])} | {row['fraction']:.0%} | "
+            f"{row['component']} | {_format_trace_tpm(row['component_tpm'])} | "
+            f"{row['reason']} |"
+        )
+    lines.append("*Same-lineage background is a caveat, not automatic exclusion; clinical maturity and eligibility still set the shortlist order.*")
+    return "\n".join(lines)
 
 
 def _panel_display_label(panel_code, panel_subtype=None):
@@ -777,7 +934,7 @@ def build_summary(
         )
         lines.append("## Top candidate therapies\n")
         lines.append(
-            "*Ranked by treatment-path maturity first, then tumor-core support; "
+            "*Ranked by treatment-path maturity first, then tumor-source support; "
             "verify current therapy before acting on any row.*\n"
         )
         if panel_code != cancer_code or panel_subtype:
@@ -810,7 +967,7 @@ def build_summary(
         else:
             lines.append(
                 "*No approved or trialed agents with a measured, "
-                "tumor-core-supported target in this sample.*\n"
+                "tumor-supported target in this sample.*\n"
             )
     else:
         lines.append(
@@ -974,7 +1131,7 @@ def build_actionable(
             lines.append("")
             lines.append(
                 "| Target | Agent | Class | Phase | Indication | "
-                "Bulk TPM (measured) | Tumor-core TPM (model) | Interpretation |"
+                "Bulk TPM (measured) | Tumor-inferred TPM (model) | Interpretation |"
             )
             lines.append(
                 "|--------|-------|-------|-------|------------|"

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -39,7 +39,9 @@ from .reporting import (
     clinical_maturity_summary,
     expression_independent_indication,
     expression_independent_interpretation,
+    expression_independent_rna_context,
     normal_expression_context,
+    report_disease_state_text,
     same_lineage_material_target_candidate,
     subtype_curation_scope_note,
     therapy_path_context,
@@ -51,7 +53,8 @@ from .reporting import (
     tpm_semantics_note,
     tumor_attribution_context,
 )
-from .sample_context import library_prep_display_label
+from .confidence import concise_confidence_reasons
+from .sample_context import library_prep_clause, library_prep_display_label
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +90,17 @@ def _display_subtype_code(code: Optional[str]) -> str:
     except Exception:
         logger.debug("subtype display lookup failed", exc_info=True)
     return text.replace("_", " ").lower()
+
+
+def _call_confidence_suffix(call_tier, *, concise: bool = True) -> str:
+    """Render cancer-call confidence consistently across Markdown reports."""
+    if call_tier.tier not in {"low", "moderate"} or not call_tier.reasons:
+        return ""
+    tier_text = f"{call_tier.tier} confidence"
+    if call_tier.tier == "low":
+        tier_text += ", provisional"
+    note = concise_confidence_reasons(call_tier) if concise else call_tier.inline_note
+    return f" — **{tier_text}** ({note})" if note else f" — **{tier_text}**"
 
 
 def _site_template_note_label(template_name: Optional[str]) -> str:
@@ -248,12 +262,25 @@ def _format_therapy_bullet(
         f" Current-therapy check: {state_caution}."
         if state_caution else ""
     )
+    maturity = clinical_maturity_summary(target_row, target_panel=target_panel)
+
+    def _sentence(parts, *, maturity: str | None = None) -> str:
+        body = "; ".join(part for part in parts if part)
+        if maturity:
+            return f"{body}. Clinical maturity: {maturity}."
+        return f"{body}."
+
     if expression_row is None:
         if expr_independent:
+            parts = [
+                expression_independent_interpretation(target_row),
+                expression_independent_rna_context(None),
+            ]
+            if path_context:
+                parts.append(path_context)
             return (
                 f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-                f"{path_prefix}{expression_independent_interpretation(target_row)}; "
-                f"target RNA was not measured.{caution_suffix}"
+                f"{_sentence(parts, maturity=maturity)}{caution_suffix}"
             )
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
@@ -262,10 +289,15 @@ def _format_therapy_bullet(
     observed = float(expression_row.get("observed_tpm") or 0.0)
     if observed < 1.0:
         if expr_independent:
+            parts = [
+                expression_independent_interpretation(target_row),
+                expression_independent_rna_context(expression_row),
+            ]
+            if path_context:
+                parts.append(path_context)
             return (
                 f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-                f"{path_prefix}{expression_independent_interpretation(target_row)}; "
-                f"bulk target RNA {observed:.1f} TPM.{caution_suffix}"
+                f"{_sentence(parts, maturity=maturity)}{caution_suffix}"
             )
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
@@ -273,31 +305,32 @@ def _format_therapy_bullet(
             f"**target absent** in this sample.{caution_suffix}"
         )
     if not tumor_band_available(expression_row):
+        parts = [f"Bulk TPM {observed:.0f}", "tumor-inferred model interval unavailable"]
+        if path_context:
+            parts.append(path_context)
         return (
             f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-            f"{path_prefix}Bulk TPM {observed:.0f}; a tumor-inferred model interval "
-            f"was not available for this run.{caution_suffix}"
+            f"{_sentence(parts, maturity=maturity)}{caution_suffix}"
         )
     source = tumor_attribution_context(expression_row)
     normal = normal_expression_context(expression_row)
-    maturity = clinical_maturity_summary(target_row, target_panel=target_panel)
     if expr_independent:
         interpretation_parts = [
             expression_independent_interpretation(target_row),
-            source["band"],
-            normal["label"],
+            expression_independent_rna_context(expression_row),
         ]
     else:
         interpretation_parts = [source["label"], source["band"], normal["label"]]
     notes = list(source.get("notes") or []) + list(normal.get("details") or [])
-    if notes:
+    if notes and not expr_independent:
         interpretation_parts.append(notes[0])
     if path_context:
         interpretation_parts.append(path_context)
     interpretation = "; ".join(part for part in interpretation_parts if part)
+    maturity_sentence = f" Clinical maturity: {maturity}." if maturity else ""
     return (
         f"- **{sym}** — {agent} ({phase}{indication_clause}). "
-        f"{interpretation}. Clinical maturity: {maturity}.{caution_suffix}"
+        f"{interpretation}.{maturity_sentence}{caution_suffix}"
     )
 
 
@@ -525,7 +558,12 @@ def _source_trace_reason(target_row, expression_row, *, in_shortlist: bool) -> s
         parts.append("same-lineage marker, provisional source")
     elif _brief_truthy(expression_row.get("matched_normal_over_predicted")):
         if comp_label != "—":
-            parts.append(f"{comp_label} over-predicts / lineage background")
+            background = (
+                "lineage background"
+                if comp_label.lower().startswith("matched-normal")
+                else "non-tumor background"
+            )
+            parts.append(f"{comp_label} over-predicts / {background}")
         else:
             parts.append("matched-normal over-predicts / lineage background")
     elif reliability == "unsupported" and attr_fraction < 0.30:
@@ -586,9 +624,6 @@ def _shortlist_omission_note(targets_df, ranges_df, top_rows) -> str:
             )
         if len(omitted) >= 4:
             break
-    if not omitted:
-        return ""
-
     shortlist_context = []
     for target, expr in top_rows:
         if expr is None:
@@ -615,19 +650,25 @@ def _shortlist_omission_note(targets_df, ranges_df, top_rows) -> str:
             break
 
     rows = shortlist_context + omitted
+    if not rows:
+        return ""
     lines = [
         "**Target expression source trace**",
         "| Gene | Bulk TPM | Tumor-inferred TPM | Tumor fraction | Top non-tumor attribution | Component TPM | Main reason |",
         "|---|---:|---:|---:|---|---:|---|",
     ]
     for row in rows:
+        component = row["component"] if row["component"] != "—" else "none modeled"
         lines.append(
             f"| {row['symbol']} | {_format_trace_tpm(row['bulk'])} | "
             f"{_format_trace_tpm(row['tumor'])} | {row['fraction']:.0%} | "
-            f"{row['component']} | {_format_trace_tpm(row['component_tpm'])} | "
+            f"{component} | {_format_trace_tpm(row['component_tpm'])} | "
             f"{row['reason']} |"
         )
-    lines.append("*Same-lineage background is a caveat, not automatic exclusion; clinical maturity and eligibility still set the shortlist order.*")
+    lines.append(
+        "*Source attribution is a caveat, not an automatic exclusion; "
+        "clinical maturity and eligibility still set the shortlist order.*"
+    )
     return "\n".join(lines)
 
 
@@ -765,16 +806,7 @@ def build_summary(
     # top-ρ cohort) disagree with the classifier's pick.
     from .confidence import compute_call_confidence
     call_tier = compute_call_confidence(analysis)
-    if call_tier.tier in {"low", "moderate"} and call_tier.reasons:
-        tier_text = f"{call_tier.tier} confidence"
-        if call_tier.tier == "low":
-            tier_text += ", provisional"
-        suffix = (
-            f" — **{tier_text}** "
-            f"({call_tier.inline_note})"
-        )
-    else:
-        suffix = ""
+    suffix = _call_confidence_suffix(call_tier, concise=True)
 
     # #171: for mixture cohorts, surface the winning subtype hypothesis
     # so the reader sees "Cancer call: SARC (subtype: rhabdomyosarcoma
@@ -907,16 +939,15 @@ def build_summary(
         )
 
     # Disease state
-    if disease_state:
-        lines.append(f"**Disease state:** {disease_state}")
+    disease_state_display = report_disease_state_text(disease_state, analysis=analysis)
+    if disease_state_display:
+        lines.append(f"**Disease state:** {disease_state_display}")
 
     # Sample context
     if sample_context is not None:
-        prep_label = library_prep_display_label(
-            getattr(sample_context, "library_prep", "unknown")
-        )
+        prep_label = library_prep_clause(getattr(sample_context, "library_prep", "unknown"))
         pres_label = str(getattr(sample_context, "preservation", "unknown")).replace("_", " ")
-        lines.append(f"**Sample:** {prep_label} library, {pres_label} preservation.")
+        lines.append(f"**Sample:** {prep_label}, {pres_label} preservation.")
 
     lines.append("")
 
@@ -931,7 +962,7 @@ def build_summary(
             ranges_df,
             limit=3,
             analysis=analysis,
-            disease_state=disease_state,
+            disease_state=disease_state_display,
         )
         lines.append("## Top candidate therapies\n")
         lines.append(
@@ -958,7 +989,7 @@ def build_summary(
                         expression_row,
                         target_panel=targets_df,
                         analysis=analysis,
-                        disease_state=disease_state,
+                        disease_state=disease_state_display,
                     )
                 )
             omission_note = _shortlist_omission_note(targets_df, ranges_df, top)
@@ -1032,7 +1063,7 @@ def build_actionable(
     # Sample + confidence paragraph
     lines.append("## Sample and confidence\n")
     prep_label = (
-        library_prep_display_label(getattr(sample_context, "library_prep", "unknown"))
+        library_prep_clause(getattr(sample_context, "library_prep", "unknown"))
         if sample_context else "unknown"
     )
     pres_label = str(
@@ -1040,7 +1071,7 @@ def build_actionable(
     ).replace("_", " ") if sample_context else "unknown"
     if sample_context:
         lines.append(
-            f"Input: **{prep_label}** library prep, **{pres_label}** "
+            f"Input: **{prep_label}**, **{pres_label}** "
             "preservation. "
             + _preservation_clinical_clause(sample_context)
         )
@@ -1065,16 +1096,7 @@ def build_actionable(
     lines.append("## Cancer call and disease state\n")
     from .confidence import compute_call_confidence
     call_tier = compute_call_confidence(analysis)
-    if call_tier.tier in {"low", "moderate"} and call_tier.reasons:
-        tier_text = f"{call_tier.tier} confidence"
-        if call_tier.tier == "low":
-            tier_text += ", provisional"
-        call_suffix = (
-            f" — **{tier_text}** "
-            f"({call_tier.inline_note})"
-        )
-    else:
-        call_suffix = ""
+    call_suffix = _call_confidence_suffix(call_tier, concise=True)
     call_punctuation = call_suffix or "."
     lines.append(
         f"Working call: **{cancer_code}** ({cancer_name}){call_punctuation}"
@@ -1091,8 +1113,9 @@ def build_actionable(
         )
         if banner:
             lines.append(f"\n{banner}")
-    if disease_state:
-        lines.append(f"\n{disease_state}")
+    disease_state_display = report_disease_state_text(disease_state, analysis=analysis)
+    if disease_state_display:
+        lines.append(f"\n{disease_state_display}")
     lines.append("")
 
     # Therapy landscape
@@ -1148,7 +1171,7 @@ def build_actionable(
                     therapy_path_rank(
                         t,
                         analysis=analysis,
-                        disease_state=disease_state,
+                        disease_state=disease_state_display,
                     )
                     for _, t in targets_df.iterrows()
                 ],
@@ -1185,19 +1208,20 @@ def build_actionable(
                         if expression_independent_indication(t):
                             interp_cell = (
                                 expression_independent_interpretation(t)
-                                + "; target RNA not measured"
+                                + "; "
+                                + expression_independent_rna_context(None)
                             )
                         else:
                             interp_cell = "not measured"
                         path_context = therapy_path_context(
                             t,
                             analysis=analysis,
-                            disease_state=disease_state,
+                            disease_state=disease_state_display,
                         )
                         state_caution = therapy_state_caution(
                             t,
                             analysis=analysis,
-                            disease_state=disease_state,
+                            disease_state=disease_state_display,
                         )
                         extra_parts = []
                         if path_context:
@@ -1213,10 +1237,11 @@ def build_actionable(
                         tumor_cell = tumor_band_cell(expr)
                         source = tumor_attribution_context(expr)
                         normal = normal_expression_context(expr)
-                        if expression_independent_indication(t):
+                        expr_independent = expression_independent_indication(t)
+                        if expr_independent:
                             interp_parts = [
                                 expression_independent_interpretation(t),
-                                normal["label"],
+                                expression_independent_rna_context(expr),
                             ]
                         else:
                             interp_parts = [source["label"], normal["label"]]
@@ -1224,19 +1249,19 @@ def build_actionable(
                             list(source.get("notes") or [])
                             + list(normal.get("details") or [])
                         )
-                        if notes:
+                        if notes and not expr_independent:
                             interp_parts.append(notes[0])
                         path_context = therapy_path_context(
                             t,
                             analysis=analysis,
-                            disease_state=disease_state,
+                            disease_state=disease_state_display,
                         )
                         if path_context:
                             interp_parts.append(path_context)
                         state_caution = therapy_state_caution(
                             t,
                             analysis=analysis,
-                            disease_state=disease_state,
+                            disease_state=disease_state_display,
                         )
                         if state_caution:
                             interp_parts.append(

--- a/pirlygenes/brief.py
+++ b/pirlygenes/brief.py
@@ -584,7 +584,7 @@ def _shortlist_omission_note(targets_df, ranges_df, top_rows) -> str:
                     "reason": _source_trace_reason(target, expr, in_shortlist=False),
                 }
             )
-        if len(omitted) >= 3:
+        if len(omitted) >= 4:
             break
     if not omitted:
         return ""
@@ -878,9 +878,10 @@ def build_summary(
         except Exception:
             subtype_annotation = f" (subtype: {winning_subtype}-consistent)"
 
+    call_punctuation = suffix or "."
     lines.append(
         f"**Cancer call:** {cancer_code} ({cancer_name})"
-        f"{subtype_annotation}.{suffix}"
+        f"{subtype_annotation}{call_punctuation}"
     )
     # Surface a subtype note only when the resolver changed the call or
     # flagged irreducible ambiguity. ``pair_inactive`` means the pair
@@ -1074,8 +1075,9 @@ def build_actionable(
         )
     else:
         call_suffix = ""
+    call_punctuation = call_suffix or "."
     lines.append(
-        f"Working call: **{cancer_code}** ({cancer_name}).{call_suffix}"
+        f"Working call: **{cancer_code}** ({cancer_name}){call_punctuation}"
     )
     # Step-0 tissue-composition banner (if non-tumor-consistent) so
     # an actionable reader sees the Step-0 caveat attached to the

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1404,7 +1404,7 @@ def _analyze_body(
                 "tumor_purity": get_tumor_purity_parameters(),
                 "decomposition": get_decomposition_parameters(),
                 "selected_sample_mode": analysis["sample_mode"],
-                "embedding_methods": ["tme"],
+                "embedding_methods": ["tme", "tme_with_normals"],
                 "sample_quality": {
                     "degradation_level": quality["degradation"]["level"],
                     "degradation_pair_index": quality["degradation"]["long_short_ratio"],
@@ -1775,7 +1775,18 @@ def _analyze_body(
     print("[plot] Generating MDS embedding (TME-low genes)...")
     mds_png = "%s-mds-tme.png" % prefix
     plot_cancer_type_mds(df_expr, method="tme", save_to_filename=mds_png, save_dpi=output_dpi)
-    embedding_pngs = [mds_png]
+    mds_normals_png = "%s-mds-tme-normals.png" % prefix
+    plot_cancer_type_mds(
+        df_expr,
+        method="tme",
+        include_normals=True,
+        label_nearest_cancers=5,
+        label_nearest_normals=5,
+        label_all=False,
+        save_to_filename=mds_normals_png,
+        save_dpi=output_dpi,
+    )
+    embedding_pngs = [mds_png, mds_normals_png]
     _plt.close("all")
 
     # Deep-dive therapy target + CTA + subtype plots
@@ -2042,6 +2053,7 @@ def _analyze_body(
                     ranges_df,
                     target_panel.reset_index(drop=True),
                     cancer_type=panel_code,
+                    df_gene_expr=df_expr,
                     save_to_filename=curated_evidence_png,
                     save_dpi=output_dpi,
                 )
@@ -2392,6 +2404,7 @@ def _analyze_body(
                     "files": _existing_figure_paths(
                         "cancer-hypotheses.png",
                         "mds-tme.png",
+                        "mds-tme-normals.png",
                         "subtype-signature.png",
                         "vs-cancer.pdf",
                     ),
@@ -2577,6 +2590,7 @@ Prefer the standalone decomposition figures for review and sharing. They replace
 | `*-purity-ctas.png` | Tumor-expression ranges for CTAs |
 | `*-purity-surface.png` | Tumor-expression ranges for surface proteins |
 | `*-mds-tme.png` | MDS: sample among TCGA cancer types (TME-low gene space) |
+| `*-mds-tme-normals.png` | MDS: sample among TCGA cancer and normal tissue types; labels nearest 5 cancer and 5 normal centroids |
 """
     readme_path.write_text(readme)
     print(f"[output] Wrote {readme_path}")
@@ -4706,7 +4720,7 @@ def _build_target_report(
         lines.append("|------|-----------|----------------|---------------------|---------|-----------|-----|---------|-----------|")
         for _, row in ctas.head(20).iterrows():
             surf = "yes" if row["is_surface"] else ""
-            tme_warn = "⚠" if row.get("tme_explainable") else ""
+            tme_warn = "tissue-explainable" if row.get("tme_explainable") else ""
             lines.append(
                 f"| **{row['symbol']}** | {render_tpm(row['median_est'])} | "
                 f"{render_tpm(row['est_1'])}\u2013{render_tpm(row['est_9'])} | "
@@ -4729,7 +4743,7 @@ def _build_target_report(
             and ctas.head(20)["tme_explainable"].any()
         ):
             lines.append(
-                "\n⚠ = sample signal could be entirely explained by a single healthy "
+                "\n`tissue-explainable` = sample signal could be entirely explained by a single healthy "
                 "tissue's expression. For CTAs this is usually benign (cohort-median "
                 "≈ 0 is normal for CTAs), but verify the flagged gene is not a germline "
                 "/ germ-cell lineage marker in this patient's context."
@@ -4761,15 +4775,10 @@ def _build_target_report(
         )
         for _, row in surface_targets.head(20).iterrows():
             bold = "**" if row["therapies"] else ""
-            # TME flag — compact key:
-            #   ⚠⚠ = ``tme_dominant`` (observed signal is mostly non-
-            #   tumor per the decomposition attribution, #108); ⚠ =
-            #   ``tme_explainable`` (a single healthy reference tissue
-            #   could explain ≥50% of signal, #45).
             if row.get("tme_dominant"):
-                tme_warn = "⚠⚠"
+                tme_warn = "background-dominant"
             elif row.get("tme_explainable"):
-                tme_warn = "⚠"
+                tme_warn = "tissue-explainable"
             else:
                 tme_warn = ""
             # Append IFN-driven cross-signal note to the therapies
@@ -4798,7 +4807,7 @@ def _build_target_report(
         )
         if any_dominant:
             lines.append(
-                "\n⚠⚠ = **TME-dominant**: the decomposition attribution "
+                "\n`background-dominant` = the decomposition attribution "
                 "assigns less than 30% of the observed TPM to the tumor "
                 "compartment (#108). These targets are very likely "
                 "stromal / immune rather than tumor-cell expressed — "
@@ -4815,10 +4824,10 @@ def _build_target_report(
                 "strongly enriched tissue — tumor-cell specificity is "
                 "not supported regardless of the numeric tumor-attributed "
                 "TPM."
-            )
+        )
         if any_explainable:
             lines.append(
-                "\n⚠ = sample signal could be entirely explained by a single healthy "
+                "\n`tissue-explainable` = sample signal could be entirely explained by a single healthy "
                 "tissue's expression (max across non-reproductive tissues ≥ 50% of "
                 "observed TPM). The tumor-cell attribution for these genes is "
                 "unreliable — consider stromal / immune origin."
@@ -4836,7 +4845,7 @@ def _build_target_report(
         lines.append("|------|-----------|----------------|---------|-----------|-----|-------------|-----|-----------|")
         for _, row in intracellular.head(15).iterrows():
             cta_flag = "yes" if row["is_cta"] else ""
-            tme_warn = "⚠" if row.get("tme_explainable") else ""
+            tme_warn = "tissue-explainable" if row.get("tme_explainable") else ""
             attribution_cell = _format_attribution_cell(row)
             lines.append(
                 f"| {row['symbol']} | {render_tpm(row['median_est'])} | "
@@ -4850,7 +4859,7 @@ def _build_target_report(
             and intracellular.head(15)["tme_explainable"].any()
         ):
             lines.append(
-                "\n⚠ = sample signal could be entirely explained by a single healthy "
+                "\n`tissue-explainable` = sample signal could be entirely explained by a single healthy "
                 "tissue's expression (max across non-reproductive tissues ≥ 50% of "
                 "observed TPM). The tumor-cell attribution for these genes is "
                 "unreliable — consider lineage-retained / stromal origin."
@@ -4862,19 +4871,18 @@ def _build_target_report(
     # --- Top recommendation summary ---
     # #79: Recommendations must respect the reliability flags from the
     # per-category tables. Previously the top-3 surface targets were
-    # chosen by TPM rank alone, which promoted genes flagged ⚠⚠ (TME-
+    # chosen by TPM rank alone, which promoted TME-dominant genes
     # dominant / very likely stromal) as "best surface targets" — the
-    # opposite of the safe default. Now: skip ⚠⚠-flagged rows
-    # entirely from the summary; ⚠-flagged retained rows carry an
-    # inline caveat.
+    # opposite of the safe default. Now: skip unsupported rows entirely
+    # from the summary; provisional retained rows carry an inline caveat.
     lines.append("## Recommended Targets Summary\n")
 
     def _reliability_badge(row):
         status = target_reliability_status(row)
         if status == "unsupported":
-            return "⚠⚠"
+            return "background-dominant"
         if status == "provisional":
-            return "⚠"
+            return "provisional"
         return ""
 
     # Best surface — promote only rows that remain supported after the
@@ -4887,7 +4895,7 @@ def _build_target_report(
         for _, row in safe_surface.iterrows():
             badge = _reliability_badge(row)
             reasons = target_reliability_reasons(row)
-            caveat = f", {badge} {reasons[0]}" if badge == "⚠" and reasons else ""
+            caveat = f", {badge}: {reasons[0]}" if badge == "provisional" and reasons else ""
             therapy_note = f" — active in {row['therapies']}" if row["therapies"] else ""
             lines.append(
                 f"- **{row['symbol']}** ({row['median_est']:.0f} TPM, "
@@ -4906,7 +4914,7 @@ def _build_target_report(
         lines.append("**Best surface targets** (ADC/CAR-T/bispecific):")
         for _, row in mixed_surface.iterrows():
             reasons = target_reliability_reasons(row)
-            caveat = f", ⚠ {reasons[0]}" if reasons else ""
+            caveat = f", provisional: {reasons[0]}" if reasons else ""
             therapy_note = f" — active in {row['therapies']}" if row["therapies"] else ""
             lines.append(
                 f"- **{row['symbol']}** ({row['median_est']:.0f} TPM, "

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -2636,7 +2636,7 @@ def _purity_ci_phrase(purity):
         )
     elif tier == "low":
         core += (
-            " — **⚠ low-confidence**: the range spans "
+            " — **low confidence**: the range spans "
             f"{(hi - lo):.0%}, so per-gene tumor-expression estimates "
             "derived from this purity carry wide error bars"
         )
@@ -3523,7 +3523,7 @@ def _generate_text_reports(
             lines.append(concentration)
         if ctx_signals.get("likely_targeted_panel"):
             lines.append(
-                "- ⚠ **Likely targeted panel** (few detected genes or >90% TPM "
+                "- **Likely targeted panel** (few detected genes or >90% TPM "
                 "concentrated in top 2000 genes) — downstream scores assume "
                 "whole-transcriptome input; interpret carefully."
             )
@@ -3534,7 +3534,7 @@ def _generate_text_reports(
                          f"p95={ctx_signals.get('log2_tpm_p95', 0):.2f}")
         if sample_context.missing_mt:
             lines.append(
-                "- ⚠ **Mitochondrial genes missing** from quant table — "
+                "- **Mitochondrial genes missing** from quant table — "
                 "degradation signal from MT fraction is unreliable."
             )
         lines.append("")
@@ -4100,7 +4100,7 @@ def _build_target_report(
     # / ADC / radioligand target tables.
     if p_mid is not None and p_mid < 0.20:
         lines.append(
-            f"> **⚠ Low-purity caveat**: estimated purity is "
+            f"> **Low-purity caveat**: estimated purity is "
             f"**{p_mid:.0%}**, so residual TPM is divided by a small "
             "number and amplified ≥5×. Genes heavily expressed in "
             "fibroblast / endothelial / immune compartments (FN1, "
@@ -4122,7 +4122,7 @@ def _build_target_report(
             if sample_context.degradation_index is not None else ""
         )
         lines.append(
-            f"> **⚠ Degradation caveat**: sample flagged as "
+            f"> **Degradation caveat**: sample flagged as "
             f"`{sample_context.degradation_severity}` degradation"
             f"{index_str}. Long-transcript TPMs are under-represented; "
             "tumor-expression estimates for long-gene targets carry "

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -70,6 +70,7 @@ from .decomposition import (
 )
 from .sample_context import (
     infer_sample_context,
+    library_prep_clause,
     library_prep_display_label,
     plot_degradation_index,
     plot_sample_context,
@@ -86,7 +87,9 @@ from .reporting import (
     cancer_key_genes_lookup_for_analysis,
     expression_independent_indication,
     expression_independent_interpretation,
+    expression_independent_rna_context,
     normal_expression_context,
+    report_disease_state_text,
     resolved_subtype_code_for_analysis,
     subtype_curation_scope_note,
     therapy_path_context,
@@ -3405,6 +3408,10 @@ def _generate_text_reports(
 
     # Disease-state synthesis (#78) — still used by analysis.md.
     disease_state_paragraph = compose_disease_state_narrative(analysis)
+    disease_state_display = report_disease_state_text(
+        disease_state_paragraph,
+        analysis=analysis,
+    )
 
     # The old free-form ``*-summary.md`` paragraph (disease-state +
     # QC + headline + composition + therapy-response state) was
@@ -3422,13 +3429,14 @@ def _generate_text_reports(
 
     # Disease-state synthesis (#78) — rendered at the top so a reader
     # sees the clinical framing before descending into pipeline detail.
-    if disease_state_paragraph:
-        lines.append(f"**Disease state**: {disease_state_paragraph}\n")
+    if disease_state_display:
+        lines.append(f"**Disease state**: {disease_state_display}\n")
 
     lines.append("## Sample framing\n")
     if sample_context is not None:
+        prep_clause = library_prep_clause(sample_context.library_prep)
         lines.append(
-            f"- **Input type**: {sample_context.library_prep.replace('_', ' ')} library prep; "
+            f"- **Input type**: {prep_clause}; "
             f"{sample_context.preservation.replace('_', ' ')} preservation."
         )
     if call_summary.get("label_options"):
@@ -3504,8 +3512,10 @@ def _generate_text_reports(
         lines.append("## Input characterization\n")
         if input_path:
             lines.append(f"- **Source file**: `{input_path}`")
-        lines.append(f"- **Library prep**: {sample_context.library_prep.replace('_', ' ')} "
-                     f"(confidence {sample_context.library_prep_confidence:.0%})")
+        lines.append(
+            f"- **Library prep**: {library_prep_display_label(sample_context.library_prep)} "
+            f"(confidence {sample_context.library_prep_confidence:.0%})"
+        )
         lines.append(f"- **Preservation**: {sample_context.preservation.replace('_', ' ')}"
                      + (f" (degradation index {sample_context.degradation_index:.2f})"
                         if sample_context.degradation_index is not None else ""))
@@ -4049,7 +4059,7 @@ def _generate_text_reports(
                 analysis,
                 ranges_df,
                 cancer_code=cancer_code,
-                disease_state=disease_state_paragraph or "",
+                disease_state=disease_state_display,
                 sample_id=sample_id,
             )
             therapy_section = _extract_markdown_section(
@@ -4173,8 +4183,8 @@ def _build_target_report(
         if expr_row is None:
             if target_row is not None and expression_independent_indication(target_row):
                 parts = [
-                    expression_independent_interpretation(target_row)
-                    + "; target RNA not measured"
+                    expression_independent_interpretation(target_row),
+                    expression_independent_rna_context(None),
                 ]
             else:
                 parts = ["not measured"]
@@ -4204,11 +4214,19 @@ def _build_target_report(
             )
         source = tumor_attribution_context(expr_row)
         normal = normal_expression_context(expr_row)
-        if target_row is not None and expression_independent_indication(target_row):
-            parts = [expression_independent_interpretation(target_row), normal["label"]]
+        expr_independent = (
+            target_row is not None and expression_independent_indication(target_row)
+        )
+        if expr_independent:
+            parts = [
+                expression_independent_interpretation(target_row),
+                expression_independent_rna_context(expr_row),
+            ]
         else:
             parts = [source["label"], normal["label"]]
-        if source.get("notes"):
+        if expr_independent:
+            pass
+        elif source.get("notes"):
             parts.append(source["notes"][0])
         elif normal.get("details"):
             parts.append(normal["details"][0])
@@ -4241,7 +4259,10 @@ def _build_target_report(
     )
     fit_quality = analysis.get("fit_quality", {})
     family_display = (analysis.get("family_summary") or {}).get("display")
-    disease_state = compose_disease_state_narrative(analysis)
+    disease_state = report_disease_state_text(
+        compose_disease_state_narrative(analysis),
+        analysis=analysis,
+    )
     matched_normal_summary = _matched_normal_split_summary(ranges_df)
     mhc_status_label, mhc_status_text = _mhc1_status_text(analysis.get("mhc1"))
     panel_target_symbols = set()

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -1404,7 +1404,7 @@ def _analyze_body(
                 "tumor_purity": get_tumor_purity_parameters(),
                 "decomposition": get_decomposition_parameters(),
                 "selected_sample_mode": analysis["sample_mode"],
-                "embedding_methods": ["tme", "tme_with_normals"],
+                "embedding_methods": ["tme", "tme_with_subtypes_and_normals"],
                 "sample_quality": {
                     "degradation_level": quality["degradation"]["level"],
                     "degradation_pair_index": quality["degradation"]["long_short_ratio"],
@@ -1764,14 +1764,16 @@ def _analyze_body(
     # in analysis.md without adding interpretive value. The functions
     # remain in ``pirlygenes.plot_embedding`` for Python-API consumers.
 
-    # Sample-among-TCGA embedding: MDS in the TME-low gene space is the
+    # Sample-among-reference embedding: MDS in the TME-low gene space is the
     # preferred view — robust at low purity (where hierarchy-method plots
     # can cluster the sample by infiltrate instead of by tumor biology),
     # and MDS preserves pairwise distances better than PCA for samples
     # that sit between canonical cancer-type centroids.  Other
     # method/algorithm combinations are available in the Python API but
     # are not emitted by default; see pirl-unc/pirlygenes#... for the
-    # design rationale.
+    # design rationale. The companion view appends available subtype
+    # references and normal-tissue centroids; registry-only cancer types
+    # without expression medians are not embedded.
     print("[plot] Generating MDS embedding (TME-low genes)...")
     mds_png = "%s-mds-tme.png" % prefix
     plot_cancer_type_mds(df_expr, method="tme", save_to_filename=mds_png, save_dpi=output_dpi)
@@ -1780,6 +1782,7 @@ def _analyze_body(
         df_expr,
         method="tme",
         include_normals=True,
+        include_subtypes=True,
         label_nearest_cancers=5,
         label_nearest_normals=5,
         label_all=False,
@@ -2736,7 +2739,7 @@ def _target_value_label(sample_mode):
         return "Cellular TPM (model)"
     if sample_mode == "heme":
         return "Malignant-lineage TPM (model)"
-    return "Tumor-core TPM (model)"
+    return "Tumor-inferred TPM (model)"
 
 
 def _mhc1_status_text(mhc1):
@@ -4296,7 +4299,7 @@ def _build_target_report(
                 if panel_subtype else cancer_biomarker_genes(panel_code)
             )
             if biomarker_syms:
-                lines.append("| Gene | Bulk TPM (measured) | Tumor-core TPM (model) | Attribution |")
+                lines.append("| Gene | Bulk TPM (measured) | Tumor-inferred TPM (model) | Attribution |")
                 lines.append("|------|---------------------|------------------------|-------------|")
                 for sym in biomarker_syms:
                     row = sym_to_row.get(sym)
@@ -4344,7 +4347,7 @@ def _build_target_report(
             if len(targets_df):
                 lines.append(
                     "| Target | Agent | Class | Phase | Indication | "
-                    "Bulk TPM (measured) | Tumor-core TPM (model) | Attribution | Interpretation |"
+                    "Bulk TPM (measured) | Tumor-inferred TPM (model) | Attribution | Interpretation |"
                 )
                 lines.append(
                     "|--------|-------|-------|-------|------------|"

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -379,7 +379,7 @@ def compute_target_confidence(
     if isinstance(attr_fraction, (int, float)) and 0.3 <= float(attr_fraction) < 0.5:
         if tier == "high":
             tier = "moderate"
-        reasons.append(f"only {float(attr_fraction):.0%} of signal attributed to tumor core")
+        reasons.append(f"only {float(attr_fraction):.0%} of signal attributed to tumor")
 
     # Deduplicate reasons while preserving order.
     seen = set()

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -39,8 +39,8 @@ class ConfidenceTier:
     @property
     def badge(self) -> str:
         return {
-            "low": "⚠⚠",
-            "moderate": "⚠",
+            "low": "low",
+            "moderate": "moderate",
             "high": "",
             "degenerate": "—",
             "unknown": "?",

--- a/pirlygenes/confidence.py
+++ b/pirlygenes/confidence.py
@@ -28,6 +28,7 @@ Two computed tiers:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 from typing import List
 
 
@@ -58,6 +59,48 @@ class ConfidenceTier:
         note = self.inline_note
         prefix = f"**{self.tier} confidence**"
         return f"{prefix} ({note})" if note else prefix
+
+
+def concise_confidence_reasons(tier: ConfidenceTier, max_reasons: int = 3) -> str:
+    """Return reader-facing shorthand for verbose confidence reasons.
+
+    The full reason strings remain in ``analysis.md`` / evidence tables.
+    The one-page summary needs the same information in a compact form so
+    the cancer-call line stays skimmable across cancer types.
+    """
+    notes: list[str] = []
+    for reason in tier.reasons or []:
+        text = str(reason)
+        low = text.lower()
+        note = ""
+        if "fit quality is weak" in low:
+            note = "weak fit"
+        elif "fit quality is ambiguous" in low:
+            note = "ambiguous fit"
+        elif "lineage-pattern concordance" in low:
+            note = "lineage mismatch"
+        elif "beats runner-up" in low:
+            match = re.search(r"runner-up ([A-Za-z0-9_]+)", text)
+            note = (
+                f"near tie with {match.group(1)}"
+                if match else "near tie with runner-up"
+            )
+        elif "raw signature score favored" in low:
+            match = re.search(r"raw signature score favored ([A-Za-z0-9_]+)", text)
+            note = (
+                f"raw signature favors {match.group(1)}"
+                if match else "raw signature conflict"
+            )
+        elif "step-0 correlation favored" in low:
+            match = re.search(r"Step-0 correlation favored ([A-Za-z0-9_]+)", text)
+            note = f"Step-0 favors {match.group(1)}" if match else "Step-0 conflict"
+        else:
+            note = text.split(" — ", 1)[0].strip()
+        if note and note not in notes:
+            notes.append(note)
+        if len(notes) >= max_reasons:
+            break
+    return "; ".join(notes)
 
 
 def compute_purity_confidence(

--- a/pirlygenes/data/cancer-key-genes.csv
+++ b/pirlygenes/data/cancer-key-genes.csv
@@ -1,824 +1,824 @@
-cancer_code,subtype,symbol,role,agent,agent_class,phase,indication,rationale,source
-PRAD,,AR,biomarker,,,,,Androgen receptor — lineage confirmation; retained expression with collapsed transactivation targets indicates castrate-resistant disease,PMID:23332746
-PRAD,,KLK3,biomarker,,,,,PSA — transactivated target of AR; collapse with retained AR indicates CRPC,PMID:23332746
-PRAD,,KLK2,biomarker,,,,,Kallikrein 2 — AR-transactivated; parallels KLK3 in CRPC de-differentiation,PMID:23332746
-PRAD,,NKX3-1,biomarker,,,,,Prostate lineage transcription factor; lost in NEPC / de-differentiated disease,PMID:17538631
-PRAD,,HOXB13,biomarker,,,,,Prostate lineage; combined with NKX3-1 loss signals de-differentiation,PMID:28069311
-PRAD,,TMPRSS2,biomarker,,,,,AR-target gene; part of TMPRSS2-ERG fusion landscape,PMID:16254181
-PRAD,,ENO2,biomarker,,,,,Neuron-specific enolase — core NE-differentiation marker; elevation with AR-target collapse warrants NEPC workup,PMID:27322743
-PRAD,,CHGA,biomarker,,,,,Chromogranin A — NE differentiation marker,PMID:27322743
-PRAD,,SYP,biomarker,,,,,Synaptophysin — NE differentiation marker,PMID:27322743
-PRAD,,ASCL1,biomarker,,,,,NE lineage transcription factor; active in NEPC,PMID:31611234
-PRAD,,INSM1,biomarker,,,,,NE transcription factor; preferred marker over CHGA/SYP in some NEPC panels,PMID:31611234
-PRAD,,FOLH1,target,177Lu-PSMA-617,radioligand,approved,mCRPC,PSMA — lutetium radioligand approved for PSMA-PET positive mCRPC post-ARPI,PMID:34161051
-PRAD,,FOLH1,target,225Ac-PSMA-617,radioligand,phase_3,mCRPC,PSMA alpha-emitter in late-stage trials for PSMA-PET positive mCRPC,PMID:35930720
-PRAD,,STEAP1,target,AMG-509 (xaluritamig),TCE,phase_2,mCRPC,STEAP1×CD3 bispecific T-cell engager in mCRPC; encouraging phase 1 responses,PMID:37812792
-PRAD,,STEAP2,target,,ADC,preclinical,mCRPC,STEAP2 ADCs in discovery; coexpressed with STEAP1,
-PRAD,,DLL3,target,tarlatamab,TCE,phase_2,NEPC,DLL3×CD3 BiTE initially approved for SCLC; active trials in NEPC where DLL3 is retained,PMID:36417474
-PRAD,,KLK2,target,JNJ-69086420,bispecific,phase_1,mCRPC,KLK2-targeting bispecific in early-phase trials,PMID:38110199
-PRAD,,TACSTD2,target,sacituzumab govitecan,ADC,phase_2,mCRPC,Trop-2 ADC trials in CRPC following breast and urothelial approvals,
-PRAD,,AR,target,enzalutamide,small_molecule,approved,mCRPC,Second-generation AR antagonist; standard of care in CRPC,PMID:22894553
-PRAD,,AR,target,apalutamide,small_molecule,approved,nmCRPC,Approved for non-metastatic CRPC and mHSPC,PMID:29420164
-PRAD,,PSCA,biomarker,,,,,Prostate stem cell antigen — PRAD-adenocarcinoma-enriched lineage marker; co-expressed with PSMA / STEAP1 / TROP-2 in AR-retained disease,PMID:9653118
-PRAD,,PSCA,target,BPX-601,CAR-T,phase_1,mCRPC,PSCA-directed autologous CAR-T with rimiducid (GoCAR-T) — early-phase PRAD trial,PMID:32961293
-PRAD,,PSCA,target,PSMA-PSCA bispecific,bispecific,preclinical,mCRPC,PSMA×PSCA dual-targeting bispecifics in preclinical / early trials — leverage co-expression to narrow on-target / off-tumor toxicity,
-PRAD,,CD276,biomarker,,,,,B7-H3 — surface protein positively correlated with AR expression in PRAD; overexpressed in AR-retained mCRPC and a subset of NEPC,PMID:35839033
-PRAD,,CD276,target,ifinatamab deruxtecan (DS-7300),ADC,phase_2,mCRPC,B7-H3 DXd-payload ADC — active in pretreated mCRPC regardless of PSMA status; positively correlated with AR expression,PMID:35839033
-PRAD,,CD276,target,vobramitamab duocarmazine (MGC018),ADC,phase_2,mCRPC,B7-H3 ADC — TAMARACK trial in pretreated mCRPC,PMID:38061024
-PRAD,,CD276,target,enoblituzumab,antibody,phase_2,mCRPC,Anti-B7-H3 antibody — neoadjuvant and combination trials,
-PRAD,,CEACAM5,biomarker,,,,,CEA — negatively correlated with AR expression in PRAD; enriched in AR-suppressed / NEPC-trending disease where PSMA is lost,PMID:30333172
-PRAD,,CEACAM5,target,labetuzumab govitecan,ADC,phase_2,AR-low / NEPC mCRPC,CEACAM5 ADC — basket activity; candidate for AR-suppressed mCRPC where PSMA is low,
-PRAD,,CEACAM5,target,tusamitamab ravtansine,ADC,phase_2,CEACAM5+ mCRPC,CEACAM5 ADC extending from NSCLC; trials in AR-low / NE-differentiated mCRPC,
-PRAD,,FAP,biomarker,,,,,Fibroblast activation protein — marks cancer-associated fibroblasts in PRAD stroma; expression **not strongly correlated** with PSMA because it's CAF-origin rather than tumor-cell,PMID:36898755
-PRAD,,FAP,target,[68Ga]FAPI-46,radioligand,phase_2,mCRPC,FAP-directed PET imaging — detects PSMA-negative / NEPC disease by imaging tumor stroma,PMID:36898755
-PRAD,,FAP,target,[177Lu]FAPI-46,radioligand,phase_1,mCRPC,FAP-directed radioligand therapy — early-phase trials for PSMA-low or PSMA-refractory mCRPC,PMID:36898755
-BRCA,,ESR1,biomarker,,,,,Estrogen receptor — drives endocrine therapy indication; loss / mutation marks endocrine resistance,PMID:27532823
-BRCA,,PGR,biomarker,,,,,Progesterone receptor — luminal marker; retained PR favors endocrine sensitivity,PMID:17438091
-BRCA,,ERBB2,biomarker,,,,,HER2 — gating biomarker for HER2-targeted agents; IHC/ISH 3+ or FISH-amplified eligible,PMID:17544441
-BRCA,,MKI67,biomarker,,,,,Ki-67 proliferation index; prognostic and guides chemo decisions in ER+ disease,PMID:21965299
-BRCA,,GATA3,biomarker,,,,,Luminal transcription factor; diagnostic for mammary origin,PMID:16730215
-BRCA,,FOXA1,biomarker,,,,,Pioneer factor cooperating with ER; luminal identity,PMID:20378679
-BRCA,,BRCA1,biomarker,,,,,Germline/somatic loss drives PARP inhibitor indication,PMID:19553641
-BRCA,,BRCA2,biomarker,,,,,Germline/somatic loss drives PARP inhibitor indication,PMID:19553641
-BRCA,,ERBB2,target,trastuzumab,antibody,approved,HER2+ BRCA,First-in-class anti-HER2 monoclonal; standard backbone for HER2+ disease,PMID:11248153
-BRCA,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,HER2+ / HER2-low BRCA,Enhertu — expanded approval to HER2-low metastatic breast cancer,PMID:35665782
-BRCA,,ERBB2,target,pertuzumab,antibody,approved,HER2+ BRCA,Dual HER2 blockade with trastuzumab,PMID:22149875
-BRCA,,TACSTD2,target,sacituzumab govitecan,ADC,approved,mTNBC / HR+/HER2-,Trodelvy — Trop-2 ADC approved in mTNBC and HR+/HER2- post-endocrine,PMID:33882206
-BRCA,,FOLR1,target,mirvetuximab soravtansine,ADC,phase_3,TNBC subsets,Folate receptor alpha ADC in basket trials including TNBC,PMID:37094291
-BRCA,,ESR1,target,elacestrant,small_molecule,approved,ER+/HER2- ESR1-mut BRCA,Oral SERD approved for ESR1-mutant metastatic ER+ disease,PMID:36924229
-BRCA,,PGR,target,,hormone,approved,ER+/HER2- BRCA,PR positivity supports endocrine therapy with AI or tamoxifen,
-BRCA,,CDK4,target,palbociclib,small_molecule,approved,HR+/HER2- BRCA,CDK4/6 inhibitor combined with endocrine therapy,PMID:25524798
-BRCA,,CDK6,target,abemaciclib,small_molecule,approved,HR+/HER2- BRCA,CDK4/6 inhibitor including adjuvant use,PMID:31158057
-LUAD,,EGFR,biomarker,,,,,Activating mutations (exon 19 del / L858R) gate TKI indication; T790M drives osimertinib selection,PMID:15118073
-LUAD,,KRAS,biomarker,,,,,G12C targetable; other alleles remain a negative predictor for EGFR TKIs,PMID:32955177
-LUAD,,ALK,biomarker,,,,,EML4-ALK fusion — alectinib-eligible,PMID:17625570
-LUAD,,ROS1,biomarker,,,,,ROS1 fusion — crizotinib / entrectinib eligible,PMID:22215748
-LUAD,,BRAF,biomarker,,,,,V600E mutation — dabrafenib+trametinib eligible,PMID:27283860
-LUAD,,RET,biomarker,,,,,RET fusion — selpercatinib / pralsetinib eligible,PMID:32273263
-LUAD,,MET,biomarker,,,,,Exon 14 skipping — capmatinib / tepotinib eligible,PMID:31950082
-LUAD,,NTRK1,biomarker,,,,,NTRK fusion — larotrectinib / entrectinib eligible (basket),PMID:29466156
-LUAD,,CD274,biomarker,,,,,PD-L1 expression gates first-line pembrolizumab monotherapy,PMID:27718847
-LUAD,,KEAP1,biomarker,,,,,Co-mutation with STK11 predicts immunotherapy resistance,PMID:30275273
-LUAD,,STK11,biomarker,,,,,Loss predicts immunotherapy resistance in KRAS-mutant LUAD,PMID:30287575
-LUAD,,NKX2-1,biomarker,,,,,TTF-1 — adenocarcinoma lineage confirmation,PMID:20686206
-LUAD,,EGFR,target,osimertinib,small_molecule,approved,EGFR-mut LUAD,Third-generation EGFR TKI — frontline and resistance setting,PMID:31733398
-LUAD,,ALK,target,alectinib,small_molecule,approved,ALK-rearranged LUAD,Second-generation ALK TKI — frontline standard,PMID:28586279
-LUAD,,KRAS,target,sotorasib,small_molecule,approved,KRAS G12C LUAD,First KRAS G12C inhibitor approved,PMID:34252278
-LUAD,,KRAS,target,adagrasib,small_molecule,approved,KRAS G12C LUAD,Second KRAS G12C inhibitor,PMID:35658005
-LUAD,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600E LUAD,BRAF/MEK combination,PMID:27283860
-LUAD,,MET,target,capmatinib,small_molecule,approved,MET exon 14 LUAD,MET inhibitor for exon 14 skipping,PMID:32877583
-LUAD,,RET,target,selpercatinib,small_molecule,approved,RET fusion LUAD,Selective RET inhibitor,PMID:32846060
-LUAD,,CD274,target,pembrolizumab,antibody,approved,PD-L1 high LUAD,Anti-PD-1; first-line for TPS ≥50%,PMID:27718847
-LUAD,,CEACAM5,target,tusamitamab ravtansine,ADC,phase_3,CEACAM5+ NSCLC,Phase 3 CARMEN-LC03 trial,PMID:36070567
-LUAD,,TROP2,target,datopotamab deruxtecan,ADC,approved,NSCLC,Dato-DXd approved in advanced/metastatic nsqNSCLC,
-COAD,,KRAS,biomarker,,,,,KRAS wild-type required for EGFR antibody (cetuximab / panitumumab) response,PMID:18316791
-COAD,,NRAS,biomarker,,,,,Must be wild-type for EGFR-antibody response; pan-RAS testing standard,PMID:20921462
-COAD,,BRAF,biomarker,,,,,V600E — poor prognosis; triple combo encorafenib+cetuximab+MEK eligible,PMID:24637364
-COAD,,MLH1,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; gates checkpoint IO,PMID:11932474
-COAD,,MSH2,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; Lynch syndrome relevance,PMID:11932474
-COAD,,MSH6,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; Lynch syndrome relevance,PMID:11932474
-COAD,,PMS2,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR,PMID:11932474
-COAD,,CDX2,biomarker,,,,,Intestinal lineage transcription factor — diagnostic of GI adenocarcinoma,PMID:18818409
-COAD,,CEACAM5,biomarker,,,,,CEA — serum / tissue biomarker for colorectal adenocarcinoma,PMID:15767599
-COAD,,ERBB2,biomarker,,,,,HER2 amplification — approved indication for trastuzumab combos in RAS WT,PMID:27108243
-COAD,,TP53,biomarker,,,,,Prognostic / predictive; mutation common and linked to chemo response,PMID:27496642
-COAD,,APC,biomarker,,,,,Gatekeeper driver of adenoma-carcinoma sequence; Wnt pathway activation,PMID:20180050
-COAD,,BRAF,target,encorafenib + cetuximab,small_molecule,approved,BRAF V600E mCRC,BEACON triplet / doublet for BRAF V600E mCRC,PMID:31566309
-COAD,,KRAS,target,sotorasib,small_molecule,approved,KRAS G12C mCRC,Approved in pretreated KRAS G12C mCRC (CodeBreaK 300),PMID:37882531
-COAD,,KRAS,target,adagrasib,small_molecule,approved,KRAS G12C mCRC,Approved with cetuximab for pretreated KRAS G12C mCRC,
-COAD,,ERBB2,target,trastuzumab + tucatinib,antibody,approved,HER2+ RAS-WT mCRC,MOUNTAINEER trial result; HER2+ mCRC,PMID:37084732
-COAD,,EGFR,target,cetuximab,antibody,approved,RAS-WT mCRC,Anti-EGFR in RAS/BRAF wild-type mCRC,PMID:19339720
-COAD,,EGFR,target,panitumumab,antibody,approved,RAS-WT mCRC,Fully human anti-EGFR antibody,PMID:20921462
-COAD,,CD274,target,pembrolizumab,antibody,approved,MSI-H / dMMR mCRC,Frontline IO in MSI-H / dMMR mCRC (KEYNOTE-177),PMID:33264544
-COAD,,CEACAM5,target,labetuzumab govitecan,ADC,phase_2,CEACAM5+ mCRC,CEACAM5 ADC in clinical trials,
-SKCM,,BRAF,biomarker,,,,,V600E/K — gates BRAF/MEK inhibition,PMID:22460905
-SKCM,,NRAS,biomarker,,,,,Q61 mutations — MEK / ERK-directed trials,PMID:23410882
-SKCM,,MITF,biomarker,,,,,Melanocyte lineage transcription factor; amplification in some resistance phenotypes,PMID:16172454
-SKCM,,S100B,biomarker,,,,,Serum biomarker for melanoma progression,PMID:19380449
-SKCM,,MLANA,biomarker,,,,,Melan-A / MART-1 — melanocyte lineage antigen and TCR target,PMID:7539751
-SKCM,,TYR,biomarker,,,,,Tyrosinase — melanocyte lineage antigen,PMID:8201753
-SKCM,,PMEL,biomarker,,,,,gp100 — melanocyte antigen; vaccine and TCR target,PMID:8201753
-SKCM,,PRAME,biomarker,,,,,Cancer-testis antigen broadly expressed in melanoma; IMCgp100 / PRAME TCR trials,PMID:34428009
-SKCM,,CD274,biomarker,,,,,PD-L1 stratifies IO response,PMID:26027431
-SKCM,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600 melanoma,Standard BRAF/MEK combination in V600-mutant disease,PMID:25399551
-SKCM,,BRAF,target,encorafenib + binimetinib,small_molecule,approved,BRAF V600 melanoma,COLUMBUS trial combination,PMID:29573941
-SKCM,,BRAF,target,vemurafenib,small_molecule,approved,BRAF V600 melanoma,First BRAF inhibitor approved for melanoma,PMID:21639808
-SKCM,,CD274,target,pembrolizumab,antibody,approved,advanced melanoma,First-line anti-PD-1,PMID:25891173
-SKCM,,CD274,target,nivolumab,antibody,approved,advanced melanoma,First-line anti-PD-1; combined with ipi for high-risk disease,PMID:26027431
-SKCM,,CTLA4,target,ipilimumab,antibody,approved,advanced melanoma,Anti-CTLA4; combination with nivolumab standard of care,PMID:20525992
-SKCM,,LAG3,target,relatlimab,antibody,approved,advanced melanoma,LAG-3 + PD-1 combination (nivolumab-relatlimab),PMID:35063055
-SKCM,,PRAME,target,IMA203,TCR-T,phase_2,advanced melanoma,PRAME-directed TCR-T trials,PMID:34428009
-SKCM,,PMEL,target,IMCgp100 / tebentafusp,TCE,approved,uveal melanoma,gp100 ImmTAC — approved for HLA-A*02:01 uveal melanoma,PMID:33053284
-SKCM,,TYR,target,,TCR-T,preclinical,melanoma,Historical tyrosinase TCRs; active cell-therapy research,
-HNSC,,CDKN2A,biomarker,,,,,p16 — elevated in HPV-driven HNSC (surrogate for E6/E7 inactivation),PMID:21079132
-HNSC,,EGFR,biomarker,,,,,Overexpression / mutation — cetuximab eligibility,PMID:11309435
-HNSC,,CD274,biomarker,,,,,PD-L1 CPS gates first-line pembrolizumab monotherapy or combo,PMID:30509740
-HNSC,,CCND1,biomarker,,,,,Cyclin D1 — frequently amplified in HPV-negative HNSC,PMID:26457759
-HNSC,,TP53,biomarker,,,,,Mutation common in HPV-negative disease; prognostic,PMID:26457759
-HNSC,,PIK3CA,biomarker,,,,,Hotspot mutations prevalent; relevant to PI3K-pathway trials,PMID:21430269
-HNSC,,FADD,biomarker,,,,,Amplified in HPV-negative HNSC; linked to resistance signaling,PMID:21430269
-HNSC,,EGFR,target,cetuximab,antibody,approved,recurrent/metastatic HNSC,Anti-EGFR — combined with chemo or RT,PMID:18784101
-HNSC,,CD274,target,pembrolizumab,antibody,approved,recurrent/metastatic HNSC,Frontline IO per CPS (KEYNOTE-048),PMID:31679945
-HNSC,,CD274,target,nivolumab,antibody,approved,recurrent/metastatic HNSC,Anti-PD-1 post-platinum (CheckMate 141),PMID:27718847
-DLBC,,MS4A1,biomarker,,,,,CD20 — lineage for B-cell lymphoma; gates rituximab,PMID:9562152
-DLBC,,CD19,biomarker,,,,,B-cell lineage; gates CD19 CAR-T,PMID:29466159
-DLBC,,CD79A,biomarker,,,,,BCR complex component; helps confirm B-cell lineage,PMID:21893720
-DLBC,,CD79B,biomarker,,,,,BCR complex component; polatuzumab target and ABC-subtype marker,PMID:31091374
-DLBC,,BCL6,biomarker,,,,,GCB marker per Hans algorithm,PMID:14504078
-DLBC,,MME,biomarker,,,,,CD10 — GCB marker per Hans algorithm,PMID:14504078
-DLBC,,IRF4,biomarker,,,,,MUM1 — ABC marker per Hans algorithm,PMID:14504078
-DLBC,,MYC,biomarker,,,,,Rearrangement / co-expression marker — double/triple-hit lymphoma,PMID:19917594
-DLBC,,BCL2,biomarker,,,,,Rearrangement / high expression — double/triple-hit; BCL2 inhibitor eligibility,PMID:19917594
-DLBC,,MS4A1,target,rituximab,antibody,approved,DLBCL,Anti-CD20 — backbone of R-CHOP,PMID:12075054
-DLBC,,CD19,target,axicabtagene ciloleucel,CAR-T,approved,R/R DLBCL,Anti-CD19 CAR-T (Yescarta),PMID:29091450
-DLBC,,CD19,target,tisagenlecleucel,CAR-T,approved,R/R DLBCL,Anti-CD19 CAR-T (Kymriah),PMID:30501490
-DLBC,,CD19,target,lisocabtagene maraleucel,CAR-T,approved,R/R DLBCL,Anti-CD19 CAR-T (Breyanzi),PMID:33301694
-DLBC,,CD19,target,loncastuximab tesirine,ADC,approved,R/R DLBCL,Anti-CD19 ADC (Zynlonta),PMID:34123378
-DLBC,,CD19,target,tafasitamab,antibody,approved,R/R DLBCL,Anti-CD19 with lenalidomide,PMID:32654889
-DLBC,,CD79B,target,polatuzumab vedotin,ADC,approved,R/R DLBCL / 1L DLBCL,Anti-CD79B ADC; Pola-R-CHP new frontline standard,PMID:31091374
-DLBC,,CD22,target,inotuzumab ozogamicin,ADC,phase_2,R/R aggressive B-NHL,CD22 ADC extended from ALL to aggressive B-NHL trials,PMID:25605598
-DLBC,,CD20,target,glofitamab,TCE,approved,R/R DLBCL,CD20×CD3 bispecific (Columvi),PMID:36542511
-DLBC,,CD20,target,epcoritamab,TCE,approved,R/R DLBCL,CD20×CD3 bispecific (Epkinly),PMID:37093768
-DLBC,,BCL2,target,venetoclax,small_molecule,phase_2,DLBCL,Active trials in double-hit and ABC DLBCL subtypes,PMID:29523570
-LAML,,CD33,biomarker,,,,,Myeloid lineage — gates gemtuzumab ozogamicin,PMID:21233305
-LAML,,KIT,biomarker,,,,,CD117 — myeloid progenitor marker; D816V mutation in core-binding-factor AML,PMID:16293591
-LAML,,FLT3,biomarker,,,,,ITD / TKD mutations — midostaurin / gilteritinib eligibility,PMID:28644114
-LAML,,NPM1,biomarker,,,,,Exon 12 mutation — favorable prognosis in CN-AML; menin-inhibitor sensitive,PMID:15659725
-LAML,,CEBPA,biomarker,,,,,Biallelic mutation — favorable prognosis,PMID:18489401
-LAML,,IDH1,biomarker,,,,,R132 mutation — ivosidenib eligibility,PMID:29860938
-LAML,,IDH2,biomarker,,,,,R140/R172 mutation — enasidenib eligibility,PMID:28588020
-LAML,,RUNX1,biomarker,,,,,Mutation — adverse prognosis; included in WHO classification,PMID:25082879
-LAML,,TP53,biomarker,,,,,Mutation — adverse prognosis; APR-246 trials,PMID:27959686
-LAML,,DNMT3A,biomarker,,,,,Mutation — adverse prognosis,PMID:21067377
-LAML,,KMT2A,biomarker,,,,,Rearrangement — menin-inhibitor eligibility; adverse prognosis,PMID:37018480
-LAML,,MPO,biomarker,,,,,Myeloid granulocytic lineage confirmation (cytochemistry / IHC),
-LAML,,CD33,target,gemtuzumab ozogamicin,ADC,approved,CD33+ AML,First ADC approved; combined with chemo in newly diagnosed AML,PMID:15178638
-LAML,,FLT3,target,midostaurin,small_molecule,approved,FLT3-mut AML,Type I FLT3 inhibitor — newly diagnosed FLT3-mut AML,PMID:28644114
-LAML,,FLT3,target,gilteritinib,small_molecule,approved,R/R FLT3-mut AML,Type I FLT3 inhibitor — relapsed/refractory setting,PMID:31634902
-LAML,,IDH1,target,ivosidenib,small_molecule,approved,R/R IDH1-mut AML,IDH1 inhibitor; combined with azacitidine in newly diagnosed unfit patients,PMID:29860938
-LAML,,IDH2,target,enasidenib,small_molecule,approved,R/R IDH2-mut AML,IDH2 inhibitor,PMID:28588020
-LAML,,BCL2,target,venetoclax,small_molecule,approved,AML (unfit),Venetoclax+azacitidine/decitabine standard for unfit newly diagnosed AML,PMID:32786187
-LAML,,KMT2A,target,revumenib,small_molecule,approved,R/R KMT2A-rearranged AML,Menin inhibitor approved in KMT2A-rearranged R/R AML,PMID:37018480
-LAML,,NPM1,target,revumenib,small_molecule,phase_2,NPM1-mut AML,Menin inhibitor trials in NPM1-mutant AML,PMID:37018480
-LAML,,CD123,target,tagraxofusp,fusion,approved,BPDCN,CD123-directed; approved for BPDCN (related myeloid malignancy),PMID:30987805
-LAML,apl,PML,biomarker,,,,,PML-RARA fusion partner — pathognomonic for APL (t(15;17)); defines the subtype,PMID:11001887
-LAML,apl,RARA,biomarker,,,,,PML-RARA fusion — ATRA differentiation target; near-universal in APL,PMID:11001887
-LAML,apl,FLT3,biomarker,,,,,ITD co-mutation in 30-40% of APL — hyperleukocytosis risk factor,PMID:18234679
-LAML,apl,RARA,target,tretinoin,small_molecule,approved,APL,All-trans retinoic acid (ATRA) — differentiation therapy; combined with ATO in low-risk APL,PMID:15837627
-LAML,apl,PML,target,arsenic trioxide,small_molecule,approved,APL,ATO targets PML moiety of PML-RARA; ATRA+ATO is chemo-free standard for low-risk APL,PMID:23841729
-UCEC,,MLH1,biomarker,,,,,MMR gene — loss indicates MSI-H / dMMR; gates pembrolizumab / dostarlimab,PMID:26028255
-UCEC,,MSH2,biomarker,,,,,MMR gene — MSI-H / dMMR marker; Lynch syndrome relevance,PMID:26028255
-UCEC,,MSH6,biomarker,,,,,MMR gene — MSI-H / dMMR marker,PMID:26028255
-UCEC,,PMS2,biomarker,,,,,MMR gene — MSI-H / dMMR marker,PMID:26028255
-UCEC,,POLE,biomarker,,,,,Ultramutated TCGA subtype; exceptional IO responders despite MMR-proficient,PMID:23636398
-UCEC,,PTEN,biomarker,,,,,Loss common in endometrioid; prognostic,PMID:23636398
-UCEC,,TP53,biomarker,,,,,Mutation marks serous-like / copy-number-high TCGA subtype; adverse prognosis,PMID:23636398
-UCEC,,PAX8,biomarker,,,,,Müllerian lineage — diagnostic of endometrial / gynaecologic origin,PMID:21577204
-UCEC,,ERBB2,biomarker,,,,,HER2 amplified / overexpressed in serous subtype; gates trastuzumab combos,PMID:29967118
-UCEC,,ARID1A,biomarker,,,,,Loss common in endometrioid and clear-cell subtypes; IO-modifying,PMID:23636398
-UCEC,,CTNNB1,biomarker,,,,,Exon 3 mutation — low-grade endometrioid marker with distinct prognosis,PMID:23636398
-UCEC,,CD274,target,pembrolizumab,antibody,approved,MSI-H / dMMR UCEC,PD-1 blockade — frontline IO for MSI-H / dMMR advanced UCEC,PMID:32834393
-UCEC,,CD274,target,dostarlimab,antibody,approved,MSI-H / dMMR UCEC,PD-1 blockade approved for dMMR endometrial cancer (GARNET),PMID:32941234
-UCEC,,CD274,target,pembrolizumab + lenvatinib,antibody,approved,pMMR UCEC,IO + VEGFR-TKI combination for pMMR advanced endometrial,PMID:32150749
-UCEC,,ERBB2,target,trastuzumab,antibody,phase_3,HER2+ serous UCEC,HER2 combined with chemo in HER2+ serous UCEC,PMID:29967118
-UCEC,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,HER2+/HER2-low UCEC,Enhertu basket activity in HER2-expressing endometrial,PMID:36423325
-STAD,,ERBB2,biomarker,,,,,HER2 amplification — gates trastuzumab-based therapy,PMID:20728210
-STAD,,CLDN18,biomarker,,,,,Claudin-18 isoform 2 expression — gates zolbetuximab,PMID:37256819
-STAD,,MLH1,biomarker,,,,,MSI-H marker; gates checkpoint IO,PMID:25079317
-STAD,,MSH2,biomarker,,,,,MSI-H marker; Lynch syndrome relevance,PMID:25079317
-STAD,,EBER1,biomarker,,,,,EBV-encoded RNA — marks EBV subtype with distinct IO sensitivity,PMID:25079317
-STAD,,CD274,biomarker,,,,,PD-L1 CPS gates first-line IO,PMID:32171126
-STAD,,FGFR2,biomarker,,,,,Amplification in diffuse-type gastric; FGFR inhibitor eligibility,PMID:23674492
-STAD,,MET,biomarker,,,,,Amplification / overexpression; targeted-therapy interest,PMID:28947956
-STAD,,ERBB2,target,trastuzumab,antibody,approved,HER2+ gastric/GEJ,First-line with chemo for HER2+ gastric (ToGA),PMID:20728210
-STAD,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,HER2+ gastric/GEJ,Enhertu approved in HER2-mut / HER2+ gastric post-progression,PMID:32469182
-STAD,,CLDN18,target,zolbetuximab,antibody,approved,CLDN18.2+ HER2- gastric/GEJ,SPOTLIGHT and GLOW trial-led approval for CLDN18.2+ HER2-negative advanced gastric,PMID:37256819
-STAD,,CD274,target,pembrolizumab,antibody,approved,PD-L1+ / MSI-H gastric/GEJ,KEYNOTE-859 — first-line IO combo for PD-L1 CPS ≥1 (≥10 in EU),PMID:37989261
-STAD,,CD274,target,nivolumab,antibody,approved,gastric/GEJ,CheckMate 649 — first-line IO combo,PMID:33891889
-STAD,,VEGFR2,target,ramucirumab,antibody,approved,pretreated gastric/GEJ,Anti-VEGFR2 — second-line combined with paclitaxel,PMID:25240821
-STAD,,FGFR2,target,bemarituzumab,antibody,phase_3,FGFR2b+ gastric,FIGHT trial — FGFR2b-selective antibody,PMID:36089003
-BLCA,,FGFR3,biomarker,,,,,Activating mutations / fusions — erdafitinib eligibility,PMID:31340094
-BLCA,,NECTIN4,biomarker,,,,,Nectin-4 expression — gates enfortumab vedotin,PMID:30423390
-BLCA,,TACSTD2,biomarker,,,,,Trop-2 expression — gates sacituzumab govitecan,PMID:33882206
-BLCA,,CD274,biomarker,,,,,PD-L1 — gates first-line IO (CPS-aware),PMID:29268932
-BLCA,,ERBB2,biomarker,,,,,HER2 amplification subset — trastuzumab combos / ADCs,PMID:35665782
-BLCA,,FOXA1,biomarker,,,,,Luminal-subtype marker (BASE47 / consensus classifiers),PMID:28988769
-BLCA,,UPK2,biomarker,,,,,Uroplakin II — urothelial lineage confirmation,PMID:9890150
-BLCA,,GATA3,biomarker,,,,,Luminal urothelial lineage marker,PMID:28988769
-BLCA,,KRT5,biomarker,,,,,Basal-subtype marker,PMID:28988769
-BLCA,,FGFR3,target,erdafitinib,small_molecule,approved,FGFR3-altered advanced urothelial,FGFR1-4 inhibitor — second-line post platinum + IO (THOR),PMID:37870969
-BLCA,,NECTIN4,target,enfortumab vedotin,ADC,approved,advanced urothelial,Padcev — first-line combined with pembrolizumab (EV-302) and monotherapy in subsequent lines,PMID:38076652
-BLCA,,TACSTD2,target,sacituzumab govitecan,ADC,approved,advanced urothelial,Trodelvy — second-line post platinum/IO,PMID:33882206
-BLCA,,CD274,target,pembrolizumab,antibody,approved,advanced urothelial,First-line with EV (EV-302) and monotherapy for cisplatin-ineligible PD-L1+,PMID:38076652
-BLCA,,CD274,target,atezolizumab,antibody,approved,advanced urothelial,Anti-PD-L1; earlier approvals since narrowed,PMID:28212060
-BLCA,,CD274,target,avelumab,antibody,approved,advanced urothelial,Maintenance IO after platinum response (JAVELIN Bladder 100),PMID:32945632
-BLCA,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,HER2+ urothelial,Enhertu basket activity in HER2-expressing urothelial,PMID:36423325
-KIRC,,KDR,biomarker,,,,,VEGFR2 — target of TKI backbone in RCC,PMID:17215530
-KIRC,,FLT1,biomarker,,,,,VEGFR1 — VEGF pathway marker,
-KIRC,,MET,biomarker,,,,,MET overexpression / amplification — cabozantinib activity,PMID:26406150
-KIRC,,AXL,biomarker,,,,,Cabozantinib target; linked to VEGFR-TKI resistance,PMID:26406150
-KIRC,,CD274,biomarker,,,,,PD-L1 enriched in sarcomatoid; prognostic for IO response,PMID:25399552
-KIRC,,PBRM1,biomarker,,,,,Loss common in ccRCC; candidate IO-response biomarker,PMID:29301960
-KIRC,,BAP1,biomarker,,,,,Loss — adverse prognosis; differential biology,PMID:22683710
-KIRC,,VHL,biomarker,,,,,Inactivation drives HIF axis; universal in sporadic ccRCC,PMID:22683710
-KIRC,,HIF1A,biomarker,,,,,HIF axis activation marker downstream of VHL loss,
-KIRC,,CA9,biomarker,,,,,CAIX — HIF-driven surface marker; diagnostic and theranostic target,PMID:18483390
-KIRC,,PAX8,biomarker,,,,,Kidney epithelial lineage — diagnostic in difficult cases,PMID:21577204
-KIRC,,KDR,target,sunitinib,small_molecule,approved,advanced RCC,Multikinase TKI — historic first-line backbone,PMID:17215530
-KIRC,,KDR,target,pazopanib,small_molecule,approved,advanced RCC,Multikinase TKI,PMID:20100962
-KIRC,,KDR,target,cabozantinib,small_molecule,approved,advanced RCC,MET/VEGFR/AXL multi-TKI — monotherapy and combined with IO,PMID:26406150
-KIRC,,KDR,target,axitinib,small_molecule,approved,advanced RCC,VEGFR inhibitor — combined with pembrolizumab or avelumab in first-line,PMID:30779529
-KIRC,,KDR,target,lenvatinib,small_molecule,approved,advanced RCC,VEGFR multi-TKI — with pembrolizumab (CLEAR) in first-line,PMID:33616314
-KIRC,,CD274,target,pembrolizumab,antibody,approved,advanced RCC,Anti-PD-1 — first-line combined with axitinib or lenvatinib,PMID:30779529
-KIRC,,CD274,target,nivolumab + ipilimumab,antibody,approved,intermediate/poor-risk RCC,IO-IO combination (CheckMate 214),PMID:29562145
-KIRC,,CD274,target,avelumab + axitinib,antibody,approved,advanced RCC,Anti-PD-L1 + VEGFR-TKI combination,PMID:30779531
-KIRC,,HIF2A,target,belzutifan,small_molecule,approved,VHL-associated RCC / advanced ccRCC,HIF-2α inhibitor — approved for VHL syndrome and post-IO/TKI ccRCC,PMID:34597551
-KIRC,,CA9,target,girentuximab,antibody,phase_3,non-metastatic ccRCC,"CAIX antibody — ZIRCON imaging approved; ARISER, adjuvant trials",PMID:24100620
-CESC,,CDKN2A,biomarker,,,,,p16 — surrogate marker for HPV-driven cervical / head-and-neck,PMID:12649158
-CESC,,CD274,biomarker,,,,,PD-L1 CPS — gates first-line pembrolizumab,PMID:32795402
-CESC,,F3,biomarker,,,,,Tissue factor expression — gates tisotumab vedotin,PMID:32882178
-CESC,,MUC16,biomarker,,,,,Elevated in adenocarcinoma subset; emerging target,
-CESC,,CD274,target,pembrolizumab,antibody,approved,recurrent/metastatic CESC,Anti-PD-1 — first-line with chemo (KEYNOTE-826),PMID:34534429
-CESC,,CD274,target,cemiplimab,antibody,approved,recurrent/metastatic CESC,Anti-PD-1 — post-progression (EMPOWER-Cervical 1),PMID:35179851
-CESC,,F3,target,tisotumab vedotin,ADC,approved,recurrent/metastatic CESC,Tivdak — tissue-factor ADC,PMID:33497583
-CESC,,CD274,target,nivolumab,antibody,phase_3,recurrent/metastatic CESC,Anti-PD-1 — CheckMate 358 activity,PMID:31116649
-ESCA,,ERBB2,biomarker,,,,,HER2 amplification in adenocarcinoma — trastuzumab eligibility,PMID:20728210
-ESCA,,CD274,biomarker,,,,,PD-L1 CPS — first-line IO,PMID:32178703
-ESCA,,MLH1,biomarker,,,,,MSI-H marker — uncommon but eligible for IO,
-ESCA,,TP53,biomarker,,,,,Mutation common; prognostic,PMID:28052061
-ESCA,,CLDN18,biomarker,,,,,CLDN18.2 expression in GEJ / lower-esophageal adeno,PMID:37256819
-ESCA,,FGFR2,biomarker,,,,,Amplification subset; FGFR-inhibitor eligibility,PMID:23674492
-ESCA,,ERBB2,target,trastuzumab,antibody,approved,HER2+ GEJ/esophageal,First-line with chemo (ToGA extension),PMID:20728210
-ESCA,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,HER2+ GEJ/esophageal,Enhertu in HER2-mut / HER2+ esophagogastric post-progression,PMID:32469182
-ESCA,,CD274,target,nivolumab,antibody,approved,advanced esophageal/GEJ,First-line IO combination (CheckMate 648 / 649),PMID:33891889
-ESCA,,CD274,target,pembrolizumab,antibody,approved,advanced esophageal squamous / adeno,First-line with chemo (KEYNOTE-590),PMID:34454674
-ESCA,,CLDN18,target,zolbetuximab,antibody,approved,CLDN18.2+ HER2- GEJ,SPOTLIGHT / GLOW — CLDN18.2+ HER2-negative advanced gastric/GEJ,PMID:37256819
-PAAD,,KRAS,biomarker,,,,,Activating mutations near universal (G12D most common); predictive and stratifying,PMID:20644561
-PAAD,,BRCA1,biomarker,,,,,Germline mutation — olaparib maintenance eligibility,PMID:31157963
-PAAD,,BRCA2,biomarker,,,,,Germline mutation — olaparib maintenance eligibility,PMID:31157963
-PAAD,,PALB2,biomarker,,,,,HRD gene; emerging PARP inhibitor trials,PMID:33293427
-PAAD,,TP53,biomarker,,,,,Mutation common; prognostic and co-occurring with KRAS,PMID:25079552
-PAAD,,CDKN2A,biomarker,,,,,Frequent loss; potential synthetic-lethal approaches,PMID:25079552
-PAAD,,SMAD4,biomarker,,,,,Loss associated with metastatic phenotype / adverse prognosis,PMID:25079552
-PAAD,,CLDN18,biomarker,,,,,CLDN18.2 expression subset — emerging target for zolbetuximab / ADCs,PMID:37256819
-PAAD,,NRG1,biomarker,,,,,NRG1 fusion — actionable subset with zenocutuzumab,PMID:34521628
-PAAD,,KRT19,biomarker,,,,,Pancreatic ductal adenocarcinoma lineage marker,PMID:18239683
-PAAD,,PDX1,biomarker,,,,,Pancreatic lineage transcription factor,
-PAAD,,BRCA1,target,olaparib,small_molecule,approved,gBRCA-mut metastatic PAAD,PARP inhibitor maintenance after platinum response (POLO),PMID:31157963
-PAAD,,NRG1,target,zenocutuzumab,antibody,approved,NRG1-fusion PAAD and NSCLC,Bispecific HER2/HER3 in NRG1-fusion tumours,PMID:34521628
-PAAD,,KRAS,target,adagrasib,small_molecule,phase_2,KRAS G12C PAAD,KRAS G12C inhibitor — basket activity,PMID:35658005
-PAAD,,KRAS,target,sotorasib,small_molecule,phase_2,KRAS G12C PAAD,KRAS G12C inhibitor — basket activity,PMID:34252278
-PAAD,,KRAS,target,MRTX1133,small_molecule,phase_1,KRAS G12D PAAD,Selective KRAS G12D inhibitor in early clinical development,PMID:36446367
-PAAD,,CLDN18,target,zolbetuximab,antibody,phase_2,CLDN18.2+ PAAD,CLDN18.2 antibody extending from gastric into PAAD trials,
-PAAD,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,HER2+ PAAD,Enhertu basket activity in HER2-expressing PAAD,PMID:36423325
-LIHC,,AFP,biomarker,,,,,Alpha-fetoprotein — diagnostic and prognostic serum marker,PMID:14985538
-LIHC,,GPC3,biomarker,,,,,Glypican-3 — HCC-enriched surface antigen; diagnostic and target,PMID:14985538
-LIHC,,CTNNB1,biomarker,,,,,Activating exon 3 mutations common; β-catenin-active subtype,PMID:28187286
-LIHC,,TERT,biomarker,,,,,Promoter mutation — the most frequent somatic alteration in HCC,PMID:24753553
-LIHC,,TP53,biomarker,,,,,Mutation marks HBV-associated and more aggressive disease,PMID:28187286
-LIHC,,AXIN1,biomarker,,,,,Wnt pathway alteration — subset of HCC,PMID:28187286
-LIHC,,FGF19,biomarker,,,,,11q13 amplification with CCND1 — FGFR4 pathway,PMID:24474064
-LIHC,,VEGFA,biomarker,,,,,Elevated in HCC; rationale for VEGF-axis therapy,
-LIHC,,MET,biomarker,,,,,Overexpression subset; tivantinib / cabozantinib interest,PMID:26436913
-LIHC,,CD274,biomarker,,,,,PD-L1 prognostic in some cohorts; role in IO response,PMID:32185388
-LIHC,,CD274,target,atezolizumab + bevacizumab,antibody,approved,advanced HCC,First-line IO + VEGF (IMbrave150),PMID:32402160
-LIHC,,CD274,target,durvalumab + tremelimumab,antibody,approved,advanced HCC,STRIDE regimen — PD-L1 + CTLA-4 (HIMALAYA),PMID:36198093
-LIHC,,KDR,target,sorafenib,small_molecule,approved,advanced HCC,Historic first-line multikinase TKI,PMID:18650514
-LIHC,,KDR,target,lenvatinib,small_molecule,approved,advanced HCC,First-line multikinase TKI (REFLECT),PMID:29433850
-LIHC,,MET,target,cabozantinib,small_molecule,approved,advanced HCC (2L),Multikinase TKI — second-line post sorafenib (CELESTIAL),PMID:29972759
-LIHC,,KDR,target,regorafenib,small_molecule,approved,advanced HCC (2L),Multikinase TKI — post-sorafenib,PMID:27932229
-LIHC,,VEGFR2,target,ramucirumab,antibody,approved,AFP+ advanced HCC (2L),Anti-VEGFR2 for AFP ≥ 400 (REACH-2),PMID:30665869
-LIHC,,GPC3,target,codrituzumab,antibody,phase_2,GPC3+ HCC,Glypican-3 antibody — earlier trials; active ADC / CAR-T programmes,PMID:28698288
-LIHC,,FGF19,target,fisogatinib,small_molecule,phase_1,FGF19+ HCC,FGFR4-selective inhibitor for FGF19-amplified HCC,PMID:31694886
-SARC,leiomyosarcoma,ACTA2,biomarker,,,,,Smooth-muscle actin — lineage marker for LMS,PMID:23954400
-SARC,leiomyosarcoma,CALD1,biomarker,,,,,Caldesmon (h-caldesmon) — smooth-muscle lineage confirmation in LMS,PMID:23954400
-SARC,leiomyosarcoma,MYH11,biomarker,,,,,Smooth-muscle myosin heavy chain — LMS lineage,PMID:23954400
-SARC,leiomyosarcoma,DES,biomarker,,,,,Desmin — confirms smooth-muscle / striated-muscle lineage,PMID:23954400
-SARC,leiomyosarcoma,CDKN2A,biomarker,,,,,Frequent loss in LMS; prognostic,PMID:23954400
-SARC,leiomyosarcoma,TP53,biomarker,,,,,High somatic mutation rate in LMS; adverse prognosis,PMID:23954400
-SARC,leiomyosarcoma,RB1,biomarker,,,,,Frequent inactivation in LMS,PMID:23954400
-SARC,leiomyosarcoma,,target,trabectedin,small_molecule,approved,advanced LMS,Alkylating agent — approved for L-sarcomas (LMS/liposarcoma) after anthracycline,PMID:26967202
-SARC,leiomyosarcoma,,target,pazopanib,small_molecule,approved,advanced non-adipocytic STS,Multikinase TKI — PALETTE trial; includes LMS,PMID:22595799
-SARC,leiomyosarcoma,,target,doxorubicin,small_molecule,approved,first-line STS,Anthracycline — backbone cytotoxic,PMID:22595799
-SARC,dedifferentiated_liposarcoma,MDM2,biomarker,,,,,Ring-chromosome 12q amplification with MDM2 — pathognomonic for WDLPS/DDLPS,PMID:20181787
-SARC,dedifferentiated_liposarcoma,CDK4,biomarker,,,,,Co-amplified with MDM2 on 12q13-15 — gates CDK4/6-inhibitor eligibility,PMID:20181787
-SARC,dedifferentiated_liposarcoma,HMGA2,biomarker,,,,,12q amplicon — lipogenic-lineage marker in WDLPS/DDLPS,PMID:20181787
-SARC,dedifferentiated_liposarcoma,FRS2,biomarker,,,,,12q co-amplification; FGFR-pathway adapter,PMID:20181787
-SARC,dedifferentiated_liposarcoma,TP53,biomarker,,,,,More common in DDLPS than WDLPS — adverse prognosis,PMID:20181787
-SARC,dedifferentiated_liposarcoma,MDM2,target,brigimadlin (BI 907828),small_molecule,phase_3,MDM2-amplified DDLPS,MDM2-p53 antagonist — Brightline-1 phase 3 trial,PMID:37467370
-SARC,dedifferentiated_liposarcoma,MDM2,target,milademetan,small_molecule,phase_3,MDM2-amplified DDLPS,MDM2-p53 antagonist — MANTRA phase 3 (failed primary) with ongoing combination exploration,PMID:37467370
-SARC,dedifferentiated_liposarcoma,CDK4,target,palbociclib,small_molecule,phase_2,CDK4-amplified WDLPS/DDLPS,CDK4/6 inhibitor — encouraging phase 2 results in WDLPS/DDLPS,PMID:26948088
-SARC,dedifferentiated_liposarcoma,CDK4,target,abemaciclib,small_molecule,phase_2,CDK4-amplified WDLPS/DDLPS,CDK4/6 inhibitor — SARC041 and other phase 2 studies,PMID:31924739
-SARC,dedifferentiated_liposarcoma,,target,trabectedin,small_molecule,approved,advanced liposarcoma,Approved L-sarcoma indication — includes myxoid and DDLPS,PMID:26967202
-SARC,myxoid_liposarcoma,DDIT3,biomarker,,,,,FUS-DDIT3 (formerly FUS-CHOP) fusion — pathognomonic for MRCLS,PMID:20181787
-SARC,myxoid_liposarcoma,MAGE-A4,biomarker,,,,,Expressed in ~40% of MRCLS — gates afami-cel / MAGE-A4 TCR-T eligibility,PMID:39141605
-SARC,myxoid_liposarcoma,CTAG1B,biomarker,,,,,NY-ESO-1 — expressed in majority of MRCLS; TCR-T target,PMID:25668005
-SARC,myxoid_liposarcoma,PRAME,biomarker,,,,,CT antigen expressed in MRCLS; TCR-T / ADC target,PMID:34428009
-SARC,myxoid_liposarcoma,PPARG,biomarker,,,,,Adipogenic master regulator; lineage confirmation,PMID:20181787
-SARC,myxoid_liposarcoma,MAGE-A4,target,afami-cel (afamitresgene autoleucel),TCR-T,phase_2,HLA-A*02+ MAGE-A4+ MRCLS,First-in-class engineered TCR-T — approved in synovial sarcoma; MRCLS cohorts in basket trials,PMID:39141605
-SARC,myxoid_liposarcoma,CTAG1B,target,letetresgene autoleucel,TCR-T,phase_2,HLA-A*02+ NY-ESO-1+ MRCLS,NY-ESO-1 TCR-T — phase 2 in synovial / MRCLS,PMID:25668005
-SARC,myxoid_liposarcoma,,target,trabectedin,small_molecule,approved,advanced MRCLS,Approved L-sarcoma indication — particularly active in MRCLS,PMID:26967202
-SARC,synovial_sarcoma,SS18,biomarker,,,,,SS18-SSX1/2/4 fusion (typically t(X;18)) — pathognomonic for synovial sarcoma,PMID:23583762
-SARC,synovial_sarcoma,MAGE-A4,biomarker,,,,,Expressed in majority of synovial sarcoma — gates afami-cel eligibility,PMID:39141605
-SARC,synovial_sarcoma,CTAG1B,biomarker,,,,,NY-ESO-1 — widely expressed; lete-cel target,PMID:25668005
-SARC,synovial_sarcoma,PRAME,biomarker,,,,,Broadly expressed CT antigen; candidate TCR-T target,PMID:34428009
-SARC,synovial_sarcoma,TLE1,biomarker,,,,,Diagnostic IHC marker — near-universal nuclear staining in synovial sarcoma,PMID:17255762
-SARC,synovial_sarcoma,BCL2,biomarker,,,,,Broadly overexpressed — candidate for BCL2-targeted therapy trials,PMID:11297487
-SARC,synovial_sarcoma,MAGE-A4,target,afami-cel (Tecelra),TCR-T,approved,HLA-A*02+ MAGE-A4+ advanced synovial sarcoma,First engineered TCR-T approved by FDA (2024) — SPEARHEAD-1 trial,PMID:39141605
-SARC,synovial_sarcoma,CTAG1B,target,letetresgene autoleucel (lete-cel),TCR-T,phase_2,HLA-A*02+ NY-ESO-1+ synovial sarcoma,NY-ESO-1 TCR-T — pivotal phase 2,PMID:38458182
-SARC,synovial_sarcoma,,target,pazopanib,small_molecule,approved,advanced non-adipocytic STS,Multikinase TKI — PALETTE trial; synovial sarcoma included,PMID:22595799
-SARC,synovial_sarcoma,,target,trabectedin,small_molecule,phase_3,advanced synovial sarcoma,Alkylating agent — activity documented in synovial sarcoma subgroups,PMID:26967202
-SARC,dsrct,EWSR1,biomarker,,,,,EWSR1-WT1 t(11;22)(p13;q12) fusion — pathognomonic for desmoplastic small round cell tumor,PMID:11559696
-SARC,dsrct,WT1,biomarker,,,,,C-terminal WT1 IHC — positive due to the EWSR1-WT1 fusion; diagnostic,PMID:11559696
-SARC,dsrct,DES,biomarker,,,,,Dot-like desmin IHC — characteristic DSRCT pattern,PMID:11559696
-SARC,dsrct,VIM,biomarker,,,,,Vimentin positivity alongside keratin — DSRCT polyphenotypic pattern,PMID:11559696
-SARC,dsrct,WT1,target,,TCR-T,phase_1,WT1+ DSRCT,WT1-directed TCR-T and peptide vaccines in early trials,PMID:35379757
-SARC,gist,KIT,biomarker,,,,,CD117 — activating mutation in majority of GIST; gates imatinib / sunitinib / avapritinib eligibility,PMID:12522257
-SARC,gist,PDGFRA,biomarker,,,,,Imatinib-sensitive mutations (e.g. V561D); D842V requires avapritinib,PMID:12522257
-SARC,gist,SDHB,biomarker,,,,,Loss identifies SDH-deficient (WT) GIST — paediatric/young adult subtype with different biology,PMID:21252315
-SARC,gist,SDHA,biomarker,,,,,Alternate SDH complex loss — similar SDH-deficient biology,PMID:21252315
-SARC,gist,BRAF,biomarker,,,,,V600E in wild-type GIST — BRAF-inhibitor candidate,PMID:23054102
-SARC,gist,NF1,biomarker,,,,,NF1 inactivation in wild-type GIST,PMID:23054102
-SARC,gist,KIT,target,imatinib,small_molecule,approved,unresectable/metastatic GIST,First-line KIT/PDGFRA inhibitor — standard of care,PMID:12181401
-SARC,gist,KIT,target,sunitinib,small_molecule,approved,imatinib-resistant GIST,Multikinase — second-line after imatinib failure,PMID:17046465
-SARC,gist,KIT,target,regorafenib,small_molecule,approved,third-line GIST,Multikinase — post-imatinib/sunitinib failure,PMID:23177515
-SARC,gist,KIT,target,ripretinib,small_molecule,approved,fourth-line GIST,Switch-control KIT/PDGFRA inhibitor — INVICTUS trial,PMID:32511981
-SARC,gist,PDGFRA,target,avapritinib,small_molecule,approved,PDGFRA D842V GIST,Selective PDGFRA D842V inhibitor — NAVIGATOR trial,PMID:32078923
-SARC,gist,NTRK1,target,larotrectinib,small_molecule,approved,NTRK-fusion GIST,Tumor-agnostic NTRK inhibitor — relevant to NTRK-fusion WT GIST,PMID:29466156
-SARC,ewing_sarcoma,EWSR1,biomarker,,,,,EWSR1-FLI1 t(11;22) fusion (~85%) or EWSR1-ERG — pathognomonic for Ewing sarcoma,PMID:20142596
-SARC,ewing_sarcoma,FLI1,biomarker,,,,,Fusion partner — IHC positive in Ewing,PMID:20142596
-SARC,ewing_sarcoma,NKX2-2,biomarker,,,,,Downstream EWSR1-FLI1 target; lineage marker,PMID:21339729
-SARC,ewing_sarcoma,CD99,biomarker,,,,,Membranous CD99 staining — sensitive but not specific Ewing IHC,PMID:20142596
-SARC,ewing_sarcoma,CAV1,biomarker,,,,,Caveolin-1 — marker of Ewing differentiation,PMID:21339729
-SARC,ewing_sarcoma,PRAME,biomarker,,,,,CT antigen expressed in Ewing; TCR-T target,PMID:34428009
-SARC,ewing_sarcoma,,target,trabectedin,small_molecule,phase_2,relapsed Ewing,Alkylating agent — active in Ewing per single-agent and combo trials,PMID:26967202
-SARC,ewing_sarcoma,CDK4,target,palbociclib,small_molecule,phase_2,relapsed Ewing,CDK4/6 inhibitor — ongoing phase 2,PMID:31924739
-SARC,ewing_sarcoma,,target,TK216,small_molecule,phase_1,relapsed Ewing,Small-molecule ETV fusion inhibitor — first-in-class trial,PMID:33872428
-SARC,ewing_sarcoma,PRAME,target,IMA203,TCR-T,phase_2,PRAME+ HLA-A*02+ Ewing,PRAME-directed TCR-T — basket phase 2 including Ewing,PMID:34428009
-THCA,,BRAF,biomarker,,,,,V600E — most common mutation in papillary thyroid carcinoma (~50%); drives RAI resistance,PMID:24557579
-THCA,,RET,biomarker,,,,,RET fusions (CCDC6-RET etc.) in PTC — selpercatinib / pralsetinib eligibility,PMID:32273263
-THCA,,HRAS,biomarker,,,,,RAS-family mutation (H/N/KRAS Q61) — prevalent in follicular thyroid cancer,PMID:24557579
-THCA,,NRAS,biomarker,,,,,Most common RAS mutation in FTC; defines follicular subtype,PMID:24557579
-THCA,,NTRK1,biomarker,,,,,NTRK fusion — rare; larotrectinib / entrectinib eligibility,PMID:29466156
-THCA,,TERT,biomarker,,,,,Promoter mutation — adverse prognosis; common in anaplastic / poorly-differentiated,PMID:24035356
-THCA,,TG,biomarker,,,,,Thyroglobulin — lineage confirmation and serum recurrence marker,PMID:24557579
-THCA,,NKX2-1,biomarker,,,,,TTF-1 — thyroid lineage (also lung),PMID:24557579
-THCA,,PAX8,biomarker,,,,,Thyroid / gynecologic lineage,PMID:21577204
-THCA,,TP53,biomarker,,,,,Mutation in anaplastic thyroid carcinoma — adverse prognosis,PMID:24557579
-THCA,,KDR,target,lenvatinib,small_molecule,approved,RAI-refractory DTC,VEGFR multi-TKI — SELECT trial,PMID:25671254
-THCA,,KDR,target,sorafenib,small_molecule,approved,RAI-refractory DTC,VEGFR multi-TKI — DECISION trial,PMID:24768112
-THCA,,KDR,target,cabozantinib,small_molecule,approved,RAI-refractory DTC (2L),Multikinase TKI — COSMIC-311 trial,PMID:33798485
-THCA,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600E anaplastic thyroid,BRAF/MEK combination — tumor-agnostic plus specific ATC approval,PMID:30161798
-THCA,,RET,target,selpercatinib,small_molecule,approved,RET-altered thyroid cancer,Selective RET inhibitor — approved for medullary + RET-fusion DTC,PMID:32846060
-THCA,,RET,target,pralsetinib,small_molecule,approved,RET-altered thyroid cancer,Selective RET inhibitor,PMID:32615108
-THCA,,NTRK1,target,larotrectinib,small_molecule,approved,NTRK-fusion thyroid cancer,Tumor-agnostic NTRK inhibitor,PMID:29466156
-LGG,,IDH1,biomarker,,,,,R132H mutation — majority of adult LGG; defines IDH-mutant class; gates vorasidenib eligibility,PMID:37272516
-LGG,,IDH2,biomarker,,,,,R172 mutation — less common than IDH1; also targeted by vorasidenib,PMID:37272516
-LGG,,ATRX,biomarker,,,,,Loss — astrocytoma lineage marker (combined with IDH-mutant and 1p/19q retained),PMID:24105470
-LGG,,CDKN2A,biomarker,,,,,Homozygous deletion — adverse prognosis in IDH-mutant astrocytoma; grade 4 criterion,PMID:34185076
-LGG,,TERT,biomarker,,,,,Promoter mutation — common in oligodendroglioma and GBM; diagnostic,PMID:24327574
-LGG,,MGMT,biomarker,,,,,Promoter methylation — temozolomide response predictor,PMID:15758009
-LGG,,TP53,biomarker,,,,,Mutation — astrocytoma lineage (excluded in oligodendroglioma),PMID:24105470
-LGG,,BRAF,biomarker,,,,,V600E — pediatric LGG / pilocytic astrocytoma; dabrafenib+trametinib eligibility,PMID:32818466
-LGG,,IDH1,target,vorasidenib,small_molecule,approved,IDH-mutant residual/recurrent grade 2 LGG,Dual IDH1/2 inhibitor — INDIGO trial (2024 approval),PMID:37272516
-LGG,,IDH2,target,vorasidenib,small_molecule,approved,IDH-mutant residual/recurrent grade 2 LGG,Dual IDH1/2 inhibitor — same drug covers both,PMID:37272516
-LGG,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600E pediatric glioma,Tumor-agnostic plus pediatric LGG-specific approval,PMID:32818466
-LGG,,MGMT,target,temozolomide,small_molecule,approved,MGMT-methylated glioma,Alkylating chemo — efficacy tied to MGMT promoter methylation,PMID:15758009
-GBM,,IDH1,biomarker,,,,,Wild-type defines GBM per 2021 WHO; IDH-mutant is now classified as astrocytoma,PMID:34185076
-GBM,,MGMT,biomarker,,,,,Promoter methylation — temozolomide response predictor; ~40% of GBM,PMID:15758009
-GBM,,EGFR,biomarker,,,,,Amplification in ~40% of GBM; EGFRvIII variant in ~30% of amplified cases,PMID:24060863
-GBM,,PTEN,biomarker,,,,,Loss — common; adverse prognosis; PI3K-pathway activation,PMID:24060863
-GBM,,CDKN2A,biomarker,,,,,Deletion — very common; grade 4 criterion in IDH-mutant astrocytoma,PMID:34185076
-GBM,,TP53,biomarker,,,,,Mutation — more common in secondary GBM from astrocytoma,PMID:24060863
-GBM,,TERT,biomarker,,,,,Promoter mutation — near-universal in IDH-wildtype GBM,PMID:24327574
-GBM,,NF1,biomarker,,,,,Loss — mesenchymal subtype association,PMID:24060863
-GBM,,H3F3A,biomarker,,,,,K27M or G34R/V mutation — paediatric / diffuse midline glioma; grade-defining,PMID:22286061
-GBM,,MGMT,target,temozolomide,small_molecule,approved,MGMT-methylated GBM,Alkylating chemo — standard of care with radiation (Stupp protocol),PMID:15758009
-GBM,,KDR,target,bevacizumab,antibody,approved,recurrent GBM,Anti-VEGF — approved for recurrent disease,PMID:19114704
-GBM,,EGFR,target,depatuxizumab mafodotin,ADC,phase_3,EGFR-amplified GBM,Anti-EGFR ADC — INTELLANCE trials (mixed results),PMID:33253437
-CHOL,,FGFR2,biomarker,,,,,Fusions and rearrangements in ~15% of intrahepatic cholangiocarcinoma; gate FGFR-inhibitor eligibility,PMID:32655039
-CHOL,,IDH1,biomarker,,,,,Mutation in ~20% of intrahepatic cholangiocarcinoma; ivosidenib eligibility,PMID:32474412
-CHOL,,BRCA1,biomarker,,,,,Germline/somatic mutation — PARP inhibitor basket eligibility,PMID:30975651
-CHOL,,BRCA2,biomarker,,,,,Germline/somatic mutation — PARP inhibitor basket eligibility,PMID:30975651
-CHOL,,BAP1,biomarker,,,,,Loss — cholangiocarcinoma subtype with distinct biology; mesothelioma overlap,PMID:24035356
-CHOL,,ARID1A,biomarker,,,,,Loss — chromatin-remodeling alteration common in cholangiocarcinoma,PMID:24035356
-CHOL,,TP53,biomarker,,,,,Mutation — adverse prognosis,PMID:24035356
-CHOL,,KRAS,biomarker,,,,,Mutation — extrahepatic cholangiocarcinoma; chemoresistance marker,PMID:24035356
-CHOL,,ERBB2,biomarker,,,,,Amplification — HER2-targeted therapy basket eligibility,PMID:31843955
-CHOL,,MLH1,biomarker,,,,,MMR — MSI-H cholangiocarcinoma for pembrolizumab,PMID:26028255
-CHOL,,NTRK1,biomarker,,,,,Rare NTRK fusion — larotrectinib eligibility (tumor-agnostic),PMID:29466156
-CHOL,,FGFR2,target,pemigatinib,small_molecule,approved,FGFR2-fusion cholangiocarcinoma,Selective FGFR1-3 inhibitor — FIGHT-202 trial,PMID:32268924
-CHOL,,FGFR2,target,infigratinib,small_molecule,approved,FGFR2-fusion cholangiocarcinoma,Selective FGFR inhibitor,PMID:33570312
-CHOL,,FGFR2,target,futibatinib,small_molecule,approved,FGFR2-fusion cholangiocarcinoma,Irreversible FGFR inhibitor — FOENIX-CCA2 trial,PMID:37186853
-CHOL,,IDH1,target,ivosidenib,small_molecule,approved,IDH1-mutant cholangiocarcinoma,IDH1 inhibitor — ClarIDHy trial,PMID:32474412
-CHOL,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,BRAF V600E cholangiocarcinoma,Tumor-agnostic BRAF/MEK,PMID:32818466
-CHOL,,ERBB2,target,trastuzumab + pertuzumab,antibody,phase_2,HER2-amplified cholangiocarcinoma,HER2-targeted antibody combo — MyPathway basket,PMID:31843955
-CHOL,,NTRK1,target,larotrectinib,small_molecule,approved,NTRK-fusion cholangiocarcinoma,Tumor-agnostic NTRK inhibitor,PMID:29466156
-CHOL,,CD274,target,pembrolizumab,antibody,approved,MSI-H / dMMR cholangiocarcinoma,Tumor-agnostic checkpoint IO,PMID:32914748
-OV,,BRCA1,biomarker,,,,,Germline/somatic mutation — PARP inhibitor maintenance eligibility; 20-25% of HGSOC,PMID:22452356
-OV,,BRCA2,biomarker,,,,,Germline/somatic mutation — PARP inhibitor maintenance eligibility,PMID:22452356
-OV,,PALB2,biomarker,,,,,HR-pathway gene — PARP basket eligibility,PMID:33293427
-OV,,RAD51C,biomarker,,,,,HR-pathway gene — PARP basket eligibility; alongside RAD51D,PMID:33293427
-OV,,RAD51D,biomarker,,,,,HR-pathway gene — PARP basket eligibility,PMID:33293427
-OV,,TP53,biomarker,,,,,Mutation — near-universal in HGSOC; defines high-grade serous vs low-grade serous,PMID:22452356
-OV,,PAX8,biomarker,,,,,Müllerian lineage — diagnostic for gynaecologic origin,PMID:21577204
-OV,,WT1,biomarker,,,,,Serous lineage — IHC marker; distinguishes HGSOC from endometrioid ovarian,PMID:22452356
-OV,,FOLR1,biomarker,,,,,Folate receptor alpha — mirvetuximab soravtansine eligibility (FRα-high platinum-resistant),PMID:37094291
-OV,,CD274,biomarker,,,,,PD-L1 — MSI-H / dMMR subset for checkpoint IO,PMID:32914748
-OV,,BRCA1,target,olaparib,small_molecule,approved,BRCA-mut HGSOC,First PARP inhibitor approved — maintenance after platinum response (SOLO-1),PMID:30145076
-OV,,BRCA2,target,olaparib,small_molecule,approved,BRCA-mut HGSOC,PARP inhibitor maintenance — extends PFS dramatically,PMID:30145076
-OV,,BRCA1,target,niraparib,small_molecule,approved,HGSOC maintenance,PARP inhibitor — broader maintenance indication (BRCA-mut and BRCA-wt),PMID:28678572
-OV,,BRCA1,target,rucaparib,small_molecule,approved,BRCA-mut HGSOC,PARP inhibitor,PMID:27908594
-OV,,FOLR1,target,mirvetuximab soravtansine (Elahere),ADC,approved,FRα-high platinum-resistant HGSOC,FRα-directed ADC — first-in-class,PMID:37094291
-OV,,KDR,target,bevacizumab,antibody,approved,HGSOC maintenance / recurrence,Anti-VEGF — approved with chemo and as maintenance,PMID:22183408
-OV,,CD274,target,pembrolizumab,antibody,approved,MSI-H / dMMR OV,Tumor-agnostic checkpoint IO for MSI-H subset,PMID:32914748
-TGCT,,KIT,biomarker,,,,,Seminoma-restricted expression; CD117 IHC diagnostic,PMID:15765456
-TGCT,,AFP,biomarker,,,,,Alpha-fetoprotein — serum marker for non-seminomatous germ cell tumors,PMID:9870293
-TGCT,,CGB1,biomarker,,,,,beta-hCG — serum marker for choriocarcinoma / non-seminoma,PMID:9870293
-TGCT,,POU5F1,biomarker,,,,,OCT4 — embryonal/seminoma stem-cell lineage marker,PMID:15765456
-TGCT,,NANOG,biomarker,,,,,Pluripotency factor — germ cell / seminoma lineage,PMID:15765456
-TGCT,,SOX2,biomarker,,,,,Embryonal carcinoma lineage marker,PMID:15765456
-TGCT,,SALL4,biomarker,,,,,Stem-cell factor — diagnostic IHC for germ cell tumors,PMID:21765467
-TGCT,,LDHA,biomarker,,,,,Lactate dehydrogenase (LDH) — serum marker; prognostic in bulky disease,PMID:9870293
-NUTM,,NUTM1,biomarker,,,,,Pathognomonic fusion partner — BRD4-NUTM1 / BRD3-NUTM1 / NSD3-NUTM1 defines NUT carcinoma,PMID:12543779
-NUTM,,BRD4,biomarker,,,,,BRD4-NUTM1 most common fusion; BET-inhibitor target,PMID:16314571
-NUTM,,BRD3,biomarker,,,,,BRD3-NUTM1 in ~30%; biologically similar to BRD4 variant,PMID:19318580
-NUTM,,NSD3,biomarker,,,,,NSD3-NUTM1 in ~10% of NUT carcinoma; emerging variant,PMID:26057308
-NUTM,,MYC,biomarker,,,,,Major BRD4-NUT downstream output; drives proliferation program,PMID:24686095
-NUTM,,TP63,biomarker,,,,,ΔNp63 isoform overexpressed; squamous-like differentiation program,PMID:23152362
-NUTM,,SOX2,biomarker,,,,,Stem-cell program; commonly expressed in NUT carcinoma,PMID:23152362
-NUTM,,KRT5,biomarker,,,,,Cytokeratin — squamous-like differentiation signal in NUT carcinoma,PMID:22895140
-NUTM,,CDKN2A,biomarker,,,,,Frequently deleted — p16 loss additional cooperating lesion,PMID:23152362
-NUTM,,BRD4,target,molibresib (GSK525762),small_molecule,phase_1,NUT carcinoma,First-in-class BET bromodomain inhibitor — targets BRD4-NUT driver directly,PMID:27376203
-NUTM,,BRD4,target,birabresib (OTX015/MK-8628),small_molecule,phase_1,NUT carcinoma,BET inhibitor — early clinical activity in NUT carcinoma,PMID:27184417
-NUTM,,BRD4,target,BMS-986158,small_molecule,phase_1,NUT carcinoma,BET inhibitor trials in NUT carcinoma and hematologic malignancies,PMID:34187828
-NUTM,,BRD4,target,NUV-868,small_molecule,phase_1,NUT carcinoma,BD2-selective BET inhibitor; improved tolerability profile,PMID:38456273
-NUTM,,HDAC1,target,vorinostat,small_molecule,off_label,NUT carcinoma,HDAC inhibitor — synergizes with BET-i preclinically; case reports of clinical benefit,PMID:23152362
-ACC,,INHA,biomarker,,,,,Inhibin α — adrenal cortex lineage marker; diagnostic IHC,PMID:22684458
-ACC,,NR5A1,biomarker,,,,,SF1 / steroidogenic factor 1 — adrenocortical differentiation marker,PMID:22684458
-ACC,,STAR,biomarker,,,,,Steroidogenic acute regulatory protein — adrenal-restricted,PMID:22684458
-ACC,,TP53,biomarker,,,,,Somatic and germline (Li-Fraumeni) inactivation — predicts aggressive course,PMID:25932744
-ACC,,CTNNB1,biomarker,,,,,Activating mutations — Wnt pathway driver; worse prognosis,PMID:18974114
-ACC,,IGF2,biomarker,,,,,Overexpressed in ~90% ACC; proposed but unproven therapy target,PMID:19861546
-ACC,,MKI67,biomarker,,,,,Ki-67 >10% proliferation index — independent predictor of recurrence,PMID:19299547
-ACC,,NR5A1,target,mitotane,small_molecule,approved,advanced/metastatic ACC,Adrenolytic — standard first-line single-agent therapy in ACC,PMID:17551153
-ACC,,CTLA4,target,ipilimumab,antibody,phase_2,advanced ACC,Anti-CTLA4; modest activity in trials; limited without nivolumab combo,PMID:30528525
-ACC,,PDCD1,target,pembrolizumab,antibody,phase_2,PD-L1+ / MSI-H ACC,Anti-PD1; limited activity overall but responders documented in MSI-H subset,PMID:30763180
-KICH,,KIT,biomarker,,,,,CD117 diffuse IHC — defining KICH; distinguishes from KIRC oncocytoma,PMID:25241740
-KICH,,KRT7,biomarker,,,,,CK7 diffuse — chromophobe lineage marker; negative in KIRC,PMID:25241740
-KICH,,TP53,biomarker,,,,,Recurrent mutation in KICH; associated with sarcomatoid dedifferentiation,PMID:25241740
-KICH,,PTEN,biomarker,,,,,Loss in subset of KICH; PI3K-mTOR pathway activation,PMID:25241740
-KICH,,MET,target,cabozantinib,small_molecule,approved,advanced RCC (non-clear-cell) incl KICH,MET/VEGFR/AXL TKI — approved for advanced RCC; best evidence in papillary/non-clear,PMID:31545681
-KICH,,VEGFA,target,sunitinib,small_molecule,approved,advanced RCC,VEGFR/PDGFR TKI — included in combined non-clear-cell RCC trials,PMID:17215530
-KICH,,PDCD1,target,nivolumab,antibody,approved,advanced RCC,Anti-PD1; approved in combination settings for advanced RCC,PMID:26406148
-KIRP,,MET,biomarker,,,,,Germline and somatic activating mutations — Type 1 papillary driver,PMID:25776748
-KIRP,,CDKN2A,biomarker,,,,,9p21 deletion — Type 2 papillary; worse prognosis,PMID:25776748
-KIRP,,NF2,biomarker,,,,,Recurrent in Type 2 KIRP; Hippo pathway activation,PMID:25776748
-KIRP,,FH,biomarker,,,,,HLRCC syndrome — germline fumarate hydratase loss; aggressive Type 2 variant,PMID:25776748
-KIRP,,SETD2,biomarker,,,,,Chromatin regulator — frequently mutated in Type 2 KIRP,PMID:25776748
-KIRP,,MET,target,cabozantinib,small_molecule,approved,advanced papillary RCC,FDA-approved for advanced RCC; Type 1 MET-mut papillary may respond preferentially,PMID:31545681
-KIRP,,MET,target,savolitinib,small_molecule,phase_3,MET-driven papillary RCC,Selective MET inhibitor; positive SAMETA trial subset,PMID:37696272
-KIRP,,PDCD1,target,pembrolizumab,antibody,approved,advanced papillary RCC,Approved with lenvatinib or as monotherapy post-TKI,PMID:35297388
-MESO,,BAP1,biomarker,,,,,Loss-of-function in ~60% pleural MESO; germline predisposition; IHC diagnostic,PMID:21642991
-MESO,,NF2,biomarker,,,,,Loss in ~40% pleural MESO; Hippo pathway activation,PMID:26928227
-MESO,,CDKN2A,biomarker,,,,,9p21 homozygous deletion in ~70% — key diagnostic and prognostic,PMID:26928227
-MESO,,WT1,biomarker,,,,,Diagnostic IHC — distinguishes MESO from adenocarcinoma,PMID:9789724
-MESO,,MSLN,biomarker,,,,,Mesothelin — highly expressed; serum biomarker and therapy target,PMID:16778184
-MESO,,CALB2,biomarker,,,,,Calretinin — defining mesothelial-lineage IHC marker,PMID:9789724
-MESO,,PDCD1,target,nivolumab + ipilimumab,antibody,approved,unresectable pleural MESO,CheckMate-743 — first-line combined IO; approved 2020,PMID:33485464
-MESO,,TYMS,target,pemetrexed + cisplatin,small_molecule,approved,unresectable MESO,Antifolate + platinum — historical standard of care,PMID:12860938
-MESO,,MSLN,target,anetumab ravtansine (BAY 94-9343),ADC,phase_2,MSLN-high MESO,Anti-MSLN maytansinoid ADC; missed primary endpoint but responders documented,PMID:34045265
-MESO,,VEGFA,target,bevacizumab,antibody,approved,pleural MESO + pem/cis,Anti-VEGF — MAPS trial showed OS benefit added to pem/cis,PMID:26719230
-PCPG,,SDHB,biomarker,,,,,Germline/somatic loss — metastatic risk; SDHx immunostain-negative PCC,PMID:24029231
-PCPG,,VHL,biomarker,,,,,Germline inactivation — von Hippel-Lindau syndrome PCC,PMID:24029231
-PCPG,,RET,biomarker,,,,,Germline activating mutation — MEN2 syndrome; pheo + medullary thyroid,PMID:23551588
-PCPG,,NF1,biomarker,,,,,Neurofibromatosis type 1 — pheo predisposition,PMID:24029231
-PCPG,,CHGA,biomarker,,,,,Chromogranin A — serum marker + NE lineage IHC,PMID:26398321
-PCPG,,TH,biomarker,,,,,Tyrosine hydroxylase — catecholamine-synthesis lineage marker,PMID:26398321
-PCPG,,MAX,biomarker,,,,,Germline loss — MYC-associated-X; bilateral pheo predisposition,PMID:22436948
-PCPG,,SSTR2,target,iobenguane I-131 ([131I]-MIBG),radioligand,approved,iobenguane-scan-positive metastatic PCC/PGL,Norepinephrine-transporter-directed radionuclide; approved 2018,PMID:30940672
-PCPG,,VEGFA,target,sunitinib,small_molecule,phase_2,advanced PCC/PGL,FIRSTMAPPP trial — PFS benefit vs placebo,PMID:35934015
-PCPG,,EPAS1,target,belzutifan,small_molecule,phase_2,VHL / SDHB pheochromocytoma,HIF2α inhibitor — approved in VHL syndrome-associated PCC,PMID:34818478
-READ,,MLH1,biomarker,,,,,MMR loss — MSI-H; gates pembrolizumab / dostarlimab,PMID:26028255
-READ,,MSH2,biomarker,,,,,MMR gene — MSI-H / Lynch association,PMID:26028255
-READ,,KRAS,biomarker,,,,,Codon 12/13/61 mutation — precludes anti-EGFR therapy,PMID:18316791
-READ,,NRAS,biomarker,,,,,Exon 2-4 mutation — precludes anti-EGFR therapy,PMID:24024839
-READ,,BRAF,biomarker,,,,,V600E mutation — poor prognosis; gates BRAF+anti-EGFR combo,PMID:31566309
-READ,,ERBB2,biomarker,,,,,HER2 amplification in ~3% — trastuzumab+tucatinib,PMID:32580927
-READ,,TP53,biomarker,,,,,Frequent somatic mutation; prognostic in some contexts,PMID:22810696
-READ,,EGFR,target,cetuximab,antibody,approved,KRAS/NRAS/BRAF-WT mCRC,Anti-EGFR monoclonal; approved for RAS-WT mCRC,PMID:15020612
-READ,,BRAF,target,encorafenib + cetuximab,small_molecule,approved,BRAF V600E mCRC,BEACON trial — approved for BRAF V600E mCRC after first-line failure,PMID:31566309
-READ,,PDCD1,target,pembrolizumab,antibody,approved,MSI-H / dMMR mCRC,KEYNOTE-177 — first-line in MSI-H mCRC,PMID:33264544
-READ,,ERBB2,target,trastuzumab + tucatinib,antibody,approved,HER2-amp mCRC,MOUNTAINEER — approved 2023 for HER2-amp RAS-WT mCRC,PMID:34534392
-THYM,,GTF2I,biomarker,,,,,Thymoma-specific chromosome 7 L424H mutation — indolent-behavior predictor,PMID:24974848
-THYM,,CD5,biomarker,,,,,Diffuse CD5+ in thymic carcinoma — distinguishes from thymoma,PMID:15837625
-THYM,,KIT,biomarker,,,,,Diffuse CD117 in thymic carcinoma — distinguishes from thymoma,PMID:16385570
-THYM,,MCM2,biomarker,,,,,Proliferation marker — correlated with histologic grade in thymoma,PMID:17496220
-THYM,,VEGFA,target,sunitinib,small_molecule,approved,thymic carcinoma (limited thymoma),VEGFR/PDGFR/KIT TKI — approved 2016; myasthenia-flare caution,PMID:26706735
-THYM,,PDCD1,target,pembrolizumab,antibody,approved,thymic carcinoma,Approved in thymic carcinoma; NOT thymoma (severe myasthenia flare risk),PMID:29502935
-THYM,,KIT,target,sunitinib,small_molecule,phase_2,thymic carcinoma,TKI activity in KIT-mut thymic carcinoma — secondary endpoint,PMID:26706735
-UCS,,TP53,biomarker,,,,,Mutation in ~90% UCS — near-universal,PMID:24185509
-UCS,,PIK3CA,biomarker,,,,,Recurrent activating mutation; PI3K-pathway driver,PMID:24185509
-UCS,,ERBB2,biomarker,,,,,HER2 amplification in subset — trastuzumab-deruxtecan candidate,PMID:31880538
-UCS,,PPP2R1A,biomarker,,,,,Recurrent mutation in UCS + serous endometrial — distinctive from endometrioid,PMID:24185509
-UCS,,FBXW7,biomarker,,,,,Recurrent mutation; tumor suppressor inactivation,PMID:24185509
-UCS,,TYMS,target,carboplatin + paclitaxel,small_molecule,approved,advanced UCS,GOG-261 — superior to ifosfamide + paclitaxel; current SOC,PMID:34375086
-UCS,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,HER2-low / HER2+ endometrial / UCS,DESTINY-PanTumor trial basket — approved 2024 HER2 expressing solid tumors,PMID:38662561
-UCS,,PDCD1,target,pembrolizumab + lenvatinib,antibody,approved,pMMR advanced endometrial (incl UCS),KEYNOTE-775 — advanced endometrial/UCS after prior platinum,PMID:33711226
-UCS,,PDCD1,target,dostarlimab,antibody,approved,dMMR / MSI-H endometrial / UCS,GARNET — approved 2021 in dMMR endometrial,PMID:34026889
-UVM,,GNAQ,biomarker,,,,,Q209/R183 activating mutation — defining UVM driver (~50%),PMID:21196391
-UVM,,GNA11,biomarker,,,,,Q209/R183 activating mutation — complementary to GNAQ (~40%),PMID:21196391
-UVM,,BAP1,biomarker,,,,,Loss — strong predictor of monosomy-3 metastasis phenotype,PMID:21083361
-UVM,,SF3B1,biomarker,,,,,R625 hotspot mutation — intermediate metastatic risk; distinct from BAP1 class,PMID:24875646
-UVM,,EIF1AX,biomarker,,,,,Mutation — low-risk subset; mutually exclusive with BAP1 loss,PMID:24875646
-UVM,,PMEL,biomarker,,,,,gp100 — melanocyte lineage; tebentafusp epitope target (HLA-A*02:01+),PMID:35179935
-UVM,,PMEL,target,tebentafusp,bispecific,approved,HLA-A*02:01+ metastatic UVM,Gp100 × CD3 bispecific — first approved targeted UVM agent,PMID:35179935
-UVM,,PDCD1,target,pembrolizumab + ipilimumab,antibody,phase_2,metastatic UVM,Checkpoint combinations — limited but documented responses,PMID:34115983
-UVM,,PRKCB,target,darovasertib (IDE196),small_molecule,phase_3,metastatic UVM,Protein kinase C inhibitor — GNAQ/GNA11 pathway; phase 3 ongoing,PMID:38182506
-LUSC,,TP53,biomarker,,,,,Near-universal mutation (~80%) — dominant driver of LUSC,PMID:22960745
-LUSC,,PIK3CA,biomarker,,,,,Recurrent activating mutation / amplification; PI3K-pathway driver,PMID:22960745
-LUSC,,SOX2,biomarker,,,,,3q amplification — squamous-lineage oncogene; ~20% LUSC,PMID:22960745
-LUSC,,FGFR1,biomarker,,,,,Amplification in ~20% LUSC — historical FGFR-inhibitor trials,PMID:22960745
-LUSC,,KEAP1,biomarker,,,,,Loss-of-function — cold-immune phenotype; co-occurs with STK11 axis,PMID:27308297
-LUSC,,NFE2L2,biomarker,,,,,Gain-of-function — oxidative-stress resistance; IO-refractory,PMID:27308297
-LUSC,,CDKN2A,biomarker,,,,,9p21 deletion — common in LUSC; IO-cold axis,PMID:22960745
-LUSC,,PTEN,biomarker,,,,,Loss in ~10% LUSC — PI3K activation,PMID:22960745
-LUSC,,PDCD1,target,pembrolizumab + chemotherapy,antibody,approved,advanced LUSC,KEYNOTE-407 — first-line pembrolizumab + carboplatin + taxane,PMID:30280656
-LUSC,,PDCD1,target,cemiplimab,antibody,approved,PD-L1>=50% advanced LUSC,EMPOWER-Lung 1 — first-line PD-L1 high monotherapy,PMID:33581821
-LUSC,,PDCD1,target,nivolumab + ipilimumab,antibody,approved,advanced NSCLC,CheckMate-227 — first-line IO combination for advanced LUSC,PMID:31562796
-LUSC,,VEGFA,target,atezolizumab + bevacizumab + chemo,antibody,approved,non-squamous NSCLC (LUAD),IMpower150 — approved in LUAD; LUSC generally receives non-bevacizumab regimens (bleeding risk),PMID:29863955
-LUSC,,FGFR1,target,AZD4547,small_molecule,phase_2,FGFR1-amp LUSC,FGFR-selective TKI — mixed results historically; trials largely negative,PMID:29298535
-MM,,CD38,biomarker,,,,,Near-universal surface on plasma cells — daratumumab / isatuximab epitope,PMID:26778312
-MM,,TNFRSF17,biomarker,,,,,BCMA — plasma-cell restricted; BCMA-directed therapy target,PMID:34192469
-MM,,SLAMF7,biomarker,,,,,Elotuzumab target — expressed on myeloma + NK cells,PMID:26527819
-MM,,FCRH5,biomarker,,,,,FcRH5 — lineage-restricted; cevostamab bispecific target,PMID:35512710
-MM,,GPRC5D,biomarker,,,,,Plasma-cell lineage — talquetamab target; differential expression vs normal plasma,PMID:34192469
-MM,,MYC,biomarker,,,,,Translocations (~15%); MYC-IGH or rearrangements drive aggressive disease,PMID:22869879
-MM,,CCND1,biomarker,,,,,t(11;14) CCND1-IGH — venetoclax-sensitive subset,PMID:30808845
-MM,,FGFR3,biomarker,,,,,t(4;14) FGFR3-IGH — high-risk subset,PMID:22869879
-MM,,TP53,biomarker,,,,,del(17p) or mutation — high-risk; venetoclax + selinexor rationale,PMID:27118452
-MM,,TNFRSF17,target,teclistamab,bispecific,approved,R/R multiple myeloma,BCMA x CD3 bispecific — approved 2022; MajesTEC-1 trial,PMID:35923167
-MM,,TNFRSF17,target,elranatamab,bispecific,approved,R/R multiple myeloma,BCMA x CD3 bispecific — approved 2023; MagnetisMM-3 trial,PMID:37290434
-MM,,TNFRSF17,target,cilta-cel (ciltacabtagene autoleucel),CAR-T,approved,R/R multiple myeloma,BCMA CAR-T — approved 2022; CARTITUDE-1 trial,PMID:34175021
-MM,,TNFRSF17,target,ide-cel (idecabtagene vicleucel),CAR-T,approved,R/R multiple myeloma,BCMA CAR-T — approved 2021; KarMMa trial,PMID:33626253
-MM,,TNFRSF17,target,belantamab mafodotin,ADC,approved,R/R multiple myeloma,BCMA MMAF ADC — approved 2024; DREAMM-7 / DREAMM-8,PMID:38581663
-MM,,GPRC5D,target,talquetamab,bispecific,approved,R/R multiple myeloma,GPRC5D x CD3 bispecific — approved 2023; MonumenTAL-1 trial,PMID:37632447
-MM,,CD38,target,daratumumab,antibody,approved,multiple myeloma (multiple lines),Anti-CD38 — approved newly-diagnosed + relapsed; MAIA/CASTOR/POLLUX,PMID:28498003
-MM,,CD38,target,isatuximab,antibody,approved,R/R multiple myeloma,Anti-CD38 — approved with pom+dex (ICARIA-MM) and with carfil+dex (IKEMA),PMID:31735560
-MM,,SLAMF7,target,elotuzumab,antibody,approved,R/R multiple myeloma,Anti-SLAMF7 — approved with lenalidomide+dex; ELOQUENT-2,PMID:26527819
-MM,,BCL2,target,venetoclax,small_molecule,phase_3,t(11;14) R/R MM,BCL2 inhibitor — CANOVA trial in t(11;14) subset,PMID:32213337
-CLL,,MS4A1,biomarker,,,,,CD20 — pan-B-cell; rituximab / obinutuzumab target,PMID:21358700
-CLL,,CD5,biomarker,,,,,Aberrant T-cell marker — defining CLL phenotype (CD5+ CD23+ CD20-dim),PMID:18832546
-CLL,,CD23,biomarker,,,,,FCER2 — CLL diagnostic IHC; distinguishes from MCL (CD23-),PMID:18832546
-CLL,,IGHV,biomarker,,,,,Unmutated IGHV (U-CLL) — poor prognosis; mutated (M-CLL) — favorable,PMID:10477712
-CLL,,TP53,biomarker,,,,,del(17p) or TP53 mutation — highest-risk; venetoclax + BTK-inhibitor preferred,PMID:22323484
-CLL,,NOTCH1,biomarker,,,,,Recurrent mutation — mutated IGHV independence; ATM subset,PMID:22150006
-CLL,,BTK,target,ibrutinib,small_molecule,approved,CLL first-line + R/R,First-in-class BTK inhibitor — RESONATE / RESONATE-2,PMID:26639149
-CLL,,BTK,target,acalabrutinib,small_molecule,approved,CLL first-line + R/R,Second-gen BTK inhibitor — improved selectivity / tolerability; ELEVATE-RR/TN,PMID:34358457
-CLL,,BTK,target,zanubrutinib,small_molecule,approved,CLL first-line + R/R,Second-gen BTK inhibitor — SEQUOIA / ALPINE trials,PMID:36791211
-CLL,,BTK,target,pirtobrutinib,small_molecule,approved,R/R CLL after covalent BTK-i,Non-covalent BTK-i — overcomes C481 resistance; BRUIN,PMID:37099297
-CLL,,BCL2,target,venetoclax,small_molecule,approved,CLL first-line + R/R,BCL2 inhibitor — ven+obinutuzumab (CLL14) or ven+ibrutinib (CAPTIVATE),PMID:30864090
-CLL,,MS4A1,target,obinutuzumab,antibody,approved,previously untreated CLL,Anti-CD20 type II — replaces rituximab in several CLL regimens; CLL11,PMID:24631112
-MCL,,CCND1,biomarker,,,,,t(11;14) CCND1-IGH — pathognomonic for MCL; cyclin D1 overexpression,PMID:9500537
-MCL,,SOX11,biomarker,,,,,Expressed in ~95% MCL — defines classical MCL; distinguishes from CLL,PMID:20554603
-MCL,,TP53,biomarker,,,,,Mutation / del(17p) — blastoid variant; chemorefractory,PMID:28035779
-MCL,,BTK,target,ibrutinib,small_molecule,approved,R/R MCL,BTK inhibitor — first-line MCL after chemo; LYM-3002,PMID:23782157
-MCL,,BTK,target,acalabrutinib,small_molecule,approved,R/R MCL,Second-gen BTK-i — more selective; approval basis ACE-LY-004,PMID:29126709
-MCL,,BTK,target,zanubrutinib,small_molecule,approved,R/R MCL,Second-gen BTK-i — approved 2019,PMID:31492771
-MCL,,CD19,target,brexucabtagene autoleucel (brexu-cel),CAR-T,approved,R/R MCL,CD19 CAR-T — approved 2020; ZUMA-2 trial,PMID:32726532
-MCL,,BCL2,target,venetoclax,small_molecule,phase_2,R/R MCL,"BCL2 inhibitor — activity in R/R MCL, especially with ibrutinib combo",PMID:30275128
-HL,,TNFRSF8,biomarker,,,,,CD30 — Reed-Sternberg / Hodgkin lineage; brentuximab-vedotin target,PMID:21128251
-HL,,PDCD1LG2,biomarker,,,,,PD-L2 — commonly amplified 9p24.1 in cHL with PD-L1 co-amp,PMID:27391691
-HL,,CD274,biomarker,,,,,PD-L1 — 9p24.1 amplification characteristic of cHL; IO sensitivity,PMID:27391691
-HL,,TNFRSF8,target,brentuximab vedotin,ADC,approved,CD30+ Hodgkin + PTCL,Anti-CD30 MMAE ADC — first-line AVD (ECHELON-1) + R/R,PMID:28636853
-HL,,PDCD1,target,nivolumab,antibody,approved,R/R classic Hodgkin,Anti-PD1 — CheckMate-205; approved R/R cHL,PMID:25482239
-HL,,PDCD1,target,pembrolizumab,antibody,approved,R/R classic Hodgkin,Anti-PD1 — KEYNOTE-204 (vs brentuximab),PMID:34264741
-B_ALL,,CD19,biomarker,,,,,Pan-B-cell surface — blinatumomab + tisa-cel epitope; near-universal in B-ALL,PMID:25795067
-B_ALL,,CD22,biomarker,,,,,Pan-B-cell surface — inotuzumab / moxetumomab epitope,PMID:27959700
-B_ALL,,CD20,biomarker,,,,,Variable expression in B-ALL — rituximab candidate in CD20+ subset,PMID:26919009
-B_ALL,,BCR,biomarker,,,,,BCR-ABL1 (Philadelphia chromosome) — TKI-eligible subset (~25% adult),PMID:26183700
-B_ALL,,BCR,target,imatinib + chemo,small_molecule,approved,Ph+ (BCR-ABL1) B-ALL,First-gen BCR-ABL TKI — added to induction for Ph+ B-ALL,PMID:16837215
-B_ALL,,BCR,target,ponatinib + chemo,small_molecule,approved,Ph+ B-ALL (incl T315I),Third-gen BCR-ABL TKI — active against T315I; PhALLCON trial,PMID:37917421
-B_ALL,,CD19,target,blinatumomab,bispecific,approved,R/R B-ALL + MRD+ B-ALL,CD19 x CD3 BiTE — approved 2014 R/R; 2018 MRD+ setting,PMID:25795067
-B_ALL,,CD19,target,tisagenlecleucel (tisa-cel),CAR-T,approved,R/R pediatric / young adult B-ALL,CD19 CAR-T — first-of-kind FDA approval 2017,PMID:28562253
-B_ALL,,CD19,target,brexucabtagene autoleucel (brexu-cel),CAR-T,approved,R/R adult B-ALL,CD19 CAR-T — approved 2021; ZUMA-3 trial,PMID:34214213
-B_ALL,,CD22,target,inotuzumab ozogamicin,ADC,approved,R/R B-ALL,CD22 calicheamicin ADC — approved 2017; INO-VATE trial,PMID:27386334
-OS,,RB1,biomarker,,,,,Loss (~50%) — tumor suppressor; germline RB1 loss predisposes to OS,PMID:29156804
-OS,,TP53,biomarker,,,,,Mutation / Li-Fraumeni germline — ubiquitous driver,PMID:29156804
-OS,,ATRX,biomarker,,,,,Loss — ALT telomere-maintenance phenotype,PMID:29156804
-OS,,MDM2,biomarker,,,,,Amplification in parosteal OS variant — MDM2-p53 axis,PMID:24909179
-OS,,CDK4,biomarker,,,,,Co-amplified with MDM2 in parosteal OS; palbociclib rationale,PMID:24909179
-OS,,RUNX2,biomarker,,,,,Osteoblast master TF — lineage marker; retained in OS tumors,PMID:29156804
-OS,,COL1A1,biomarker,,,,,Osteoid matrix production — tumor-intrinsic (not TME) in OS,PMID:29156804
-OS,,GD2_SYN,biomarker,,,,,ST8SIA1 encodes GD2 synthase — variable surface GD2 expression,PMID:34648686
-OS,,B4GALNT1,target,dinutuximab,antibody,phase_2,advanced / metastatic OS,Anti-GD2 — AOST1421 trial; active in subset,PMID:34648686
-OS,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,HER2-expressing OS,Trastuzumab + chemo backbone trials in HER2+ OS,PMID:22271477
-OS,,IGF1R,target,ganitumab + chemo,antibody,phase_2,metastatic OS,IGF1R inhibitor — SARC021 + AEWS1221 trials,PMID:32762005
-OS,,VEGFA,target,cabozantinib,small_molecule,phase_2,R/R OS,CABONE / CABOSARC trials — activity documented,PMID:33008784
-EWS,,EWSR1,biomarker,,,,,EWSR1 fusion partner — defines Ewing family; translocation partner FLI1 (most) / ERG (~10%),PMID:26009011
-EWS,,FLI1,biomarker,,,,,EWSR1-FLI1 fusion — pathognomonic; EWS master driver,PMID:26009011
-EWS,,ERG,biomarker,,,,,EWSR1-ERG fusion in ~10% — alternative to FLI1; indistinguishable clinically,PMID:26009011
-EWS,,CD99,biomarker,,,,,MIC2 — diffuse membrane IHC; diagnostic for Ewing,PMID:2185739
-EWS,,NKX2-2,biomarker,,,,,Downstream EWS-FLI1 target; diagnostic IHC,PMID:18812539
-EWS,,STAG2,biomarker,,,,,Recurrent loss in Ewing — cohesin complex; poor prognosis subset,PMID:24814251
-EWS,,IGF1R,target,ganitumab,antibody,phase_3,high-risk EWS,AEWS1221 phase 3 — IGF1R inhibitor + VDC/IE in high-risk EWS,PMID:32762005
-EWS,,ERG,target,TK216,small_molecule,phase_2,R/R EWS,EWS-FLI1 direct inhibitor (small molecule) — phase 2 trials,PMID:33712479
-EWS,,KDM1A,target,seclidemstat,small_molecule,phase_1,R/R Ewing,LSD1 inhibitor — EWS-FLI1-dependent program,PMID:29438748
-EWS,,PRAME,target,IMA203,TCR-T,phase_2,PRAME+ HLA-A*02+ Ewing,PRAME-directed TCR-T in EWS-expressing samples,PMID:38197793
-RMS_ERMS,,MYOD1,biomarker,,,,,Myogenic regulatory factor — embryonal skeletal-muscle program; diagnostic IHC,PMID:22290179
-RMS_ERMS,,MYOG,biomarker,,,,,Myogenin — downstream MYOD1; focal IHC pattern (vs diffuse in ARMS),PMID:22290179
-RMS_ERMS,,DES,biomarker,,,,,Desmin — skeletal-muscle lineage IHC,PMID:22290179
-RMS_ERMS,,NRAS,biomarker,,,,,Recurrent activating mutation in ERMS — RAS-pathway driver,PMID:24703002
-RMS_ERMS,,TYMS,target,vincristine + actinomycin + cyclophosphamide (VAC),small_molecule,approved,ERMS first-line,VAC is pediatric RMS chemotherapy backbone — IRS/COG trials,PMID:19901112
-RMS_ARMS,,FOXO1,biomarker,,,,,PAX3-FOXO1 or PAX7-FOXO1 fusion — pathognomonic for fusion-positive RMS,PMID:19901112
-RMS_ARMS,,PAX3,biomarker,,,,,Majority PAX3-FOXO1 variant — worst prognosis,PMID:19901112
-RMS_ARMS,,PAX7,biomarker,,,,,PAX7-FOXO1 variant — better prognosis than PAX3,PMID:19901112
-RMS_ARMS,,MYOG,biomarker,,,,,Diffuse myogenin IHC (vs focal in ERMS) — diagnostic,PMID:22290179
-RMS_ARMS,,FGFR4,biomarker,,,,,Recurrent activating mutation in fusion-negative RMS — erdafitinib candidate,PMID:24703002
-RMS_ARMS,,FGFR4,target,erdafitinib,small_molecule,phase_2,FGFR4-mut fusion-neg RMS,FGFR-selective TKI — activity in FGFR-altered tumors,PMID:31378236
-WILMS,,WT1,biomarker,,,,,Wilms tumor gene — recurrent loss; metanephric lineage,PMID:18612257
-WILMS,,CTNNB1,biomarker,,,,,Activating mutation — Wnt pathway; co-occurs with WT1 mutation,PMID:18612257
-WILMS,,AMER1,biomarker,,,,,Loss — Wnt-pathway component; recurrent,PMID:18612257
-WILMS,,TP53,biomarker,,,,,Anaplastic variant — poor prognosis; chemo-resistant,PMID:15044706
-WILMS,,DROSHA,biomarker,,,,,Recurrent mutation — miRNA biogenesis; WT-specific,PMID:24909177
-WILMS,,DGCR8,biomarker,,,,,Recurrent mutation — miRNA biogenesis; WT-specific,PMID:24909177
-WILMS,,TYMS,target,vincristine + actinomycin + doxorubicin,small_molecule,approved,favorable-histology Wilms,COG / SIOP chemo backbone — risk-stratified intensity,PMID:23965906
-NBL,,MYCN,biomarker,,,,,Amplification — defines high-risk NBL; single strongest prognostic biomarker,PMID:3822889
-NBL,,ALK,biomarker,,,,,Activating mutation or amplification — ~10% NBL; crizotinib / lorlatinib rationale,PMID:18724361
-NBL,,ATRX,biomarker,,,,,Loss — ALT phenotype; older-age NBL subset,PMID:22367537
-NBL,,PHOX2B,biomarker,,,,,Sympathetic-nervous-system lineage TF — pan-NBL IHC,PMID:16636671
-NBL,,TH,biomarker,,,,,Tyrosine hydroxylase — catecholamine synthesis; neuroblastic IHC,PMID:16636671
-NBL,,B4GALNT1,biomarker,,,,,GD2 synthase — surface GD2 near-universal in NBL,PMID:21045144
-NBL,,B4GALNT1,target,dinutuximab,antibody,approved,high-risk NBL,Anti-GD2 + GM-CSF / IL2 — approved first-line maintenance,PMID:20879881
-NBL,,B4GALNT1,target,naxitamab,antibody,approved,R/R high-risk NBL (bone / marrow),Anti-GD2 humanized — approved 2020,PMID:34380744
-NBL,,ALK,target,lorlatinib,small_molecule,phase_2,ALK-mut NBL,Third-gen ALK TKI — NANT trial in R/R ALK-altered NBL,PMID:34480566
-NBL,,ALK,target,crizotinib,small_molecule,phase_1,ALK-mut NBL,First-gen ALK TKI — pediatric trials in ALK-altered NBL,PMID:21926007
-NBL,,MYCN,target,aurora A kinase inhibitors,small_molecule,phase_1,MYCN-amp NBL,Aurora-A stabilises MYCN — alisertib / LY3295668 trials,PMID:29514830
-MBL,,MYC,biomarker,,,,,Amplification — defines Group 3 MBL; worst prognosis,PMID:22265402
-MBL,,MYCN,biomarker,,,,,Amplification — subset of Group 4 + SHH-TP53-mut MBL,PMID:22265402
-MBL,,CTNNB1,biomarker,,,,,Activating mutation — WNT subgroup; best prognosis,PMID:22265402
-MBL,,PTCH1,biomarker,,,,,Germline or somatic loss — SHH subgroup; vismodegib candidate,PMID:22265402
-MBL,,SMO,biomarker,,,,,Activating mutation — SHH subgroup; vismodegib target,PMID:22265402
-MBL,,TP53,biomarker,,,,,Germline (Li-Fraumeni) — SHH subgroup high-risk anaplastic variant,PMID:24493713
-MBL,,SMO,target,vismodegib,small_molecule,phase_2,SHH-subgroup MBL,Smoothened inhibitor — SHH-specific activity; limited pediatric approval,PMID:24493713
-MBL,,TYMS,target,cisplatin + CCNU + vincristine,small_molecule,approved,newly-diagnosed MBL,Standard-risk / high-risk backbone — Packer regimen,PMID:16614307
-ATRT,,SMARCB1,biomarker,,,,,Biallelic loss — pathognomonic for ATRT (and non-CNS RT),PMID:21062906
-ATRT,,VIM,biomarker,,,,,Mesenchymal marker — frequently expressed in rhabdoid tumors,PMID:21062906
-ATRT,,EZH2,target,tazemetostat,small_molecule,phase_2,R/R SMARCB1-deficient ATRT,EZH2 inhibitor — SMARCB1-loss synthetic-lethal; pediatric trials,PMID:32750541
-ATRT,,TYMS,target,intensive chemo + radiation,small_molecule,approved,newly-diagnosed ATRT,Multi-agent pediatric regimens — no single-agent backbone,PMID:25825194
-RB,,RB1,biomarker,,,,,Biallelic inactivation — defines retinoblastoma; germline or somatic,PMID:12399767
-RB,,MYCN,biomarker,,,,,Amplification in rare RB1-wildtype variant — distinct entity,PMID:24606874
-RB,,TYMS,target,intra-arterial melphalan,small_molecule,approved,advanced unilateral RB (globe salvage),Intra-arterial chemotherapy — globe-preservation standard,PMID:24030949
-RB,,TYMS,target,carboplatin + etoposide + vincristine,small_molecule,approved,bilateral / recently-diagnosed RB,Systemic chemoreduction — first-line bilateral RB,PMID:19289752
-HEPB,,CTNNB1,biomarker,,,,,Activating mutation — Wnt-pathway driver in ~70% hepatoblastoma,PMID:24691097
-HEPB,,AFP,biomarker,,,,,Alpha-fetoprotein — near-universal serum elevation in hepatoblastoma,PMID:24691097
-HEPB,,TP53,biomarker,,,,,Rare in HEPB — high-risk subset; hepatocellular carcinoma overlap,PMID:24691097
-HEPB,,TYMS,target,cisplatin + doxorubicin (PLADO),small_molecule,approved,newly-diagnosed HEPB,International cooperative backbone — SIOPEL / COG regimens,PMID:28445040
-PANNET,,MEN1,biomarker,,,,,Most common driver — ~45% panNETs; MEN1 syndrome predisposition,PMID:28280049
-PANNET,,ATRX,biomarker,,,,,Loss — ALT phenotype; associated with larger tumors / worse prognosis,PMID:28280049
-PANNET,,DAXX,biomarker,,,,,Loss — alternative to ATRX; ALT/chromatin axis,PMID:28280049
-PANNET,,MTOR,biomarker,,,,,Pathway activation frequent — everolimus rationale,PMID:21306238
-PANNET,,CHGA,biomarker,,,,,Chromogranin A — serum marker + NE lineage IHC,PMID:26398321
-PANNET,,SYP,biomarker,,,,,Synaptophysin — NE lineage IHC,PMID:26398321
-PANNET,,SSTR2,biomarker,,,,,Somatostatin receptor 2 — octreotide / 177Lu-DOTATATE target,PMID:28185094
-PANNET,,SSTR2,target,octreotide long-acting,small_molecule,approved,advanced panNET,Somatostatin analog — first-line antiproliferative,PMID:19726064
-PANNET,,SSTR2,target,lanreotide,small_molecule,approved,advanced panNET,Somatostatin analog — CLARINET trial; PFS benefit,PMID:25014687
-PANNET,,SSTR2,target,[177Lu]Lu-DOTA-TATE,radioligand,approved,SSTR2+ advanced GEP-NET,NETTER-1 — first approved radioligand therapy,PMID:28076709
-PANNET,,MTOR,target,everolimus,small_molecule,approved,advanced panNET,mTOR inhibitor — RADIANT-3; PFS benefit,PMID:21306238
-PANNET,,VEGFA,target,sunitinib,small_molecule,approved,advanced panNET,VEGFR/PDGFR TKI — approved 2011; PFS benefit,PMID:21306235
-MID_NET,,CHGA,biomarker,,,,,Chromogranin A — serum marker in midgut carcinoid,PMID:26398321
-MID_NET,,SYP,biomarker,,,,,Synaptophysin — NE lineage IHC,PMID:26398321
-MID_NET,,SSTR2,biomarker,,,,,Somatostatin receptor 2 — defining for octreoscan / 177Lu-DOTATATE eligibility,PMID:28185094
-MID_NET,,TPH1,biomarker,,,,,Tryptophan hydroxylase — serotonin synthesis enzyme; carcinoid-specific,PMID:25538161
-MID_NET,,SSTR2,target,octreotide long-acting,small_molecule,approved,midgut carcinoid (carcinoid syndrome + antiproliferative),First-line for functional and nonfunctional midgut NETs,PMID:19726064
-MID_NET,,SSTR2,target,[177Lu]Lu-DOTA-TATE,radioligand,approved,SSTR2+ advanced midgut NET,NETTER-1 — approved for progressive midgut NETs,PMID:28076709
-MID_NET,,TPH1,target,telotristat ethyl,small_molecule,approved,carcinoid syndrome diarrhea,Oral inhibitor of TPH — approved 2017 for carcinoid-syndrome diarrhea,PMID:28444947
-LUNG_NET_LC,,CHGA,biomarker,,,,,Chromogranin A — serum + IHC; lung carcinoid diagnostic,PMID:26398321
-LUNG_NET_LC,,SYP,biomarker,,,,,Synaptophysin — NE lineage,PMID:26398321
-LUNG_NET_LC,,SSTR2,biomarker,,,,,Somatostatin receptor 2 — octreotide-scan positivity,PMID:28185094
-LUNG_NET_LC,,MEN1,biomarker,,,,,MEN1 loss — subset of atypical lung carcinoid,PMID:24584669
-LUNG_NET_LC,,SSTR2,target,octreotide long-acting,small_molecule,approved,advanced well-differentiated lung NET,Antiproliferative + symptom control,PMID:19726064
-LUNG_NET_LC,,MTOR,target,everolimus,small_molecule,approved,advanced well-differentiated lung NET,RADIANT-4 — approved 2016 for non-functional NETs incl lung,PMID:26703889
-MEC,,TNFRSF9,biomarker,,,,,Merkel cell lineage — CK20-positive perinuclear dot-like IHC characteristic,PMID:17189037
-MEC,,CD274,biomarker,,,,,PD-L1 expression — predictive for avelumab response,PMID:27093365
-MEC,,CHGA,biomarker,,,,,Chromogranin A — NE lineage; diffuse in MEC,PMID:17189037
-MEC,,SYP,biomarker,,,,,Synaptophysin — NE lineage,PMID:17189037
-MEC,,PDCD1,target,avelumab,antibody,approved,metastatic Merkel cell carcinoma,Anti-PD-L1 — JAVELIN-200; approved 2017; first MEC IO approval,PMID:27093365
-MEC,,PDCD1,target,pembrolizumab,antibody,approved,advanced MEC,Anti-PD1 — approved in first-line MEC,PMID:31158039
-MEC,,PDCD1,target,nivolumab + ipilimumab,antibody,phase_2,advanced MEC,Combination IO — improved responses in IO-refractory subset,PMID:30242127
-MTC,,RET,biomarker,,,,,Germline (MEN2A/B) or somatic RET mutation — driver; gates selpercatinib/pralsetinib,PMID:23590294
-MTC,,CALCA,biomarker,,,,,Calcitonin — diagnostic + treatment-response serum marker,PMID:24488796
-MTC,,CEACAM5,biomarker,,,,,CEA — adjunct serum marker; prognostic when calcitonin elevated,PMID:24488796
-MTC,,CHGA,biomarker,,,,,Chromogranin A — NE lineage; universal in MTC,PMID:26398321
-MTC,,RET,target,selpercatinib,small_molecule,approved,RET-mut metastatic MTC,Selective RET TKI — LIBRETTO-531; approved 2020,PMID:32846062
-MTC,,RET,target,pralsetinib,small_molecule,approved,RET-mut metastatic MTC,Selective RET TKI — approved 2020; ARROW trial,PMID:33534865
-MTC,,VEGFA,target,cabozantinib,small_molecule,approved,advanced metastatic MTC,Multi-TKI (incl RET) — approved pre-selective era; EXAM trial,PMID:24092931
-MTC,,VEGFA,target,vandetanib,small_molecule,approved,symptomatic advanced MTC,Multi-TKI — ZETA trial; first approved MTC-specific agent,PMID:22331954
-NPC,,EBV_LMP1,biomarker,,,,,EBV-encoded — near-universal in endemic NPC; distinguishes from HNSC,PMID:27832553
-NPC,,EBV_BZLF1,biomarker,,,,,Lytic-phase marker — EBV-reactivation axis,PMID:27832553
-NPC,,CD274,biomarker,,,,,PD-L1 — elevated in NPC tumor + immune infiltrate; IO-sensitive,PMID:30249639
-NPC,,PDCD1,target,toripalimab + gemcitabine/cisplatin,antibody,approved,recurrent/metastatic NPC,JUPITER-02 — approved 2023 first-line; anti-PD1,PMID:34516835
-NPC,,PDCD1,target,tislelizumab,antibody,approved,R/R NPC,RATIONALE-309 — approved in NPC 2023,PMID:36933560
-NPC,,PDCD1,target,pembrolizumab,antibody,approved,R/R NPC,Basket approval PD-L1+ solid tumors; KEYNOTE-122,PMID:32163866
-ACINIC,,BCL6,biomarker,,,,,Translocation (ACIN) — MSA-B family marker; salivary acinic carcinoma,PMID:26811196
-ACINIC,,DOG1,biomarker,,,,,Anoctamin 1 — distinctive IHC for acinic cell carcinoma,PMID:19820346
-ACINIC,,NR4A3,biomarker,,,,,HTN3-MSANTD3 fusion → NR4A3 overexpression; diagnostic for ACC variant,PMID:30980744
-ACINIC,,TYMS,target,carboplatin + paclitaxel,small_molecule,off_label,advanced acinic cell carcinoma,Rarely needed — mostly indolent; reserved for high-grade transformed variant,PMID:25974463
-ADCC,,MYB,biomarker,,,,,MYB-NFIB translocation — pathognomonic for adenoid cystic carcinoma (~60%),PMID:20093190
-ADCC,,NFIB,biomarker,,,,,MYB-NFIB fusion — more rarely MYBL1-NFIB,PMID:24002401
-ADCC,,NOTCH1,biomarker,,,,,Recurrent activating mutation — subset has aggressive phenotype + NOTCH-inhibitor rationale,PMID:27149988
-ADCC,,KIT,biomarker,,,,,Near-universal expression — historically imatinib trialed (largely negative),PMID:17762320
-ADCC,,MYB,target,brontictuzumab,antibody,phase_1,NOTCH1-mut ADCC,Anti-NOTCH1 monoclonal — limited activity; high-toxicity,PMID:31064789
-ADCC,,FGF2,target,lenvatinib,small_molecule,phase_2,advanced ADCC,Multikinase TKI — modest activity in advanced ADCC,PMID:30496135
-CHOR,,T,biomarker,,,,,Brachyury (TBXT) — pathognomonic for chordoma; defining nuclear IHC,PMID:18094074
-CHOR,,CDKN2A,biomarker,,,,,Frequent homozygous deletion — prognostic,PMID:24509719
-CHOR,,LYST,biomarker,,,,,Recurrent loss — subset of chordoma,PMID:30266954
-CHOR,,EGFR,target,erlotinib / gefitinib,small_molecule,phase_2,advanced chordoma,EGFR inhibitors — activity observed in subset; small series,PMID:21775476
-CHOR,,PDGFRB,target,imatinib,small_molecule,phase_2,advanced chordoma,Case reports + small series of durable responses in PDGFR-expressing chordoma,PMID:15751962
-CHOR,,T,target,brachyury vaccine,vaccine,phase_2,resectable chordoma,GI-6301 brachyury yeast vaccine — immunotherapy trials,PMID:29391359
-CHON,,IDH1,biomarker,,,,,Recurrent mutation in conventional chondrosarcoma — driver; potential ivosidenib-eligible,PMID:22057233
-CHON,,IDH2,biomarker,,,,,Recurrent mutation; complementary to IDH1; enasidenib rationale,PMID:22057233
-CHON,,EXT1,biomarker,,,,,Germline inactivation — hereditary multiple exostoses + secondary chondrosarcoma risk,PMID:19255577
-CHON,,EXT2,biomarker,,,,,Germline inactivation — hereditary multiple exostoses,PMID:19255577
-CHON,,COL2A1,biomarker,,,,,Mutation in small subset; cartilage-lineage driver in hereditary enchondromatosis,PMID:21643004
-CHON,,HEY1,biomarker,,,,,HEY1-NCOA2 fusion — defining for mesenchymal chondrosarcoma variant,PMID:22836606
-CHON,,IDH1,target,ivosidenib,small_molecule,phase_1,IDH1-mut advanced chondrosarcoma,Selective IDH1 inhibitor — activity in IDH1-R132 chondrosarcoma subset,PMID:32679069
-CHON,,VEGFA,target,pazopanib,small_molecule,phase_2,advanced chondrosarcoma,VEGFR multi-TKI — modest PFS benefit; pan-sarcoma data,PMID:22749852
-BL,,MYC,biomarker,,,,,"Defining oncogene — t(8;14) IGH-MYC (~80%), t(2;8) or t(8;22) variants; drives aggressive proliferation",PMID:16760443
-BL,,MS4A1,biomarker,,,,,CD20 — B-cell lineage; rituximab target,PMID:11807147
-BL,,CD79A,biomarker,,,,,B-cell receptor — BCR pathway component,PMID:19194475
-BL,,BCL6,biomarker,,,,,Germinal-center B-cell transcription factor — Burkitt cell of origin,PMID:14688368
-BL,,TP53,biomarker,,,,,Frequently mutated (~40%); high-risk in HIV-associated BL,PMID:22343534
-BL,,MS4A1,target,rituximab,antibody,approved,BL (DA-EPOCH-R),Anti-CD20 — standard of care with DA-EPOCH chemo backbone,PMID:32356518
-BL,,CD19,target,tisagenlecleucel,CAR-T,phase_2,R/R BL (pediatric),CD19 CAR-T — pediatric R/R BL activity in JULIET / ELIANA follow-ups,PMID:29262281
-BL,,CD22,target,inotuzumab ozogamicin,ADC,phase_2,R/R BL,CD22 ADC — activity in R/R BCR signaling B-cell lymphomas including BL,PMID:22431578
-FL,,MS4A1,biomarker,,,,,CD20 — germinal-center B-cell; anti-CD20 backbone of FL therapy,PMID:18836437
-FL,,BCL2,biomarker,,,,,t(14;18) IGH-BCL2 (~85%) — defining cytogenetic — anti-apoptotic driver,PMID:15033871
-FL,,BCL6,biomarker,,,,,Germinal-center TF; retained in FL vs lost in transformed aggressive variants,PMID:11432899
-FL,,CD10,biomarker,,,,,MME — germinal-center marker; differentiates FL from other B-NHLs,PMID:11432899
-FL,,EZH2,biomarker,,,,,Gain-of-function mutations (~25%); tazemetostat-sensitive subset,PMID:30692609
-FL,,MS4A1,target,rituximab,antibody,approved,FL (first-line maintenance + R/R),"Anti-CD20 — R-bendamustine / R-CHOP backbone, rituximab maintenance extends PFS",PMID:21890466
-FL,,MS4A1,target,obinutuzumab,antibody,approved,FL (R/R rituximab-refractory),Type-2 anti-CD20 — GADOLIN trial in rituximab-refractory FL,PMID:27686830
-FL,,EZH2,target,tazemetostat,small_molecule,approved,R/R EZH2-mutant FL,EZH2 inhibitor — approved 2020; response enriched in EZH2-mutant subset,PMID:33035457
-FL,,MS4A1,target,mosunetuzumab,bispecific,approved,R/R FL (≥2 prior lines),CD20xCD3 bispecific — approved 2022; GO29781 trial,PMID:36463577
-FL,,MS4A1,target,epcoritamab,bispecific,approved,R/R FL,CD20xCD3 bispecific — EPCORE NHL-1 trial,PMID:37192387
-FL,,CD19,target,axicabtagene ciloleucel (axi-cel),CAR-T,approved,R/R FL,CD19 CAR-T — ZUMA-5 trial; approved 2021,PMID:35045297
-FL,,CD19,target,lisocabtagene maraleucel (liso-cel),CAR-T,approved,R/R FL,CD19 CAR-T — TRANSCEND FL trial,PMID:37125909
-HCL,,BRAF,biomarker,,,,,V600E mutation — pathognomonic for classical HCL; ~100% of cases,PMID:21666225
-HCL,,CD20,biomarker,,,,,Strong B-cell surface expression — rituximab target,PMID:22689687
-HCL,,CD22,biomarker,,,,,B-cell surface — moxetumomab pasudotox target,PMID:30093631
-HCL,,CD25,biomarker,,,,,IL2RA — characteristic of classical HCL (vs HCL-v which is CD25-),PMID:22689687
-HCL,,BRAF,target,vemurafenib,small_molecule,approved,R/R classical HCL,BRAF V600E inhibitor — FDA approved 2024 for R/R HCL after purine analogs,PMID:26352686
-HCL,,BRAF,target,dabrafenib + trametinib,small_molecule,phase_2,R/R HCL,BRAF + MEK combo — clinical trial data in purine-analog refractory cases,PMID:35404892
-HCL,,CD22,target,moxetumomab pasudotox,ADC,approved,R/R classical HCL,CD22 immunotoxin — approved 2018 for multiply-relapsed HCL,PMID:30093631
-CML,,BCR,biomarker,,,,,BCR-ABL1 fusion — t(9;22) Philadelphia chromosome; pathognomonic for CML,PMID:10086668
-CML,,ABL1,biomarker,,,,,Kinase domain of BCR-ABL1 fusion — T315I mutation confers resistance to 1st/2nd-gen TKIs,PMID:11337484
-CML,,ABL1,target,imatinib,small_molecule,approved,CML chronic phase,First-gen BCR-ABL TKI — first-line standard since 2001; IRIS trial,PMID:12637609
-CML,,ABL1,target,dasatinib,small_molecule,approved,CML first-line or imatinib-resistant,Second-gen BCR-ABL TKI — DASISION trial,PMID:20525993
-CML,,ABL1,target,nilotinib,small_molecule,approved,CML first-line or imatinib-resistant,Second-gen BCR-ABL TKI — ENESTnd trial,PMID:20525997
-CML,,ABL1,target,bosutinib,small_molecule,approved,CML R/R or intolerant to imatinib,Second-gen BCR-ABL TKI — approved 2012,PMID:22829185
-CML,,ABL1,target,ponatinib,small_molecule,approved,T315I-mutant or multi-TKI-refractory CML,Third-gen BCR-ABL TKI — only approved agent with T315I activity,PMID:23770846
-CML,,ABL1,target,asciminib,small_molecule,approved,R/R CML including T315I,STAMP inhibitor — myristoyl-pocket allosteric inhibitor; approved 2021,PMID:34407557
-SCLC,,DLL3,biomarker,,,,,NOTCH ligand — overexpressed on SCLC; low in normal tissues except testis/brain,PMID:26330465
-SCLC,,ASCL1,biomarker,,,,,Subtype-defining TF — SCLC-A predominant subtype (Rudin 2019),PMID:30804526
-SCLC,,NEUROD1,biomarker,,,,,Subtype-defining TF — SCLC-N subtype,PMID:30804526
-SCLC,,POU2F3,biomarker,,,,,Subtype-defining TF — SCLC-P tuft-cell-like variant,PMID:30804526
-SCLC,,YAP1,biomarker,,,,,Subtype-defining TF — SCLC-Y inflammatory variant,PMID:30804526
-SCLC,,TP53,biomarker,,,,,Near-universal loss (~90%) — smoker-associated LoF,PMID:26168399
-SCLC,,RB1,biomarker,,,,,Near-universal loss (~90%) alongside TP53 — biallelic inactivation defines SCLC,PMID:26168399
-SCLC,,DLL3,target,tarlatamab,bispecific,approved,R/R SCLC (≥2 prior lines),DLL3xCD3 bispecific — approved 2024; DeLLphi-301 trial,PMID:37830521
-SCLC,,TOP1,target,lurbinectedin,small_molecule,approved,R/R SCLC,Transcription-inhibitor alkylator — accelerated approval 2020,PMID:32622651
-SCLC,,TOP1,target,topotecan,small_molecule,approved,R/R SCLC,TOP1 inhibitor — standard second-line SCLC chemo,PMID:16880325
-SCLC,,CD274,target,atezolizumab,antibody,approved,ES-SCLC first-line (+ chemo),Anti-PD-L1 — IMpower133; first chemo-IO approval in SCLC,PMID:30280641
-SCLC,,CD274,target,durvalumab,antibody,approved,ES-SCLC first-line (+ chemo),Anti-PD-L1 — CASPIAN trial,PMID:31590988
-T_ALL,,CD7,biomarker,,,,,T-cell surface — broadly expressed on T-ALL blasts; CAR-T target,PMID:30020014
-T_ALL,,NOTCH1,biomarker,,,,,Activating mutation (~60%) — HES1/MYC axis driver,PMID:15472075
-T_ALL,,FBXW7,biomarker,,,,,Co-occurs with NOTCH1 — sensitizes to γ-secretase inhibitors in preclinical,PMID:17641202
-T_ALL,,TP53,biomarker,,,,,Loss-of-function — high-risk relapsed T-ALL,PMID:24132215
-T_ALL,,CD7,target,WU-CART-007,CAR-T,phase_1,R/R T-ALL,Allogeneic CD7 CAR-T — early-phase data in R/R T-ALL,PMID:37523543
-T_ALL,,NT5E,target,nelarabine,small_molecule,approved,R/R T-ALL,Ara-G prodrug — selectively toxic to T-lineage blasts; approved 2005,PMID:16287964
-T_ALL,,CD38,target,daratumumab,antibody,phase_2,R/R T-ALL (CD38+),Anti-CD38 — activity in CD38+ T-ALL per investigator trials,PMID:35316844
-CTCL,,CD4,biomarker,,,,,Helper-T lineage; CTCL blasts are CD4+ CD26-,PMID:29997202
-CTCL,,DPP4,biomarker,,,,,CD26 loss on CTCL blasts is diagnostic,PMID:29997202
-CTCL,,PTK7,biomarker,,,,,Overexpressed on Sézary cells — cofetuzumab pelidotin target,PMID:28765115
-CTCL,,CCR4,biomarker,,,,,Elevated on CTCL blasts — mogamulizumab target,PMID:30366567
-CTCL,,TNFRSF8,biomarker,,,,,"CD30 — positive in ~50% CTCL cases, defines BV-eligible subset",PMID:28024975
-CTCL,,CCR4,target,mogamulizumab,antibody,approved,R/R mycosis fungoides / Sézary,Anti-CCR4 — approved 2018; MAVORIC trial,PMID:30366567
-CTCL,,TNFRSF8,target,brentuximab vedotin,ADC,approved,CD30+ CTCL,CD30 MMAE ADC — approved 2017; ALCANZA trial,PMID:28433508
-CTCL,,HDAC1,target,romidepsin,small_molecule,approved,R/R CTCL,Class-1 HDAC inhibitor — approved 2009,PMID:19451442
-CTCL,,HDAC1,target,vorinostat,small_molecule,approved,R/R CTCL,Pan-HDAC inhibitor — approved 2006,PMID:17227786
-SARC,MPNST,NF1,biomarker,,,,,Biallelic NF1 loss drives constitutive RAS/MAPK signaling in MPNST (up to 50% NF1-associated; sporadic cases also NF1-null),PMID:37173835
-SARC,MPNST,CDKN2A,biomarker,,,,,CDKN2A/B loss near-obligate in MPNST progression; marker of malignant transformation from plexiform NF,PMID:37173835
-SARC,MPNST,CDKN2B,biomarker,,,,,Co-deleted with CDKN2A in MPNST,PMID:37173835
-SARC,MPNST,TP53,biomarker,,,,,TP53 inactivation frequent in high-grade MPNST,PMID:37173835
-SARC,MPNST,SUZ12,biomarker,,,,,PRC2 loss-of-function (SUZ12/EED) yields global H3K27me3 loss — diagnostically useful IHC correlate,PMID:24857941
-SARC,MPNST,EED,biomarker,,,,,PRC2 loss-of-function partner of SUZ12 — global H3K27me3 loss,PMID:24857941
-SARC,MPNST,SMARCB1,biomarker,,,,,SMARCB1 loss in a subset of MPNST (epithelioid variant); overlaps with epithelioid sarcoma biology,PMID:25348869
-SARC,MPNST,SOX10,biomarker,,,,,Schwann-cell lineage confirmation — frequently retained in MPNST despite differentiation drift,PMID:37173835
-SARC,MPNST,S100B,biomarker,,,,,Schwann-cell lineage marker; loss often accompanies high-grade / dedifferentiated MPNST,PMID:37173835
-SARC,MPNST,MEK1,target,trametinib,small_molecule,phase_2,unresectable/metastatic NF1-associated MPNST,RAS-pathway dependency from NF1 loss; SARC031 trial investigating trametinib ± SHP2i,PMID:37173835
-SARC,MPNST,MEK1,target,selumetinib,small_molecule,phase_2,NF1-associated MPNST (investigational),"FDA-approved for inoperable plexiform NF (the MPNST precursor); extending into MPNST trials",PMID:32029004
-SARC,MPNST,MDM2,target,brigimadlin (BI 907828),small_molecule,phase_1,MDM2-amplified TP53-retained MPNST,MDM2 inhibition where TP53 wild-type preserved,PMID:35551194
-SARC,MPNST,EZH2,target,tazemetostat,small_molecule,phase_2,PRC2-null / SMARCB1-null MPNST,Synthetic lethal with PRC2 loss; FDA-approved for epithelioid sarcoma (SMARCB1-null) precedent,PMID:32507290
-SARC,MPNST,PTPN11,target,SHP2 inhibitors (trials),small_molecule,phase_1,RAS-driven MPNST (MEK-combo trials),SHP2 inhibition as MEK-resistance mitigator,PMID:37173835
-SARC,MPNST,BRD4,target,BET inhibitors (trials),small_molecule,phase_1,MPNST (preclinical / early-phase),BRD4 dependency in PRC2-null contexts — synergy with MEK inhibition,PMID:29203800
+cancer_code,subtype,symbol,role,agent,agent_class,phase,treatment_path_tier,line_of_therapy,eligibility_note,indication,rationale,source
+PRAD,,AR,biomarker,,,,,,,,Androgen receptor — lineage confirmation; retained expression with collapsed transactivation targets indicates castrate-resistant disease,PMID:23332746
+PRAD,,KLK3,biomarker,,,,,,,,PSA — transactivated target of AR; collapse with retained AR indicates CRPC,PMID:23332746
+PRAD,,KLK2,biomarker,,,,,,,,Kallikrein 2 — AR-transactivated; parallels KLK3 in CRPC de-differentiation,PMID:23332746
+PRAD,,NKX3-1,biomarker,,,,,,,,Prostate lineage transcription factor; lost in NEPC / de-differentiated disease,PMID:17538631
+PRAD,,HOXB13,biomarker,,,,,,,,Prostate lineage; combined with NKX3-1 loss signals de-differentiation,PMID:28069311
+PRAD,,TMPRSS2,biomarker,,,,,,,,AR-target gene; part of TMPRSS2-ERG fusion landscape,PMID:16254181
+PRAD,,ENO2,biomarker,,,,,,,,Neuron-specific enolase — core NE-differentiation marker; elevation with AR-target collapse warrants NEPC workup,PMID:27322743
+PRAD,,CHGA,biomarker,,,,,,,,Chromogranin A — NE differentiation marker,PMID:27322743
+PRAD,,SYP,biomarker,,,,,,,,Synaptophysin — NE differentiation marker,PMID:27322743
+PRAD,,ASCL1,biomarker,,,,,,,,NE lineage transcription factor; active in NEPC,PMID:31611234
+PRAD,,INSM1,biomarker,,,,,,,,NE transcription factor; preferred marker over CHGA/SYP in some NEPC panels,PMID:31611234
+PRAD,,FOLH1,target,177Lu-PSMA-617,radioligand,approved,approved_later_line,later_line_approved,confirm imaging/eligibility and prior-line requirements,mCRPC,PSMA — lutetium radioligand approved for PSMA-PET positive mCRPC post-ARPI,PMID:34161051
+PRAD,,FOLH1,target,225Ac-PSMA-617,radioligand,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,mCRPC,PSMA alpha-emitter in late-stage trials for PSMA-PET positive mCRPC,PMID:35930720
+PRAD,,STEAP1,target,AMG-509 (xaluritamig),TCE,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,STEAP1×CD3 bispecific T-cell engager in mCRPC; encouraging phase 1 responses,PMID:37812792
+PRAD,,STEAP2,target,,ADC,preclinical,preclinical,preclinical,preclinical follow-up; not a clinical recommendation,mCRPC,STEAP2 ADCs in discovery; coexpressed with STEAP1,
+PRAD,,DLL3,target,tarlatamab,TCE,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NEPC,DLL3×CD3 BiTE initially approved for SCLC; active trials in NEPC where DLL3 is retained,PMID:36417474
+PRAD,,KLK2,target,JNJ-69086420,bispecific,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,KLK2-targeting bispecific in early-phase trials,PMID:38110199
+PRAD,,TACSTD2,target,sacituzumab govitecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,Trop-2 ADC trials in CRPC following breast and urothelial approvals,
+PRAD,,AR,target,enzalutamide,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,mCRPC,Second-generation AR antagonist; standard of care in CRPC,PMID:22894553
+PRAD,,AR,target,apalutamide,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,nmCRPC,Approved for non-metastatic CRPC and mHSPC,PMID:29420164
+PRAD,,PSCA,biomarker,,,,,,,,Prostate stem cell antigen — PRAD-adenocarcinoma-enriched lineage marker; co-expressed with PSMA / STEAP1 / TROP-2 in AR-retained disease,PMID:9653118
+PRAD,,PSCA,target,BPX-601,CAR-T,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,PSCA-directed autologous CAR-T with rimiducid (GoCAR-T) — early-phase PRAD trial,PMID:32961293
+PRAD,,PSCA,target,PSMA-PSCA bispecific,bispecific,preclinical,preclinical,preclinical,preclinical follow-up; not a clinical recommendation,mCRPC,PSMA×PSCA dual-targeting bispecifics in preclinical / early trials — leverage co-expression to narrow on-target / off-tumor toxicity,
+PRAD,,CD276,biomarker,,,,,,,,B7-H3 — surface protein positively correlated with AR expression in PRAD; overexpressed in AR-retained mCRPC and a subset of NEPC,PMID:35839033
+PRAD,,CD276,target,ifinatamab deruxtecan (DS-7300),ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,B7-H3 DXd-payload ADC — active in pretreated mCRPC regardless of PSMA status; positively correlated with AR expression,PMID:35839033
+PRAD,,CD276,target,vobramitamab duocarmazine (MGC018),ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,B7-H3 ADC — TAMARACK trial in pretreated mCRPC,PMID:38061024
+PRAD,,CD276,target,enoblituzumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,Anti-B7-H3 antibody — neoadjuvant and combination trials,
+PRAD,,CEACAM5,biomarker,,,,,,,,CEA — negatively correlated with AR expression in PRAD; enriched in AR-suppressed / NEPC-trending disease where PSMA is lost,PMID:30333172
+PRAD,,CEACAM5,target,labetuzumab govitecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,AR-low / NEPC mCRPC,CEACAM5 ADC — basket activity; candidate for AR-suppressed mCRPC where PSMA is low,
+PRAD,,CEACAM5,target,tusamitamab ravtansine,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,CEACAM5+ mCRPC,CEACAM5 ADC extending from NSCLC; trials in AR-low / NE-differentiated mCRPC,
+PRAD,,FAP,biomarker,,,,,,,,Fibroblast activation protein — marks cancer-associated fibroblasts in PRAD stroma; expression **not strongly correlated** with PSMA because it's CAF-origin rather than tumor-cell,PMID:36898755
+PRAD,,FAP,target,[68Ga]FAPI-46,radioligand,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,FAP-directed PET imaging — detects PSMA-negative / NEPC disease by imaging tumor stroma,PMID:36898755
+PRAD,,FAP,target,[177Lu]FAPI-46,radioligand,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,mCRPC,FAP-directed radioligand therapy — early-phase trials for PSMA-low or PSMA-refractory mCRPC,PMID:36898755
+BRCA,,ESR1,biomarker,,,,,,,,Estrogen receptor — drives endocrine therapy indication; loss / mutation marks endocrine resistance,PMID:27532823
+BRCA,,PGR,biomarker,,,,,,,,Progesterone receptor — luminal marker; retained PR favors endocrine sensitivity,PMID:17438091
+BRCA,,ERBB2,biomarker,,,,,,,,HER2 — gating biomarker for HER2-targeted agents; IHC/ISH 3+ or FISH-amplified eligible,PMID:17544441
+BRCA,,MKI67,biomarker,,,,,,,,Ki-67 proliferation index; prognostic and guides chemo decisions in ER+ disease,PMID:21965299
+BRCA,,GATA3,biomarker,,,,,,,,Luminal transcription factor; diagnostic for mammary origin,PMID:16730215
+BRCA,,FOXA1,biomarker,,,,,,,,Pioneer factor cooperating with ER; luminal identity,PMID:20378679
+BRCA,,BRCA1,biomarker,,,,,,,,Germline/somatic loss drives PARP inhibitor indication,PMID:19553641
+BRCA,,BRCA2,biomarker,,,,,,,,Germline/somatic loss drives PARP inhibitor indication,PMID:19553641
+BRCA,,ERBB2,target,trastuzumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,HER2+ BRCA,First-in-class anti-HER2 monoclonal; standard backbone for HER2+ disease,PMID:11248153
+BRCA,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HER2+ / HER2-low BRCA,Enhertu — expanded approval to HER2-low metastatic breast cancer,PMID:35665782
+BRCA,,ERBB2,target,pertuzumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HER2+ BRCA,Dual HER2 blockade with trastuzumab,PMID:22149875
+BRCA,,TACSTD2,target,sacituzumab govitecan,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,mTNBC / HR+/HER2-,Trodelvy — Trop-2 ADC approved in mTNBC and HR+/HER2- post-endocrine,PMID:33882206
+BRCA,,FOLR1,target,mirvetuximab soravtansine,ADC,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,TNBC subsets,Folate receptor alpha ADC in basket trials including TNBC,PMID:37094291
+BRCA,,ESR1,target,elacestrant,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,ER+/HER2- ESR1-mut BRCA,Oral SERD approved for ESR1-mutant metastatic ER+ disease,PMID:36924229
+BRCA,,PGR,target,,hormone,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,ER+/HER2- BRCA,PR positivity supports endocrine therapy with AI or tamoxifen,
+BRCA,,CDK4,target,palbociclib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HR+/HER2- BRCA,CDK4/6 inhibitor combined with endocrine therapy,PMID:25524798
+BRCA,,CDK6,target,abemaciclib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,HR+/HER2- BRCA,CDK4/6 inhibitor including adjuvant use,PMID:31158057
+LUAD,,EGFR,biomarker,,,,,,,,Activating mutations (exon 19 del / L858R) gate TKI indication; T790M drives osimertinib selection,PMID:15118073
+LUAD,,KRAS,biomarker,,,,,,,,G12C targetable; other alleles remain a negative predictor for EGFR TKIs,PMID:32955177
+LUAD,,ALK,biomarker,,,,,,,,EML4-ALK fusion — alectinib-eligible,PMID:17625570
+LUAD,,ROS1,biomarker,,,,,,,,ROS1 fusion — crizotinib / entrectinib eligible,PMID:22215748
+LUAD,,BRAF,biomarker,,,,,,,,V600E mutation — dabrafenib+trametinib eligible,PMID:27283860
+LUAD,,RET,biomarker,,,,,,,,RET fusion — selpercatinib / pralsetinib eligible,PMID:32273263
+LUAD,,MET,biomarker,,,,,,,,Exon 14 skipping — capmatinib / tepotinib eligible,PMID:31950082
+LUAD,,NTRK1,biomarker,,,,,,,,NTRK fusion — larotrectinib / entrectinib eligible (basket),PMID:29466156
+LUAD,,CD274,biomarker,,,,,,,,PD-L1 expression gates first-line pembrolizumab monotherapy,PMID:27718847
+LUAD,,KEAP1,biomarker,,,,,,,,Co-mutation with STK11 predicts immunotherapy resistance,PMID:30275273
+LUAD,,STK11,biomarker,,,,,,,,Loss predicts immunotherapy resistance in KRAS-mutant LUAD,PMID:30287575
+LUAD,,NKX2-1,biomarker,,,,,,,,TTF-1 — adenocarcinoma lineage confirmation,PMID:20686206
+LUAD,,EGFR,target,osimertinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,EGFR-mut LUAD,Third-generation EGFR TKI — frontline and resistance setting,PMID:31733398
+LUAD,,ALK,target,alectinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,ALK-rearranged LUAD,Second-generation ALK TKI — frontline standard,PMID:28586279
+LUAD,,KRAS,target,sotorasib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,KRAS G12C LUAD,First KRAS G12C inhibitor approved,PMID:34252278
+LUAD,,KRAS,target,adagrasib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,KRAS G12C LUAD,Second KRAS G12C inhibitor,PMID:35658005
+LUAD,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600E LUAD,BRAF/MEK combination,PMID:27283860
+LUAD,,MET,target,capmatinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,MET exon 14 LUAD,MET inhibitor for exon 14 skipping,PMID:32877583
+LUAD,,RET,target,selpercatinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RET fusion LUAD,Selective RET inhibitor,PMID:32846060
+LUAD,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,PD-L1 high LUAD,Anti-PD-1; first-line for TPS ≥50%,PMID:27718847
+LUAD,,CEACAM5,target,tusamitamab ravtansine,ADC,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,CEACAM5+ NSCLC,Phase 3 CARMEN-LC03 trial,PMID:36070567
+LUAD,,TROP2,target,datopotamab deruxtecan,ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,NSCLC,Dato-DXd approved in advanced/metastatic nsqNSCLC,
+COAD,,KRAS,biomarker,,,,,,,,KRAS wild-type required for EGFR antibody (cetuximab / panitumumab) response,PMID:18316791
+COAD,,NRAS,biomarker,,,,,,,,Must be wild-type for EGFR-antibody response; pan-RAS testing standard,PMID:20921462
+COAD,,BRAF,biomarker,,,,,,,,V600E — poor prognosis; triple combo encorafenib+cetuximab+MEK eligible,PMID:24637364
+COAD,,MLH1,biomarker,,,,,,,,MMR gene — loss indicates MSI-H / dMMR; gates checkpoint IO,PMID:11932474
+COAD,,MSH2,biomarker,,,,,,,,MMR gene — loss indicates MSI-H / dMMR; Lynch syndrome relevance,PMID:11932474
+COAD,,MSH6,biomarker,,,,,,,,MMR gene — loss indicates MSI-H / dMMR; Lynch syndrome relevance,PMID:11932474
+COAD,,PMS2,biomarker,,,,,,,,MMR gene — loss indicates MSI-H / dMMR,PMID:11932474
+COAD,,CDX2,biomarker,,,,,,,,Intestinal lineage transcription factor — diagnostic of GI adenocarcinoma,PMID:18818409
+COAD,,CEACAM5,biomarker,,,,,,,,CEA — serum / tissue biomarker for colorectal adenocarcinoma,PMID:15767599
+COAD,,ERBB2,biomarker,,,,,,,,HER2 amplification — approved indication for trastuzumab combos in RAS WT,PMID:27108243
+COAD,,TP53,biomarker,,,,,,,,Prognostic / predictive; mutation common and linked to chemo response,PMID:27496642
+COAD,,APC,biomarker,,,,,,,,Gatekeeper driver of adenoma-carcinoma sequence; Wnt pathway activation,PMID:20180050
+COAD,,BRAF,target,encorafenib + cetuximab,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600E mCRC,BEACON triplet / doublet for BRAF V600E mCRC,PMID:31566309
+COAD,,KRAS,target,sotorasib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,KRAS G12C mCRC,Approved in pretreated KRAS G12C mCRC (CodeBreaK 300),PMID:37882531
+COAD,,KRAS,target,adagrasib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,KRAS G12C mCRC,Approved with cetuximab for pretreated KRAS G12C mCRC,
+COAD,,ERBB2,target,trastuzumab + tucatinib,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HER2+ RAS-WT mCRC,MOUNTAINEER trial result; HER2+ mCRC,PMID:37084732
+COAD,,EGFR,target,cetuximab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RAS-WT mCRC,Anti-EGFR in RAS/BRAF wild-type mCRC,PMID:19339720
+COAD,,EGFR,target,panitumumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RAS-WT mCRC,Fully human anti-EGFR antibody,PMID:20921462
+COAD,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,MSI-H / dMMR mCRC,Frontline IO in MSI-H / dMMR mCRC (KEYNOTE-177),PMID:33264544
+COAD,,CEACAM5,target,labetuzumab govitecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,CEACAM5+ mCRC,CEACAM5 ADC in clinical trials,
+SKCM,,BRAF,biomarker,,,,,,,,V600E/K — gates BRAF/MEK inhibition,PMID:22460905
+SKCM,,NRAS,biomarker,,,,,,,,Q61 mutations — MEK / ERK-directed trials,PMID:23410882
+SKCM,,MITF,biomarker,,,,,,,,Melanocyte lineage transcription factor; amplification in some resistance phenotypes,PMID:16172454
+SKCM,,S100B,biomarker,,,,,,,,Serum biomarker for melanoma progression,PMID:19380449
+SKCM,,MLANA,biomarker,,,,,,,,Melan-A / MART-1 — melanocyte lineage antigen and TCR target,PMID:7539751
+SKCM,,TYR,biomarker,,,,,,,,Tyrosinase — melanocyte lineage antigen,PMID:8201753
+SKCM,,PMEL,biomarker,,,,,,,,gp100 — melanocyte antigen; vaccine and TCR target,PMID:8201753
+SKCM,,PRAME,biomarker,,,,,,,,Cancer-testis antigen broadly expressed in melanoma; IMCgp100 / PRAME TCR trials,PMID:34428009
+SKCM,,CD274,biomarker,,,,,,,,PD-L1 stratifies IO response,PMID:26027431
+SKCM,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,BRAF V600 melanoma,Standard BRAF/MEK combination in V600-mutant disease,PMID:25399551
+SKCM,,BRAF,target,encorafenib + binimetinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600 melanoma,COLUMBUS trial combination,PMID:29573941
+SKCM,,BRAF,target,vemurafenib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600 melanoma,First BRAF inhibitor approved for melanoma,PMID:21639808
+SKCM,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced melanoma,First-line anti-PD-1,PMID:25891173
+SKCM,,CD274,target,nivolumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced melanoma,First-line anti-PD-1; combined with ipi for high-risk disease,PMID:26027431
+SKCM,,CTLA4,target,ipilimumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced melanoma,Anti-CTLA4; combination with nivolumab standard of care,PMID:20525992
+SKCM,,LAG3,target,relatlimab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced melanoma,LAG-3 + PD-1 combination (nivolumab-relatlimab),PMID:35063055
+SKCM,,PRAME,target,IMA203,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced melanoma,PRAME-directed TCR-T trials,PMID:34428009
+SKCM,,PMEL,target,IMCgp100 / tebentafusp,TCE,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,uveal melanoma,gp100 ImmTAC — approved for HLA-A*02:01 uveal melanoma,PMID:33053284
+SKCM,,TYR,target,,TCR-T,preclinical,preclinical,preclinical,preclinical follow-up; not a clinical recommendation,melanoma,Historical tyrosinase TCRs; active cell-therapy research,
+HNSC,,CDKN2A,biomarker,,,,,,,,p16 — elevated in HPV-driven HNSC (surrogate for E6/E7 inactivation),PMID:21079132
+HNSC,,EGFR,biomarker,,,,,,,,Overexpression / mutation — cetuximab eligibility,PMID:11309435
+HNSC,,CD274,biomarker,,,,,,,,PD-L1 CPS gates first-line pembrolizumab monotherapy or combo,PMID:30509740
+HNSC,,CCND1,biomarker,,,,,,,,Cyclin D1 — frequently amplified in HPV-negative HNSC,PMID:26457759
+HNSC,,TP53,biomarker,,,,,,,,Mutation common in HPV-negative disease; prognostic,PMID:26457759
+HNSC,,PIK3CA,biomarker,,,,,,,,Hotspot mutations prevalent; relevant to PI3K-pathway trials,PMID:21430269
+HNSC,,FADD,biomarker,,,,,,,,Amplified in HPV-negative HNSC; linked to resistance signaling,PMID:21430269
+HNSC,,EGFR,target,cetuximab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,recurrent/metastatic HNSC,Anti-EGFR — combined with chemo or RT,PMID:18784101
+HNSC,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,recurrent/metastatic HNSC,Frontline IO per CPS (KEYNOTE-048),PMID:31679945
+HNSC,,CD274,target,nivolumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,recurrent/metastatic HNSC,Anti-PD-1 post-platinum (CheckMate 141),PMID:27718847
+DLBC,,MS4A1,biomarker,,,,,,,,CD20 — lineage for B-cell lymphoma; gates rituximab,PMID:9562152
+DLBC,,CD19,biomarker,,,,,,,,B-cell lineage; gates CD19 CAR-T,PMID:29466159
+DLBC,,CD79A,biomarker,,,,,,,,BCR complex component; helps confirm B-cell lineage,PMID:21893720
+DLBC,,CD79B,biomarker,,,,,,,,BCR complex component; polatuzumab target and ABC-subtype marker,PMID:31091374
+DLBC,,BCL6,biomarker,,,,,,,,GCB marker per Hans algorithm,PMID:14504078
+DLBC,,MME,biomarker,,,,,,,,CD10 — GCB marker per Hans algorithm,PMID:14504078
+DLBC,,IRF4,biomarker,,,,,,,,MUM1 — ABC marker per Hans algorithm,PMID:14504078
+DLBC,,MYC,biomarker,,,,,,,,Rearrangement / co-expression marker — double/triple-hit lymphoma,PMID:19917594
+DLBC,,BCL2,biomarker,,,,,,,,Rearrangement / high expression — double/triple-hit; BCL2 inhibitor eligibility,PMID:19917594
+DLBC,,MS4A1,target,rituximab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,DLBCL,Anti-CD20 — backbone of R-CHOP,PMID:12075054
+DLBC,,CD19,target,axicabtagene ciloleucel,CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,Anti-CD19 CAR-T (Yescarta),PMID:29091450
+DLBC,,CD19,target,tisagenlecleucel,CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,Anti-CD19 CAR-T (Kymriah),PMID:30501490
+DLBC,,CD19,target,lisocabtagene maraleucel,CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,Anti-CD19 CAR-T (Breyanzi),PMID:33301694
+DLBC,,CD19,target,loncastuximab tesirine,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,Anti-CD19 ADC (Zynlonta),PMID:34123378
+DLBC,,CD19,target,tafasitamab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,Anti-CD19 with lenalidomide,PMID:32654889
+DLBC,,CD79B,target,polatuzumab vedotin,ADC,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,R/R DLBCL / 1L DLBCL,Anti-CD79B ADC; Pola-R-CHP new frontline standard,PMID:31091374
+DLBC,,CD22,target,inotuzumab ozogamicin,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R aggressive B-NHL,CD22 ADC extended from ALL to aggressive B-NHL trials,PMID:25605598
+DLBC,,CD20,target,glofitamab,TCE,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,CD20×CD3 bispecific (Columvi),PMID:36542511
+DLBC,,CD20,target,epcoritamab,TCE,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R DLBCL,CD20×CD3 bispecific (Epkinly),PMID:37093768
+DLBC,,BCL2,target,venetoclax,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,DLBCL,Active trials in double-hit and ABC DLBCL subtypes,PMID:29523570
+LAML,,CD33,biomarker,,,,,,,,Myeloid lineage — gates gemtuzumab ozogamicin,PMID:21233305
+LAML,,KIT,biomarker,,,,,,,,CD117 — myeloid progenitor marker; D816V mutation in core-binding-factor AML,PMID:16293591
+LAML,,FLT3,biomarker,,,,,,,,ITD / TKD mutations — midostaurin / gilteritinib eligibility,PMID:28644114
+LAML,,NPM1,biomarker,,,,,,,,Exon 12 mutation — favorable prognosis in CN-AML; menin-inhibitor sensitive,PMID:15659725
+LAML,,CEBPA,biomarker,,,,,,,,Biallelic mutation — favorable prognosis,PMID:18489401
+LAML,,IDH1,biomarker,,,,,,,,R132 mutation — ivosidenib eligibility,PMID:29860938
+LAML,,IDH2,biomarker,,,,,,,,R140/R172 mutation — enasidenib eligibility,PMID:28588020
+LAML,,RUNX1,biomarker,,,,,,,,Mutation — adverse prognosis; included in WHO classification,PMID:25082879
+LAML,,TP53,biomarker,,,,,,,,Mutation — adverse prognosis; APR-246 trials,PMID:27959686
+LAML,,DNMT3A,biomarker,,,,,,,,Mutation — adverse prognosis,PMID:21067377
+LAML,,KMT2A,biomarker,,,,,,,,Rearrangement — menin-inhibitor eligibility; adverse prognosis,PMID:37018480
+LAML,,MPO,biomarker,,,,,,,,Myeloid granulocytic lineage confirmation (cytochemistry / IHC),
+LAML,,CD33,target,gemtuzumab ozogamicin,ADC,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CD33+ AML,First ADC approved; combined with chemo in newly diagnosed AML,PMID:15178638
+LAML,,FLT3,target,midostaurin,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,FLT3-mut AML,Type I FLT3 inhibitor — newly diagnosed FLT3-mut AML,PMID:28644114
+LAML,,FLT3,target,gilteritinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R FLT3-mut AML,Type I FLT3 inhibitor — relapsed/refractory setting,PMID:31634902
+LAML,,IDH1,target,ivosidenib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,R/R IDH1-mut AML,IDH1 inhibitor; combined with azacitidine in newly diagnosed unfit patients,PMID:29860938
+LAML,,IDH2,target,enasidenib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R IDH2-mut AML,IDH2 inhibitor,PMID:28588020
+LAML,,BCL2,target,venetoclax,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,AML (unfit),Venetoclax+azacitidine/decitabine standard for unfit newly diagnosed AML,PMID:32786187
+LAML,,KMT2A,target,revumenib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R KMT2A-rearranged AML,Menin inhibitor approved in KMT2A-rearranged R/R AML,PMID:37018480
+LAML,,NPM1,target,revumenib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NPM1-mut AML,Menin inhibitor trials in NPM1-mutant AML,PMID:37018480
+LAML,,CD123,target,tagraxofusp,fusion,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BPDCN,CD123-directed; approved for BPDCN (related myeloid malignancy),PMID:30987805
+LAML,apl,PML,biomarker,,,,,,,,PML-RARA fusion partner — pathognomonic for APL (t(15;17)); defines the subtype,PMID:11001887
+LAML,apl,RARA,biomarker,,,,,,,,PML-RARA fusion — ATRA differentiation target; near-universal in APL,PMID:11001887
+LAML,apl,FLT3,biomarker,,,,,,,,ITD co-mutation in 30-40% of APL — hyperleukocytosis risk factor,PMID:18234679
+LAML,apl,RARA,target,tretinoin,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,APL,All-trans retinoic acid (ATRA) — differentiation therapy; combined with ATO in low-risk APL,PMID:15837627
+LAML,apl,PML,target,arsenic trioxide,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,APL,ATO targets PML moiety of PML-RARA; ATRA+ATO is chemo-free standard for low-risk APL,PMID:23841729
+UCEC,,MLH1,biomarker,,,,,,,,MMR gene — loss indicates MSI-H / dMMR; gates pembrolizumab / dostarlimab,PMID:26028255
+UCEC,,MSH2,biomarker,,,,,,,,MMR gene — MSI-H / dMMR marker; Lynch syndrome relevance,PMID:26028255
+UCEC,,MSH6,biomarker,,,,,,,,MMR gene — MSI-H / dMMR marker,PMID:26028255
+UCEC,,PMS2,biomarker,,,,,,,,MMR gene — MSI-H / dMMR marker,PMID:26028255
+UCEC,,POLE,biomarker,,,,,,,,Ultramutated TCGA subtype; exceptional IO responders despite MMR-proficient,PMID:23636398
+UCEC,,PTEN,biomarker,,,,,,,,Loss common in endometrioid; prognostic,PMID:23636398
+UCEC,,TP53,biomarker,,,,,,,,Mutation marks serous-like / copy-number-high TCGA subtype; adverse prognosis,PMID:23636398
+UCEC,,PAX8,biomarker,,,,,,,,Müllerian lineage — diagnostic of endometrial / gynaecologic origin,PMID:21577204
+UCEC,,ERBB2,biomarker,,,,,,,,HER2 amplified / overexpressed in serous subtype; gates trastuzumab combos,PMID:29967118
+UCEC,,ARID1A,biomarker,,,,,,,,Loss common in endometrioid and clear-cell subtypes; IO-modifying,PMID:23636398
+UCEC,,CTNNB1,biomarker,,,,,,,,Exon 3 mutation — low-grade endometrioid marker with distinct prognosis,PMID:23636398
+UCEC,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,MSI-H / dMMR UCEC,PD-1 blockade — frontline IO for MSI-H / dMMR advanced UCEC,PMID:32834393
+UCEC,,CD274,target,dostarlimab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,MSI-H / dMMR UCEC,PD-1 blockade approved for dMMR endometrial cancer (GARNET),PMID:32941234
+UCEC,,CD274,target,pembrolizumab + lenvatinib,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,pMMR UCEC,IO + VEGFR-TKI combination for pMMR advanced endometrial,PMID:32150749
+UCEC,,ERBB2,target,trastuzumab,antibody,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,HER2+ serous UCEC,HER2 combined with chemo in HER2+ serous UCEC,PMID:29967118
+UCEC,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HER2+/HER2-low UCEC,Enhertu basket activity in HER2-expressing endometrial,PMID:36423325
+STAD,,ERBB2,biomarker,,,,,,,,HER2 amplification — gates trastuzumab-based therapy,PMID:20728210
+STAD,,CLDN18,biomarker,,,,,,,,Claudin-18 isoform 2 expression — gates zolbetuximab,PMID:37256819
+STAD,,MLH1,biomarker,,,,,,,,MSI-H marker; gates checkpoint IO,PMID:25079317
+STAD,,MSH2,biomarker,,,,,,,,MSI-H marker; Lynch syndrome relevance,PMID:25079317
+STAD,,EBER1,biomarker,,,,,,,,EBV-encoded RNA — marks EBV subtype with distinct IO sensitivity,PMID:25079317
+STAD,,CD274,biomarker,,,,,,,,PD-L1 CPS gates first-line IO,PMID:32171126
+STAD,,FGFR2,biomarker,,,,,,,,Amplification in diffuse-type gastric; FGFR inhibitor eligibility,PMID:23674492
+STAD,,MET,biomarker,,,,,,,,Amplification / overexpression; targeted-therapy interest,PMID:28947956
+STAD,,ERBB2,target,trastuzumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,HER2+ gastric/GEJ,First-line with chemo for HER2+ gastric (ToGA),PMID:20728210
+STAD,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,HER2+ gastric/GEJ,Enhertu approved in HER2-mut / HER2+ gastric post-progression,PMID:32469182
+STAD,,CLDN18,target,zolbetuximab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,CLDN18.2+ HER2- gastric/GEJ,SPOTLIGHT and GLOW trial-led approval for CLDN18.2+ HER2-negative advanced gastric,PMID:37256819
+STAD,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,PD-L1+ / MSI-H gastric/GEJ,KEYNOTE-859 — first-line IO combo for PD-L1 CPS ≥1 (≥10 in EU),PMID:37989261
+STAD,,CD274,target,nivolumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,gastric/GEJ,CheckMate 649 — first-line IO combo,PMID:33891889
+STAD,,VEGFR2,target,ramucirumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,pretreated gastric/GEJ,Anti-VEGFR2 — second-line combined with paclitaxel,PMID:25240821
+STAD,,FGFR2,target,bemarituzumab,antibody,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,FGFR2b+ gastric,FIGHT trial — FGFR2b-selective antibody,PMID:36089003
+BLCA,,FGFR3,biomarker,,,,,,,,Activating mutations / fusions — erdafitinib eligibility,PMID:31340094
+BLCA,,NECTIN4,biomarker,,,,,,,,Nectin-4 expression — gates enfortumab vedotin,PMID:30423390
+BLCA,,TACSTD2,biomarker,,,,,,,,Trop-2 expression — gates sacituzumab govitecan,PMID:33882206
+BLCA,,CD274,biomarker,,,,,,,,PD-L1 — gates first-line IO (CPS-aware),PMID:29268932
+BLCA,,ERBB2,biomarker,,,,,,,,HER2 amplification subset — trastuzumab combos / ADCs,PMID:35665782
+BLCA,,FOXA1,biomarker,,,,,,,,Luminal-subtype marker (BASE47 / consensus classifiers),PMID:28988769
+BLCA,,UPK2,biomarker,,,,,,,,Uroplakin II — urothelial lineage confirmation,PMID:9890150
+BLCA,,GATA3,biomarker,,,,,,,,Luminal urothelial lineage marker,PMID:28988769
+BLCA,,KRT5,biomarker,,,,,,,,Basal-subtype marker,PMID:28988769
+BLCA,,FGFR3,target,erdafitinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,FGFR3-altered advanced urothelial,FGFR1-4 inhibitor — second-line post platinum + IO (THOR),PMID:37870969
+BLCA,,NECTIN4,target,enfortumab vedotin,ADC,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced urothelial,Padcev — first-line combined with pembrolizumab (EV-302) and monotherapy in subsequent lines,PMID:38076652
+BLCA,,TACSTD2,target,sacituzumab govitecan,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,advanced urothelial,Trodelvy — second-line post platinum/IO,PMID:33882206
+BLCA,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced urothelial,First-line with EV (EV-302) and monotherapy for cisplatin-ineligible PD-L1+,PMID:38076652
+BLCA,,CD274,target,atezolizumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced urothelial,Anti-PD-L1; earlier approvals since narrowed,PMID:28212060
+BLCA,,CD274,target,avelumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced urothelial,Maintenance IO after platinum response (JAVELIN Bladder 100),PMID:32945632
+BLCA,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HER2+ urothelial,Enhertu basket activity in HER2-expressing urothelial,PMID:36423325
+KIRC,,KDR,biomarker,,,,,,,,VEGFR2 — target of TKI backbone in RCC,PMID:17215530
+KIRC,,FLT1,biomarker,,,,,,,,VEGFR1 — VEGF pathway marker,
+KIRC,,MET,biomarker,,,,,,,,MET overexpression / amplification — cabozantinib activity,PMID:26406150
+KIRC,,AXL,biomarker,,,,,,,,Cabozantinib target; linked to VEGFR-TKI resistance,PMID:26406150
+KIRC,,CD274,biomarker,,,,,,,,PD-L1 enriched in sarcomatoid; prognostic for IO response,PMID:25399552
+KIRC,,PBRM1,biomarker,,,,,,,,Loss common in ccRCC; candidate IO-response biomarker,PMID:29301960
+KIRC,,BAP1,biomarker,,,,,,,,Loss — adverse prognosis; differential biology,PMID:22683710
+KIRC,,VHL,biomarker,,,,,,,,Inactivation drives HIF axis; universal in sporadic ccRCC,PMID:22683710
+KIRC,,HIF1A,biomarker,,,,,,,,HIF axis activation marker downstream of VHL loss,
+KIRC,,CA9,biomarker,,,,,,,,CAIX — HIF-driven surface marker; diagnostic and theranostic target,PMID:18483390
+KIRC,,PAX8,biomarker,,,,,,,,Kidney epithelial lineage — diagnostic in difficult cases,PMID:21577204
+KIRC,,KDR,target,sunitinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced RCC,Multikinase TKI — historic first-line backbone,PMID:17215530
+KIRC,,KDR,target,pazopanib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced RCC,Multikinase TKI,PMID:20100962
+KIRC,,KDR,target,cabozantinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced RCC,MET/VEGFR/AXL multi-TKI — monotherapy and combined with IO,PMID:26406150
+KIRC,,KDR,target,axitinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced RCC,VEGFR inhibitor — combined with pembrolizumab or avelumab in first-line,PMID:30779529
+KIRC,,KDR,target,lenvatinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced RCC,VEGFR multi-TKI — with pembrolizumab (CLEAR) in first-line,PMID:33616314
+KIRC,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced RCC,Anti-PD-1 — first-line combined with axitinib or lenvatinib,PMID:30779529
+KIRC,,CD274,target,nivolumab + ipilimumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,intermediate/poor-risk RCC,IO-IO combination (CheckMate 214),PMID:29562145
+KIRC,,CD274,target,avelumab + axitinib,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced RCC,Anti-PD-L1 + VEGFR-TKI combination,PMID:30779531
+KIRC,,HIF2A,target,belzutifan,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,VHL-associated RCC / advanced ccRCC,HIF-2α inhibitor — approved for VHL syndrome and post-IO/TKI ccRCC,PMID:34597551
+KIRC,,CA9,target,girentuximab,antibody,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,non-metastatic ccRCC,"CAIX antibody — ZIRCON imaging approved; ARISER, adjuvant trials",PMID:24100620
+CESC,,CDKN2A,biomarker,,,,,,,,p16 — surrogate marker for HPV-driven cervical / head-and-neck,PMID:12649158
+CESC,,CD274,biomarker,,,,,,,,PD-L1 CPS — gates first-line pembrolizumab,PMID:32795402
+CESC,,F3,biomarker,,,,,,,,Tissue factor expression — gates tisotumab vedotin,PMID:32882178
+CESC,,MUC16,biomarker,,,,,,,,Elevated in adenocarcinoma subset; emerging target,
+CESC,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,recurrent/metastatic CESC,Anti-PD-1 — first-line with chemo (KEYNOTE-826),PMID:34534429
+CESC,,CD274,target,cemiplimab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,recurrent/metastatic CESC,Anti-PD-1 — post-progression (EMPOWER-Cervical 1),PMID:35179851
+CESC,,F3,target,tisotumab vedotin,ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,recurrent/metastatic CESC,Tivdak — tissue-factor ADC,PMID:33497583
+CESC,,CD274,target,nivolumab,antibody,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,recurrent/metastatic CESC,Anti-PD-1 — CheckMate 358 activity,PMID:31116649
+ESCA,,ERBB2,biomarker,,,,,,,,HER2 amplification in adenocarcinoma — trastuzumab eligibility,PMID:20728210
+ESCA,,CD274,biomarker,,,,,,,,PD-L1 CPS — first-line IO,PMID:32178703
+ESCA,,MLH1,biomarker,,,,,,,,MSI-H marker — uncommon but eligible for IO,
+ESCA,,TP53,biomarker,,,,,,,,Mutation common; prognostic,PMID:28052061
+ESCA,,CLDN18,biomarker,,,,,,,,CLDN18.2 expression in GEJ / lower-esophageal adeno,PMID:37256819
+ESCA,,FGFR2,biomarker,,,,,,,,Amplification subset; FGFR-inhibitor eligibility,PMID:23674492
+ESCA,,ERBB2,target,trastuzumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,HER2+ GEJ/esophageal,First-line with chemo (ToGA extension),PMID:20728210
+ESCA,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,HER2+ GEJ/esophageal,Enhertu in HER2-mut / HER2+ esophagogastric post-progression,PMID:32469182
+ESCA,,CD274,target,nivolumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced esophageal/GEJ,First-line IO combination (CheckMate 648 / 649),PMID:33891889
+ESCA,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced esophageal squamous / adeno,First-line with chemo (KEYNOTE-590),PMID:34454674
+ESCA,,CLDN18,target,zolbetuximab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,CLDN18.2+ HER2- GEJ,SPOTLIGHT / GLOW — CLDN18.2+ HER2-negative advanced gastric/GEJ,PMID:37256819
+PAAD,,KRAS,biomarker,,,,,,,,Activating mutations near universal (G12D most common); predictive and stratifying,PMID:20644561
+PAAD,,BRCA1,biomarker,,,,,,,,Germline mutation — olaparib maintenance eligibility,PMID:31157963
+PAAD,,BRCA2,biomarker,,,,,,,,Germline mutation — olaparib maintenance eligibility,PMID:31157963
+PAAD,,PALB2,biomarker,,,,,,,,HRD gene; emerging PARP inhibitor trials,PMID:33293427
+PAAD,,TP53,biomarker,,,,,,,,Mutation common; prognostic and co-occurring with KRAS,PMID:25079552
+PAAD,,CDKN2A,biomarker,,,,,,,,Frequent loss; potential synthetic-lethal approaches,PMID:25079552
+PAAD,,SMAD4,biomarker,,,,,,,,Loss associated with metastatic phenotype / adverse prognosis,PMID:25079552
+PAAD,,CLDN18,biomarker,,,,,,,,CLDN18.2 expression subset — emerging target for zolbetuximab / ADCs,PMID:37256819
+PAAD,,NRG1,biomarker,,,,,,,,NRG1 fusion — actionable subset with zenocutuzumab,PMID:34521628
+PAAD,,KRT19,biomarker,,,,,,,,Pancreatic ductal adenocarcinoma lineage marker,PMID:18239683
+PAAD,,PDX1,biomarker,,,,,,,,Pancreatic lineage transcription factor,
+PAAD,,BRCA1,target,olaparib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,gBRCA-mut metastatic PAAD,PARP inhibitor maintenance after platinum response (POLO),PMID:31157963
+PAAD,,NRG1,target,zenocutuzumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,NRG1-fusion PAAD and NSCLC,Bispecific HER2/HER3 in NRG1-fusion tumours,PMID:34521628
+PAAD,,KRAS,target,adagrasib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,KRAS G12C PAAD,KRAS G12C inhibitor — basket activity,PMID:35658005
+PAAD,,KRAS,target,sotorasib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,KRAS G12C PAAD,KRAS G12C inhibitor — basket activity,PMID:34252278
+PAAD,,KRAS,target,MRTX1133,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,KRAS G12D PAAD,Selective KRAS G12D inhibitor in early clinical development,PMID:36446367
+PAAD,,CLDN18,target,zolbetuximab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,CLDN18.2+ PAAD,CLDN18.2 antibody extending from gastric into PAAD trials,
+PAAD,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HER2+ PAAD,Enhertu basket activity in HER2-expressing PAAD,PMID:36423325
+LIHC,,AFP,biomarker,,,,,,,,Alpha-fetoprotein — diagnostic and prognostic serum marker,PMID:14985538
+LIHC,,GPC3,biomarker,,,,,,,,Glypican-3 — HCC-enriched surface antigen; diagnostic and target,PMID:14985538
+LIHC,,CTNNB1,biomarker,,,,,,,,Activating exon 3 mutations common; β-catenin-active subtype,PMID:28187286
+LIHC,,TERT,biomarker,,,,,,,,Promoter mutation — the most frequent somatic alteration in HCC,PMID:24753553
+LIHC,,TP53,biomarker,,,,,,,,Mutation marks HBV-associated and more aggressive disease,PMID:28187286
+LIHC,,AXIN1,biomarker,,,,,,,,Wnt pathway alteration — subset of HCC,PMID:28187286
+LIHC,,FGF19,biomarker,,,,,,,,11q13 amplification with CCND1 — FGFR4 pathway,PMID:24474064
+LIHC,,VEGFA,biomarker,,,,,,,,Elevated in HCC; rationale for VEGF-axis therapy,
+LIHC,,MET,biomarker,,,,,,,,Overexpression subset; tivantinib / cabozantinib interest,PMID:26436913
+LIHC,,CD274,biomarker,,,,,,,,PD-L1 prognostic in some cohorts; role in IO response,PMID:32185388
+LIHC,,CD274,target,atezolizumab + bevacizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced HCC,First-line IO + VEGF (IMbrave150),PMID:32402160
+LIHC,,CD274,target,durvalumab + tremelimumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced HCC,STRIDE regimen — PD-L1 + CTLA-4 (HIMALAYA),PMID:36198093
+LIHC,,KDR,target,sorafenib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced HCC,Historic first-line multikinase TKI,PMID:18650514
+LIHC,,KDR,target,lenvatinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced HCC,First-line multikinase TKI (REFLECT),PMID:29433850
+LIHC,,MET,target,cabozantinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,advanced HCC (2L),Multikinase TKI — second-line post sorafenib (CELESTIAL),PMID:29972759
+LIHC,,KDR,target,regorafenib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,advanced HCC (2L),Multikinase TKI — post-sorafenib,PMID:27932229
+LIHC,,VEGFR2,target,ramucirumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,AFP+ advanced HCC (2L),Anti-VEGFR2 for AFP ≥ 400 (REACH-2),PMID:30665869
+LIHC,,GPC3,target,codrituzumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,GPC3+ HCC,Glypican-3 antibody — earlier trials; active ADC / CAR-T programmes,PMID:28698288
+LIHC,,FGF19,target,fisogatinib,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,FGF19+ HCC,FGFR4-selective inhibitor for FGF19-amplified HCC,PMID:31694886
+SARC,leiomyosarcoma,ACTA2,biomarker,,,,,,,,Smooth-muscle actin — lineage marker for LMS,PMID:23954400
+SARC,leiomyosarcoma,CALD1,biomarker,,,,,,,,Caldesmon (h-caldesmon) — smooth-muscle lineage confirmation in LMS,PMID:23954400
+SARC,leiomyosarcoma,MYH11,biomarker,,,,,,,,Smooth-muscle myosin heavy chain — LMS lineage,PMID:23954400
+SARC,leiomyosarcoma,DES,biomarker,,,,,,,,Desmin — confirms smooth-muscle / striated-muscle lineage,PMID:23954400
+SARC,leiomyosarcoma,CDKN2A,biomarker,,,,,,,,Frequent loss in LMS; prognostic,PMID:23954400
+SARC,leiomyosarcoma,TP53,biomarker,,,,,,,,High somatic mutation rate in LMS; adverse prognosis,PMID:23954400
+SARC,leiomyosarcoma,RB1,biomarker,,,,,,,,Frequent inactivation in LMS,PMID:23954400
+SARC,leiomyosarcoma,,target,trabectedin,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced LMS,Alkylating agent — approved for L-sarcomas (LMS/liposarcoma) after anthracycline,PMID:26967202
+SARC,leiomyosarcoma,,target,pazopanib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced non-adipocytic STS,Multikinase TKI — PALETTE trial; includes LMS,PMID:22595799
+SARC,leiomyosarcoma,,target,doxorubicin,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,first-line STS,Anthracycline — backbone cytotoxic,PMID:22595799
+SARC,dedifferentiated_liposarcoma,MDM2,biomarker,,,,,,,,Ring-chromosome 12q amplification with MDM2 — pathognomonic for WDLPS/DDLPS,PMID:20181787
+SARC,dedifferentiated_liposarcoma,CDK4,biomarker,,,,,,,,Co-amplified with MDM2 on 12q13-15 — gates CDK4/6-inhibitor eligibility,PMID:20181787
+SARC,dedifferentiated_liposarcoma,HMGA2,biomarker,,,,,,,,12q amplicon — lipogenic-lineage marker in WDLPS/DDLPS,PMID:20181787
+SARC,dedifferentiated_liposarcoma,FRS2,biomarker,,,,,,,,12q co-amplification; FGFR-pathway adapter,PMID:20181787
+SARC,dedifferentiated_liposarcoma,TP53,biomarker,,,,,,,,More common in DDLPS than WDLPS — adverse prognosis,PMID:20181787
+SARC,dedifferentiated_liposarcoma,MDM2,target,brigimadlin (BI 907828),small_molecule,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,MDM2-amplified DDLPS,MDM2-p53 antagonist — Brightline-1 phase 3 trial,PMID:37467370
+SARC,dedifferentiated_liposarcoma,MDM2,target,milademetan,small_molecule,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,MDM2-amplified DDLPS,MDM2-p53 antagonist — MANTRA phase 3 (failed primary) with ongoing combination exploration,PMID:37467370
+SARC,dedifferentiated_liposarcoma,CDK4,target,palbociclib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,CDK4-amplified WDLPS/DDLPS,CDK4/6 inhibitor — encouraging phase 2 results in WDLPS/DDLPS,PMID:26948088
+SARC,dedifferentiated_liposarcoma,CDK4,target,abemaciclib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,CDK4-amplified WDLPS/DDLPS,CDK4/6 inhibitor — SARC041 and other phase 2 studies,PMID:31924739
+SARC,dedifferentiated_liposarcoma,,target,trabectedin,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced liposarcoma,Approved L-sarcoma indication — includes myxoid and DDLPS,PMID:26967202
+SARC,myxoid_liposarcoma,DDIT3,biomarker,,,,,,,,FUS-DDIT3 (formerly FUS-CHOP) fusion — pathognomonic for MRCLS,PMID:20181787
+SARC,myxoid_liposarcoma,MAGE-A4,biomarker,,,,,,,,Expressed in ~40% of MRCLS — gates afami-cel / MAGE-A4 TCR-T eligibility,PMID:39141605
+SARC,myxoid_liposarcoma,CTAG1B,biomarker,,,,,,,,NY-ESO-1 — expressed in majority of MRCLS; TCR-T target,PMID:25668005
+SARC,myxoid_liposarcoma,PRAME,biomarker,,,,,,,,CT antigen expressed in MRCLS; TCR-T / ADC target,PMID:34428009
+SARC,myxoid_liposarcoma,PPARG,biomarker,,,,,,,,Adipogenic master regulator; lineage confirmation,PMID:20181787
+SARC,myxoid_liposarcoma,MAGE-A4,target,afami-cel (afamitresgene autoleucel),TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ MAGE-A4+ MRCLS,First-in-class engineered TCR-T — approved in synovial sarcoma; MRCLS cohorts in basket trials,PMID:39141605
+SARC,myxoid_liposarcoma,CTAG1B,target,letetresgene autoleucel,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ NY-ESO-1+ MRCLS,NY-ESO-1 TCR-T — phase 2 in synovial / MRCLS,PMID:25668005
+SARC,myxoid_liposarcoma,,target,trabectedin,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced MRCLS,Approved L-sarcoma indication — particularly active in MRCLS,PMID:26967202
+SARC,synovial_sarcoma,SS18,biomarker,,,,,,,,SS18-SSX1/2/4 fusion (typically t(X;18)) — pathognomonic for synovial sarcoma,PMID:23583762
+SARC,synovial_sarcoma,MAGE-A4,biomarker,,,,,,,,Expressed in majority of synovial sarcoma — gates afami-cel eligibility,PMID:39141605
+SARC,synovial_sarcoma,CTAG1B,biomarker,,,,,,,,NY-ESO-1 — widely expressed; lete-cel target,PMID:25668005
+SARC,synovial_sarcoma,PRAME,biomarker,,,,,,,,Broadly expressed CT antigen; candidate TCR-T target,PMID:34428009
+SARC,synovial_sarcoma,TLE1,biomarker,,,,,,,,Diagnostic IHC marker — near-universal nuclear staining in synovial sarcoma,PMID:17255762
+SARC,synovial_sarcoma,BCL2,biomarker,,,,,,,,Broadly overexpressed — candidate for BCL2-targeted therapy trials,PMID:11297487
+SARC,synovial_sarcoma,MAGE-A4,target,afami-cel (Tecelra),TCR-T,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HLA-A*02+ MAGE-A4+ advanced synovial sarcoma,First engineered TCR-T approved by FDA (2024) — SPEARHEAD-1 trial,PMID:39141605
+SARC,synovial_sarcoma,CTAG1B,target,letetresgene autoleucel (lete-cel),TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ NY-ESO-1+ synovial sarcoma,NY-ESO-1 TCR-T — pivotal phase 2,PMID:38458182
+SARC,synovial_sarcoma,,target,pazopanib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced non-adipocytic STS,Multikinase TKI — PALETTE trial; synovial sarcoma included,PMID:22595799
+SARC,synovial_sarcoma,,target,trabectedin,small_molecule,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,advanced synovial sarcoma,Alkylating agent — activity documented in synovial sarcoma subgroups,PMID:26967202
+SARC,dsrct,EWSR1,biomarker,,,,,,,,EWSR1-WT1 t(11;22)(p13;q12) fusion — pathognomonic for desmoplastic small round cell tumor,PMID:11559696
+SARC,dsrct,WT1,biomarker,,,,,,,,C-terminal WT1 IHC — positive due to the EWSR1-WT1 fusion; diagnostic,PMID:11559696
+SARC,dsrct,DES,biomarker,,,,,,,,Dot-like desmin IHC — characteristic DSRCT pattern,PMID:11559696
+SARC,dsrct,VIM,biomarker,,,,,,,,Vimentin positivity alongside keratin — DSRCT polyphenotypic pattern,PMID:11559696
+SARC,dsrct,WT1,target,,TCR-T,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,WT1+ DSRCT,WT1-directed TCR-T and peptide vaccines in early trials,PMID:35379757
+SARC,gist,KIT,biomarker,,,,,,,,CD117 — activating mutation in majority of GIST; gates imatinib / sunitinib / avapritinib eligibility,PMID:12522257
+SARC,gist,PDGFRA,biomarker,,,,,,,,Imatinib-sensitive mutations (e.g. V561D); D842V requires avapritinib,PMID:12522257
+SARC,gist,SDHB,biomarker,,,,,,,,Loss identifies SDH-deficient (WT) GIST — paediatric/young adult subtype with different biology,PMID:21252315
+SARC,gist,SDHA,biomarker,,,,,,,,Alternate SDH complex loss — similar SDH-deficient biology,PMID:21252315
+SARC,gist,BRAF,biomarker,,,,,,,,V600E in wild-type GIST — BRAF-inhibitor candidate,PMID:23054102
+SARC,gist,NF1,biomarker,,,,,,,,NF1 inactivation in wild-type GIST,PMID:23054102
+SARC,gist,KIT,target,imatinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,unresectable/metastatic GIST,First-line KIT/PDGFRA inhibitor — standard of care,PMID:12181401
+SARC,gist,KIT,target,sunitinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,imatinib-resistant GIST,Multikinase — second-line after imatinib failure,PMID:17046465
+SARC,gist,KIT,target,regorafenib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,third-line GIST,Multikinase — post-imatinib/sunitinib failure,PMID:23177515
+SARC,gist,KIT,target,ripretinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,fourth-line GIST,Switch-control KIT/PDGFRA inhibitor — INVICTUS trial,PMID:32511981
+SARC,gist,PDGFRA,target,avapritinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,PDGFRA D842V GIST,Selective PDGFRA D842V inhibitor — NAVIGATOR trial,PMID:32078923
+SARC,gist,NTRK1,target,larotrectinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,NTRK-fusion GIST,Tumor-agnostic NTRK inhibitor — relevant to NTRK-fusion WT GIST,PMID:29466156
+SARC,ewing_sarcoma,EWSR1,biomarker,,,,,,,,EWSR1-FLI1 t(11;22) fusion (~85%) or EWSR1-ERG — pathognomonic for Ewing sarcoma,PMID:20142596
+SARC,ewing_sarcoma,FLI1,biomarker,,,,,,,,Fusion partner — IHC positive in Ewing,PMID:20142596
+SARC,ewing_sarcoma,NKX2-2,biomarker,,,,,,,,Downstream EWSR1-FLI1 target; lineage marker,PMID:21339729
+SARC,ewing_sarcoma,CD99,biomarker,,,,,,,,Membranous CD99 staining — sensitive but not specific Ewing IHC,PMID:20142596
+SARC,ewing_sarcoma,CAV1,biomarker,,,,,,,,Caveolin-1 — marker of Ewing differentiation,PMID:21339729
+SARC,ewing_sarcoma,PRAME,biomarker,,,,,,,,CT antigen expressed in Ewing; TCR-T target,PMID:34428009
+SARC,ewing_sarcoma,,target,trabectedin,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,relapsed Ewing,Alkylating agent — active in Ewing per single-agent and combo trials,PMID:26967202
+SARC,ewing_sarcoma,CDK4,target,palbociclib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,relapsed Ewing,CDK4/6 inhibitor — ongoing phase 2,PMID:31924739
+SARC,ewing_sarcoma,,target,TK216,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,relapsed Ewing,Small-molecule ETV fusion inhibitor — first-in-class trial,PMID:33872428
+SARC,ewing_sarcoma,PRAME,target,IMA203,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,PRAME+ HLA-A*02+ Ewing,PRAME-directed TCR-T — basket phase 2 including Ewing,PMID:34428009
+THCA,,BRAF,biomarker,,,,,,,,V600E — most common mutation in papillary thyroid carcinoma (~50%); drives RAI resistance,PMID:24557579
+THCA,,RET,biomarker,,,,,,,,RET fusions (CCDC6-RET etc.) in PTC — selpercatinib / pralsetinib eligibility,PMID:32273263
+THCA,,HRAS,biomarker,,,,,,,,RAS-family mutation (H/N/KRAS Q61) — prevalent in follicular thyroid cancer,PMID:24557579
+THCA,,NRAS,biomarker,,,,,,,,Most common RAS mutation in FTC; defines follicular subtype,PMID:24557579
+THCA,,NTRK1,biomarker,,,,,,,,NTRK fusion — rare; larotrectinib / entrectinib eligibility,PMID:29466156
+THCA,,TERT,biomarker,,,,,,,,Promoter mutation — adverse prognosis; common in anaplastic / poorly-differentiated,PMID:24035356
+THCA,,TG,biomarker,,,,,,,,Thyroglobulin — lineage confirmation and serum recurrence marker,PMID:24557579
+THCA,,NKX2-1,biomarker,,,,,,,,TTF-1 — thyroid lineage (also lung),PMID:24557579
+THCA,,PAX8,biomarker,,,,,,,,Thyroid / gynecologic lineage,PMID:21577204
+THCA,,TP53,biomarker,,,,,,,,Mutation in anaplastic thyroid carcinoma — adverse prognosis,PMID:24557579
+THCA,,KDR,target,lenvatinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,RAI-refractory DTC,VEGFR multi-TKI — SELECT trial,PMID:25671254
+THCA,,KDR,target,sorafenib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,RAI-refractory DTC,VEGFR multi-TKI — DECISION trial,PMID:24768112
+THCA,,KDR,target,cabozantinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,RAI-refractory DTC (2L),Multikinase TKI — COSMIC-311 trial,PMID:33798485
+THCA,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600E anaplastic thyroid,BRAF/MEK combination — tumor-agnostic plus specific ATC approval,PMID:30161798
+THCA,,RET,target,selpercatinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RET-altered thyroid cancer,Selective RET inhibitor — approved for medullary + RET-fusion DTC,PMID:32846060
+THCA,,RET,target,pralsetinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RET-altered thyroid cancer,Selective RET inhibitor,PMID:32615108
+THCA,,NTRK1,target,larotrectinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,NTRK-fusion thyroid cancer,Tumor-agnostic NTRK inhibitor,PMID:29466156
+LGG,,IDH1,biomarker,,,,,,,,R132H mutation — majority of adult LGG; defines IDH-mutant class; gates vorasidenib eligibility,PMID:37272516
+LGG,,IDH2,biomarker,,,,,,,,R172 mutation — less common than IDH1; also targeted by vorasidenib,PMID:37272516
+LGG,,ATRX,biomarker,,,,,,,,Loss — astrocytoma lineage marker (combined with IDH-mutant and 1p/19q retained),PMID:24105470
+LGG,,CDKN2A,biomarker,,,,,,,,Homozygous deletion — adverse prognosis in IDH-mutant astrocytoma; grade 4 criterion,PMID:34185076
+LGG,,TERT,biomarker,,,,,,,,Promoter mutation — common in oligodendroglioma and GBM; diagnostic,PMID:24327574
+LGG,,MGMT,biomarker,,,,,,,,Promoter methylation — temozolomide response predictor,PMID:15758009
+LGG,,TP53,biomarker,,,,,,,,Mutation — astrocytoma lineage (excluded in oligodendroglioma),PMID:24105470
+LGG,,BRAF,biomarker,,,,,,,,V600E — pediatric LGG / pilocytic astrocytoma; dabrafenib+trametinib eligibility,PMID:32818466
+LGG,,IDH1,target,vorasidenib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,IDH-mutant residual/recurrent grade 2 LGG,Dual IDH1/2 inhibitor — INDIGO trial (2024 approval),PMID:37272516
+LGG,,IDH2,target,vorasidenib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,IDH-mutant residual/recurrent grade 2 LGG,Dual IDH1/2 inhibitor — same drug covers both,PMID:37272516
+LGG,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600E pediatric glioma,Tumor-agnostic plus pediatric LGG-specific approval,PMID:32818466
+LGG,,MGMT,target,temozolomide,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,MGMT-methylated glioma,Alkylating chemo — efficacy tied to MGMT promoter methylation,PMID:15758009
+GBM,,IDH1,biomarker,,,,,,,,Wild-type defines GBM per 2021 WHO; IDH-mutant is now classified as astrocytoma,PMID:34185076
+GBM,,MGMT,biomarker,,,,,,,,Promoter methylation — temozolomide response predictor; ~40% of GBM,PMID:15758009
+GBM,,EGFR,biomarker,,,,,,,,Amplification in ~40% of GBM; EGFRvIII variant in ~30% of amplified cases,PMID:24060863
+GBM,,PTEN,biomarker,,,,,,,,Loss — common; adverse prognosis; PI3K-pathway activation,PMID:24060863
+GBM,,CDKN2A,biomarker,,,,,,,,Deletion — very common; grade 4 criterion in IDH-mutant astrocytoma,PMID:34185076
+GBM,,TP53,biomarker,,,,,,,,Mutation — more common in secondary GBM from astrocytoma,PMID:24060863
+GBM,,TERT,biomarker,,,,,,,,Promoter mutation — near-universal in IDH-wildtype GBM,PMID:24327574
+GBM,,NF1,biomarker,,,,,,,,Loss — mesenchymal subtype association,PMID:24060863
+GBM,,H3F3A,biomarker,,,,,,,,K27M or G34R/V mutation — paediatric / diffuse midline glioma; grade-defining,PMID:22286061
+GBM,,MGMT,target,temozolomide,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,MGMT-methylated GBM,Alkylating chemo — standard of care with radiation (Stupp protocol),PMID:15758009
+GBM,,KDR,target,bevacizumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,recurrent GBM,Anti-VEGF — approved for recurrent disease,PMID:19114704
+GBM,,EGFR,target,depatuxizumab mafodotin,ADC,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,EGFR-amplified GBM,Anti-EGFR ADC — INTELLANCE trials (mixed results),PMID:33253437
+CHOL,,FGFR2,biomarker,,,,,,,,Fusions and rearrangements in ~15% of intrahepatic cholangiocarcinoma; gate FGFR-inhibitor eligibility,PMID:32655039
+CHOL,,IDH1,biomarker,,,,,,,,Mutation in ~20% of intrahepatic cholangiocarcinoma; ivosidenib eligibility,PMID:32474412
+CHOL,,BRCA1,biomarker,,,,,,,,Germline/somatic mutation — PARP inhibitor basket eligibility,PMID:30975651
+CHOL,,BRCA2,biomarker,,,,,,,,Germline/somatic mutation — PARP inhibitor basket eligibility,PMID:30975651
+CHOL,,BAP1,biomarker,,,,,,,,Loss — cholangiocarcinoma subtype with distinct biology; mesothelioma overlap,PMID:24035356
+CHOL,,ARID1A,biomarker,,,,,,,,Loss — chromatin-remodeling alteration common in cholangiocarcinoma,PMID:24035356
+CHOL,,TP53,biomarker,,,,,,,,Mutation — adverse prognosis,PMID:24035356
+CHOL,,KRAS,biomarker,,,,,,,,Mutation — extrahepatic cholangiocarcinoma; chemoresistance marker,PMID:24035356
+CHOL,,ERBB2,biomarker,,,,,,,,Amplification — HER2-targeted therapy basket eligibility,PMID:31843955
+CHOL,,MLH1,biomarker,,,,,,,,MMR — MSI-H cholangiocarcinoma for pembrolizumab,PMID:26028255
+CHOL,,NTRK1,biomarker,,,,,,,,Rare NTRK fusion — larotrectinib eligibility (tumor-agnostic),PMID:29466156
+CHOL,,FGFR2,target,pemigatinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,FGFR2-fusion cholangiocarcinoma,Selective FGFR1-3 inhibitor — FIGHT-202 trial,PMID:32268924
+CHOL,,FGFR2,target,infigratinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,FGFR2-fusion cholangiocarcinoma,Selective FGFR inhibitor,PMID:33570312
+CHOL,,FGFR2,target,futibatinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,FGFR2-fusion cholangiocarcinoma,Irreversible FGFR inhibitor — FOENIX-CCA2 trial,PMID:37186853
+CHOL,,IDH1,target,ivosidenib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,IDH1-mutant cholangiocarcinoma,IDH1 inhibitor — ClarIDHy trial,PMID:32474412
+CHOL,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600E cholangiocarcinoma,Tumor-agnostic BRAF/MEK,PMID:32818466
+CHOL,,ERBB2,target,trastuzumab + pertuzumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HER2-amplified cholangiocarcinoma,HER2-targeted antibody combo — MyPathway basket,PMID:31843955
+CHOL,,NTRK1,target,larotrectinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,NTRK-fusion cholangiocarcinoma,Tumor-agnostic NTRK inhibitor,PMID:29466156
+CHOL,,CD274,target,pembrolizumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,MSI-H / dMMR cholangiocarcinoma,Tumor-agnostic checkpoint IO,PMID:32914748
+OV,,BRCA1,biomarker,,,,,,,,Germline/somatic mutation — PARP inhibitor maintenance eligibility; 20-25% of HGSOC,PMID:22452356
+OV,,BRCA2,biomarker,,,,,,,,Germline/somatic mutation — PARP inhibitor maintenance eligibility,PMID:22452356
+OV,,PALB2,biomarker,,,,,,,,HR-pathway gene — PARP basket eligibility,PMID:33293427
+OV,,RAD51C,biomarker,,,,,,,,HR-pathway gene — PARP basket eligibility; alongside RAD51D,PMID:33293427
+OV,,RAD51D,biomarker,,,,,,,,HR-pathway gene — PARP basket eligibility,PMID:33293427
+OV,,TP53,biomarker,,,,,,,,Mutation — near-universal in HGSOC; defines high-grade serous vs low-grade serous,PMID:22452356
+OV,,PAX8,biomarker,,,,,,,,Müllerian lineage — diagnostic for gynaecologic origin,PMID:21577204
+OV,,WT1,biomarker,,,,,,,,Serous lineage — IHC marker; distinguishes HGSOC from endometrioid ovarian,PMID:22452356
+OV,,FOLR1,biomarker,,,,,,,,Folate receptor alpha — mirvetuximab soravtansine eligibility (FRα-high platinum-resistant),PMID:37094291
+OV,,CD274,biomarker,,,,,,,,PD-L1 — MSI-H / dMMR subset for checkpoint IO,PMID:32914748
+OV,,BRCA1,target,olaparib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,BRCA-mut HGSOC,First PARP inhibitor approved — maintenance after platinum response (SOLO-1),PMID:30145076
+OV,,BRCA2,target,olaparib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,BRCA-mut HGSOC,PARP inhibitor maintenance — extends PFS dramatically,PMID:30145076
+OV,,BRCA1,target,niraparib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,HGSOC maintenance,PARP inhibitor — broader maintenance indication (BRCA-mut and BRCA-wt),PMID:28678572
+OV,,BRCA1,target,rucaparib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRCA-mut HGSOC,PARP inhibitor,PMID:27908594
+OV,,FOLR1,target,mirvetuximab soravtansine (Elahere),ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,FRα-high platinum-resistant HGSOC,FRα-directed ADC — first-in-class,PMID:37094291
+OV,,KDR,target,bevacizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,HGSOC maintenance / recurrence,Anti-VEGF — approved with chemo and as maintenance,PMID:22183408
+OV,,CD274,target,pembrolizumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,MSI-H / dMMR OV,Tumor-agnostic checkpoint IO for MSI-H subset,PMID:32914748
+TGCT,,KIT,biomarker,,,,,,,,Seminoma-restricted expression; CD117 IHC diagnostic,PMID:15765456
+TGCT,,AFP,biomarker,,,,,,,,Alpha-fetoprotein — serum marker for non-seminomatous germ cell tumors,PMID:9870293
+TGCT,,CGB1,biomarker,,,,,,,,beta-hCG — serum marker for choriocarcinoma / non-seminoma,PMID:9870293
+TGCT,,POU5F1,biomarker,,,,,,,,OCT4 — embryonal/seminoma stem-cell lineage marker,PMID:15765456
+TGCT,,NANOG,biomarker,,,,,,,,Pluripotency factor — germ cell / seminoma lineage,PMID:15765456
+TGCT,,SOX2,biomarker,,,,,,,,Embryonal carcinoma lineage marker,PMID:15765456
+TGCT,,SALL4,biomarker,,,,,,,,Stem-cell factor — diagnostic IHC for germ cell tumors,PMID:21765467
+TGCT,,LDHA,biomarker,,,,,,,,Lactate dehydrogenase (LDH) — serum marker; prognostic in bulky disease,PMID:9870293
+NUTM,,NUTM1,biomarker,,,,,,,,Pathognomonic fusion partner — BRD4-NUTM1 / BRD3-NUTM1 / NSD3-NUTM1 defines NUT carcinoma,PMID:12543779
+NUTM,,BRD4,biomarker,,,,,,,,BRD4-NUTM1 most common fusion; BET-inhibitor target,PMID:16314571
+NUTM,,BRD3,biomarker,,,,,,,,BRD3-NUTM1 in ~30%; biologically similar to BRD4 variant,PMID:19318580
+NUTM,,NSD3,biomarker,,,,,,,,NSD3-NUTM1 in ~10% of NUT carcinoma; emerging variant,PMID:26057308
+NUTM,,MYC,biomarker,,,,,,,,Major BRD4-NUT downstream output; drives proliferation program,PMID:24686095
+NUTM,,TP63,biomarker,,,,,,,,ΔNp63 isoform overexpressed; squamous-like differentiation program,PMID:23152362
+NUTM,,SOX2,biomarker,,,,,,,,Stem-cell program; commonly expressed in NUT carcinoma,PMID:23152362
+NUTM,,KRT5,biomarker,,,,,,,,Cytokeratin — squamous-like differentiation signal in NUT carcinoma,PMID:22895140
+NUTM,,CDKN2A,biomarker,,,,,,,,Frequently deleted — p16 loss additional cooperating lesion,PMID:23152362
+NUTM,,BRD4,target,molibresib (GSK525762),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NUT carcinoma,First-in-class BET bromodomain inhibitor — targets BRD4-NUT driver directly,PMID:27376203
+NUTM,,BRD4,target,birabresib (OTX015/MK-8628),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NUT carcinoma,BET inhibitor — early clinical activity in NUT carcinoma,PMID:27184417
+NUTM,,BRD4,target,BMS-986158,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NUT carcinoma,BET inhibitor trials in NUT carcinoma and hematologic malignancies,PMID:34187828
+NUTM,,BRD4,target,NUV-868,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NUT carcinoma,BD2-selective BET inhibitor; improved tolerability profile,PMID:38456273
+NUTM,,HDAC1,target,vorinostat,small_molecule,off_label,off_label,off_label,off-label follow-up; confirm rationale and alternatives,NUT carcinoma,HDAC inhibitor — synergizes with BET-i preclinically; case reports of clinical benefit,PMID:23152362
+ACC,,INHA,biomarker,,,,,,,,Inhibin α — adrenal cortex lineage marker; diagnostic IHC,PMID:22684458
+ACC,,NR5A1,biomarker,,,,,,,,SF1 / steroidogenic factor 1 — adrenocortical differentiation marker,PMID:22684458
+ACC,,STAR,biomarker,,,,,,,,Steroidogenic acute regulatory protein — adrenal-restricted,PMID:22684458
+ACC,,TP53,biomarker,,,,,,,,Somatic and germline (Li-Fraumeni) inactivation — predicts aggressive course,PMID:25932744
+ACC,,CTNNB1,biomarker,,,,,,,,Activating mutations — Wnt pathway driver; worse prognosis,PMID:18974114
+ACC,,IGF2,biomarker,,,,,,,,Overexpressed in ~90% ACC; proposed but unproven therapy target,PMID:19861546
+ACC,,MKI67,biomarker,,,,,,,,Ki-67 >10% proliferation index — independent predictor of recurrence,PMID:19299547
+ACC,,NR5A1,target,mitotane,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced/metastatic ACC,Adrenolytic — standard first-line single-agent therapy in ACC,PMID:17551153
+ACC,,CTLA4,target,ipilimumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced ACC,Anti-CTLA4; modest activity in trials; limited without nivolumab combo,PMID:30528525
+ACC,,PDCD1,target,pembrolizumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,PD-L1+ / MSI-H ACC,Anti-PD1; limited activity overall but responders documented in MSI-H subset,PMID:30763180
+KICH,,KIT,biomarker,,,,,,,,CD117 diffuse IHC — defining KICH; distinguishes from KIRC oncocytoma,PMID:25241740
+KICH,,KRT7,biomarker,,,,,,,,CK7 diffuse — chromophobe lineage marker; negative in KIRC,PMID:25241740
+KICH,,TP53,biomarker,,,,,,,,Recurrent mutation in KICH; associated with sarcomatoid dedifferentiation,PMID:25241740
+KICH,,PTEN,biomarker,,,,,,,,Loss in subset of KICH; PI3K-mTOR pathway activation,PMID:25241740
+KICH,,MET,target,cabozantinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced RCC (non-clear-cell) incl KICH,MET/VEGFR/AXL TKI — approved for advanced RCC; best evidence in papillary/non-clear,PMID:31545681
+KICH,,VEGFA,target,sunitinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced RCC,VEGFR/PDGFR TKI — included in combined non-clear-cell RCC trials,PMID:17215530
+KICH,,PDCD1,target,nivolumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced RCC,Anti-PD1; approved in combination settings for advanced RCC,PMID:26406148
+KIRP,,MET,biomarker,,,,,,,,Germline and somatic activating mutations — Type 1 papillary driver,PMID:25776748
+KIRP,,CDKN2A,biomarker,,,,,,,,9p21 deletion — Type 2 papillary; worse prognosis,PMID:25776748
+KIRP,,NF2,biomarker,,,,,,,,Recurrent in Type 2 KIRP; Hippo pathway activation,PMID:25776748
+KIRP,,FH,biomarker,,,,,,,,HLRCC syndrome — germline fumarate hydratase loss; aggressive Type 2 variant,PMID:25776748
+KIRP,,SETD2,biomarker,,,,,,,,Chromatin regulator — frequently mutated in Type 2 KIRP,PMID:25776748
+KIRP,,MET,target,cabozantinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced papillary RCC,FDA-approved for advanced RCC; Type 1 MET-mut papillary may respond preferentially,PMID:31545681
+KIRP,,MET,target,savolitinib,small_molecule,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,MET-driven papillary RCC,Selective MET inhibitor; positive SAMETA trial subset,PMID:37696272
+KIRP,,PDCD1,target,pembrolizumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,advanced papillary RCC,Approved with lenvatinib or as monotherapy post-TKI,PMID:35297388
+MESO,,BAP1,biomarker,,,,,,,,Loss-of-function in ~60% pleural MESO; germline predisposition; IHC diagnostic,PMID:21642991
+MESO,,NF2,biomarker,,,,,,,,Loss in ~40% pleural MESO; Hippo pathway activation,PMID:26928227
+MESO,,CDKN2A,biomarker,,,,,,,,9p21 homozygous deletion in ~70% — key diagnostic and prognostic,PMID:26928227
+MESO,,WT1,biomarker,,,,,,,,Diagnostic IHC — distinguishes MESO from adenocarcinoma,PMID:9789724
+MESO,,MSLN,biomarker,,,,,,,,Mesothelin — highly expressed; serum biomarker and therapy target,PMID:16778184
+MESO,,CALB2,biomarker,,,,,,,,Calretinin — defining mesothelial-lineage IHC marker,PMID:9789724
+MESO,,PDCD1,target,nivolumab + ipilimumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,unresectable pleural MESO,CheckMate-743 — first-line combined IO; approved 2020,PMID:33485464
+MESO,,TYMS,target,pemetrexed + cisplatin,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,unresectable MESO,Antifolate + platinum — historical standard of care,PMID:12860938
+MESO,,MSLN,target,anetumab ravtansine (BAY 94-9343),ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,MSLN-high MESO,Anti-MSLN maytansinoid ADC; missed primary endpoint but responders documented,PMID:34045265
+MESO,,VEGFA,target,bevacizumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,pleural MESO + pem/cis,Anti-VEGF — MAPS trial showed OS benefit added to pem/cis,PMID:26719230
+PCPG,,SDHB,biomarker,,,,,,,,Germline/somatic loss — metastatic risk; SDHx immunostain-negative PCC,PMID:24029231
+PCPG,,VHL,biomarker,,,,,,,,Germline inactivation — von Hippel-Lindau syndrome PCC,PMID:24029231
+PCPG,,RET,biomarker,,,,,,,,Germline activating mutation — MEN2 syndrome; pheo + medullary thyroid,PMID:23551588
+PCPG,,NF1,biomarker,,,,,,,,Neurofibromatosis type 1 — pheo predisposition,PMID:24029231
+PCPG,,CHGA,biomarker,,,,,,,,Chromogranin A — serum marker + NE lineage IHC,PMID:26398321
+PCPG,,TH,biomarker,,,,,,,,Tyrosine hydroxylase — catecholamine-synthesis lineage marker,PMID:26398321
+PCPG,,MAX,biomarker,,,,,,,,Germline loss — MYC-associated-X; bilateral pheo predisposition,PMID:22436948
+PCPG,,SSTR2,target,iobenguane I-131 ([131I]-MIBG),radioligand,approved,approved_later_line,later_line_approved,confirm imaging/eligibility and prior-line requirements,iobenguane-scan-positive metastatic PCC/PGL,Norepinephrine-transporter-directed radionuclide; approved 2018,PMID:30940672
+PCPG,,VEGFA,target,sunitinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced PCC/PGL,FIRSTMAPPP trial — PFS benefit vs placebo,PMID:35934015
+PCPG,,EPAS1,target,belzutifan,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,VHL / SDHB pheochromocytoma,HIF2α inhibitor — approved in VHL syndrome-associated PCC,PMID:34818478
+READ,,MLH1,biomarker,,,,,,,,MMR loss — MSI-H; gates pembrolizumab / dostarlimab,PMID:26028255
+READ,,MSH2,biomarker,,,,,,,,MMR gene — MSI-H / Lynch association,PMID:26028255
+READ,,KRAS,biomarker,,,,,,,,Codon 12/13/61 mutation — precludes anti-EGFR therapy,PMID:18316791
+READ,,NRAS,biomarker,,,,,,,,Exon 2-4 mutation — precludes anti-EGFR therapy,PMID:24024839
+READ,,BRAF,biomarker,,,,,,,,V600E mutation — poor prognosis; gates BRAF+anti-EGFR combo,PMID:31566309
+READ,,ERBB2,biomarker,,,,,,,,HER2 amplification in ~3% — trastuzumab+tucatinib,PMID:32580927
+READ,,TP53,biomarker,,,,,,,,Frequent somatic mutation; prognostic in some contexts,PMID:22810696
+READ,,EGFR,target,cetuximab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,KRAS/NRAS/BRAF-WT mCRC,Anti-EGFR monoclonal; approved for RAS-WT mCRC,PMID:15020612
+READ,,BRAF,target,encorafenib + cetuximab,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,BRAF V600E mCRC,BEACON trial — approved for BRAF V600E mCRC after first-line failure,PMID:31566309
+READ,,PDCD1,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,MSI-H / dMMR mCRC,KEYNOTE-177 — first-line in MSI-H mCRC,PMID:33264544
+READ,,ERBB2,target,trastuzumab + tucatinib,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HER2-amp mCRC,MOUNTAINEER — approved 2023 for HER2-amp RAS-WT mCRC,PMID:34534392
+THYM,,GTF2I,biomarker,,,,,,,,Thymoma-specific chromosome 7 L424H mutation — indolent-behavior predictor,PMID:24974848
+THYM,,CD5,biomarker,,,,,,,,Diffuse CD5+ in thymic carcinoma — distinguishes from thymoma,PMID:15837625
+THYM,,KIT,biomarker,,,,,,,,Diffuse CD117 in thymic carcinoma — distinguishes from thymoma,PMID:16385570
+THYM,,MCM2,biomarker,,,,,,,,Proliferation marker — correlated with histologic grade in thymoma,PMID:17496220
+THYM,,VEGFA,target,sunitinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,thymic carcinoma (limited thymoma),VEGFR/PDGFR/KIT TKI — approved 2016; myasthenia-flare caution,PMID:26706735
+THYM,,PDCD1,target,pembrolizumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,thymic carcinoma,Approved in thymic carcinoma; NOT thymoma (severe myasthenia flare risk),PMID:29502935
+THYM,,KIT,target,sunitinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,thymic carcinoma,TKI activity in KIT-mut thymic carcinoma — secondary endpoint,PMID:26706735
+UCS,,TP53,biomarker,,,,,,,,Mutation in ~90% UCS — near-universal,PMID:24185509
+UCS,,PIK3CA,biomarker,,,,,,,,Recurrent activating mutation; PI3K-pathway driver,PMID:24185509
+UCS,,ERBB2,biomarker,,,,,,,,HER2 amplification in subset — trastuzumab-deruxtecan candidate,PMID:31880538
+UCS,,PPP2R1A,biomarker,,,,,,,,Recurrent mutation in UCS + serous endometrial — distinctive from endometrioid,PMID:24185509
+UCS,,FBXW7,biomarker,,,,,,,,Recurrent mutation; tumor suppressor inactivation,PMID:24185509
+UCS,,TYMS,target,carboplatin + paclitaxel,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced UCS,GOG-261 — superior to ifosfamide + paclitaxel; current SOC,PMID:34375086
+UCS,,ERBB2,target,trastuzumab deruxtecan,ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HER2-low / HER2+ endometrial / UCS,DESTINY-PanTumor trial basket — approved 2024 HER2 expressing solid tumors,PMID:38662561
+UCS,,PDCD1,target,pembrolizumab + lenvatinib,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,pMMR advanced endometrial (incl UCS),KEYNOTE-775 — advanced endometrial/UCS after prior platinum,PMID:33711226
+UCS,,PDCD1,target,dostarlimab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,dMMR / MSI-H endometrial / UCS,GARNET — approved 2021 in dMMR endometrial,PMID:34026889
+UVM,,GNAQ,biomarker,,,,,,,,Q209/R183 activating mutation — defining UVM driver (~50%),PMID:21196391
+UVM,,GNA11,biomarker,,,,,,,,Q209/R183 activating mutation — complementary to GNAQ (~40%),PMID:21196391
+UVM,,BAP1,biomarker,,,,,,,,Loss — strong predictor of monosomy-3 metastasis phenotype,PMID:21083361
+UVM,,SF3B1,biomarker,,,,,,,,R625 hotspot mutation — intermediate metastatic risk; distinct from BAP1 class,PMID:24875646
+UVM,,EIF1AX,biomarker,,,,,,,,Mutation — low-risk subset; mutually exclusive with BAP1 loss,PMID:24875646
+UVM,,PMEL,biomarker,,,,,,,,gp100 — melanocyte lineage; tebentafusp epitope target (HLA-A*02:01+),PMID:35179935
+UVM,,PMEL,target,tebentafusp,bispecific,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HLA-A*02:01+ metastatic UVM,Gp100 × CD3 bispecific — first approved targeted UVM agent,PMID:35179935
+UVM,,PDCD1,target,pembrolizumab + ipilimumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,metastatic UVM,Checkpoint combinations — limited but documented responses,PMID:34115983
+UVM,,PRKCB,target,darovasertib (IDE196),small_molecule,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,metastatic UVM,Protein kinase C inhibitor — GNAQ/GNA11 pathway; phase 3 ongoing,PMID:38182506
+LUSC,,TP53,biomarker,,,,,,,,Near-universal mutation (~80%) — dominant driver of LUSC,PMID:22960745
+LUSC,,PIK3CA,biomarker,,,,,,,,Recurrent activating mutation / amplification; PI3K-pathway driver,PMID:22960745
+LUSC,,SOX2,biomarker,,,,,,,,3q amplification — squamous-lineage oncogene; ~20% LUSC,PMID:22960745
+LUSC,,FGFR1,biomarker,,,,,,,,Amplification in ~20% LUSC — historical FGFR-inhibitor trials,PMID:22960745
+LUSC,,KEAP1,biomarker,,,,,,,,Loss-of-function — cold-immune phenotype; co-occurs with STK11 axis,PMID:27308297
+LUSC,,NFE2L2,biomarker,,,,,,,,Gain-of-function — oxidative-stress resistance; IO-refractory,PMID:27308297
+LUSC,,CDKN2A,biomarker,,,,,,,,9p21 deletion — common in LUSC; IO-cold axis,PMID:22960745
+LUSC,,PTEN,biomarker,,,,,,,,Loss in ~10% LUSC — PI3K activation,PMID:22960745
+LUSC,,PDCD1,target,pembrolizumab + chemotherapy,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced LUSC,KEYNOTE-407 — first-line pembrolizumab + carboplatin + taxane,PMID:30280656
+LUSC,,PDCD1,target,cemiplimab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,PD-L1>=50% advanced LUSC,EMPOWER-Lung 1 — first-line PD-L1 high monotherapy,PMID:33581821
+LUSC,,PDCD1,target,nivolumab + ipilimumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced NSCLC,CheckMate-227 — first-line IO combination for advanced LUSC,PMID:31562796
+LUSC,,VEGFA,target,atezolizumab + bevacizumab + chemo,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,non-squamous NSCLC (LUAD),IMpower150 — approved in LUAD; LUSC generally receives non-bevacizumab regimens (bleeding risk),PMID:29863955
+LUSC,,FGFR1,target,AZD4547,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,FGFR1-amp LUSC,FGFR-selective TKI — mixed results historically; trials largely negative,PMID:29298535
+MM,,CD38,biomarker,,,,,,,,Near-universal surface on plasma cells — daratumumab / isatuximab epitope,PMID:26778312
+MM,,TNFRSF17,biomarker,,,,,,,,BCMA — plasma-cell restricted; BCMA-directed therapy target,PMID:34192469
+MM,,SLAMF7,biomarker,,,,,,,,Elotuzumab target — expressed on myeloma + NK cells,PMID:26527819
+MM,,FCRH5,biomarker,,,,,,,,FcRH5 — lineage-restricted; cevostamab bispecific target,PMID:35512710
+MM,,GPRC5D,biomarker,,,,,,,,Plasma-cell lineage — talquetamab target; differential expression vs normal plasma,PMID:34192469
+MM,,MYC,biomarker,,,,,,,,Translocations (~15%); MYC-IGH or rearrangements drive aggressive disease,PMID:22869879
+MM,,CCND1,biomarker,,,,,,,,t(11;14) CCND1-IGH — venetoclax-sensitive subset,PMID:30808845
+MM,,FGFR3,biomarker,,,,,,,,t(4;14) FGFR3-IGH — high-risk subset,PMID:22869879
+MM,,TP53,biomarker,,,,,,,,del(17p) or mutation — high-risk; venetoclax + selinexor rationale,PMID:27118452
+MM,,TNFRSF17,target,teclistamab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,BCMA x CD3 bispecific — approved 2022; MajesTEC-1 trial,PMID:35923167
+MM,,TNFRSF17,target,elranatamab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,BCMA x CD3 bispecific — approved 2023; MagnetisMM-3 trial,PMID:37290434
+MM,,TNFRSF17,target,cilta-cel (ciltacabtagene autoleucel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,BCMA CAR-T — approved 2022; CARTITUDE-1 trial,PMID:34175021
+MM,,TNFRSF17,target,ide-cel (idecabtagene vicleucel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,BCMA CAR-T — approved 2021; KarMMa trial,PMID:33626253
+MM,,TNFRSF17,target,belantamab mafodotin,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,BCMA MMAF ADC — approved 2024; DREAMM-7 / DREAMM-8,PMID:38581663
+MM,,GPRC5D,target,talquetamab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,GPRC5D x CD3 bispecific — approved 2023; MonumenTAL-1 trial,PMID:37632447
+MM,,CD38,target,daratumumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,multiple myeloma (multiple lines),Anti-CD38 — approved newly-diagnosed + relapsed; MAIA/CASTOR/POLLUX,PMID:28498003
+MM,,CD38,target,isatuximab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,Anti-CD38 — approved with pom+dex (ICARIA-MM) and with carfil+dex (IKEMA),PMID:31735560
+MM,,SLAMF7,target,elotuzumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R multiple myeloma,Anti-SLAMF7 — approved with lenalidomide+dex; ELOQUENT-2,PMID:26527819
+MM,,BCL2,target,venetoclax,small_molecule,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,t(11;14) R/R MM,BCL2 inhibitor — CANOVA trial in t(11;14) subset,PMID:32213337
+CLL,,MS4A1,biomarker,,,,,,,,CD20 — pan-B-cell; rituximab / obinutuzumab target,PMID:21358700
+CLL,,CD5,biomarker,,,,,,,,Aberrant T-cell marker — defining CLL phenotype (CD5+ CD23+ CD20-dim),PMID:18832546
+CLL,,CD23,biomarker,,,,,,,,FCER2 — CLL diagnostic IHC; distinguishes from MCL (CD23-),PMID:18832546
+CLL,,IGHV,biomarker,,,,,,,,Unmutated IGHV (U-CLL) — poor prognosis; mutated (M-CLL) — favorable,PMID:10477712
+CLL,,TP53,biomarker,,,,,,,,del(17p) or TP53 mutation — highest-risk; venetoclax + BTK-inhibitor preferred,PMID:22323484
+CLL,,NOTCH1,biomarker,,,,,,,,Recurrent mutation — mutated IGHV independence; ATM subset,PMID:22150006
+CLL,,BTK,target,ibrutinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CLL first-line + R/R,First-in-class BTK inhibitor — RESONATE / RESONATE-2,PMID:26639149
+CLL,,BTK,target,acalabrutinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CLL first-line + R/R,Second-gen BTK inhibitor — improved selectivity / tolerability; ELEVATE-RR/TN,PMID:34358457
+CLL,,BTK,target,zanubrutinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CLL first-line + R/R,Second-gen BTK inhibitor — SEQUOIA / ALPINE trials,PMID:36791211
+CLL,,BTK,target,pirtobrutinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R CLL after covalent BTK-i,Non-covalent BTK-i — overcomes C481 resistance; BRUIN,PMID:37099297
+CLL,,BCL2,target,venetoclax,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CLL first-line + R/R,BCL2 inhibitor — ven+obinutuzumab (CLL14) or ven+ibrutinib (CAPTIVATE),PMID:30864090
+CLL,,MS4A1,target,obinutuzumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,previously untreated CLL,Anti-CD20 type II — replaces rituximab in several CLL regimens; CLL11,PMID:24631112
+MCL,,CCND1,biomarker,,,,,,,,t(11;14) CCND1-IGH — pathognomonic for MCL; cyclin D1 overexpression,PMID:9500537
+MCL,,SOX11,biomarker,,,,,,,,Expressed in ~95% MCL — defines classical MCL; distinguishes from CLL,PMID:20554603
+MCL,,TP53,biomarker,,,,,,,,Mutation / del(17p) — blastoid variant; chemorefractory,PMID:28035779
+MCL,,BTK,target,ibrutinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,R/R MCL,BTK inhibitor — first-line MCL after chemo; LYM-3002,PMID:23782157
+MCL,,BTK,target,acalabrutinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R MCL,Second-gen BTK-i — more selective; approval basis ACE-LY-004,PMID:29126709
+MCL,,BTK,target,zanubrutinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R MCL,Second-gen BTK-i — approved 2019,PMID:31492771
+MCL,,CD19,target,brexucabtagene autoleucel (brexu-cel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R MCL,CD19 CAR-T — approved 2020; ZUMA-2 trial,PMID:32726532
+MCL,,BCL2,target,venetoclax,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R MCL,"BCL2 inhibitor — activity in R/R MCL, especially with ibrutinib combo",PMID:30275128
+HL,,TNFRSF8,biomarker,,,,,,,,CD30 — Reed-Sternberg / Hodgkin lineage; brentuximab-vedotin target,PMID:21128251
+HL,,PDCD1LG2,biomarker,,,,,,,,PD-L2 — commonly amplified 9p24.1 in cHL with PD-L1 co-amp,PMID:27391691
+HL,,CD274,biomarker,,,,,,,,PD-L1 — 9p24.1 amplification characteristic of cHL; IO sensitivity,PMID:27391691
+HL,,TNFRSF8,target,brentuximab vedotin,ADC,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CD30+ Hodgkin + PTCL,Anti-CD30 MMAE ADC — first-line AVD (ECHELON-1) + R/R,PMID:28636853
+HL,,PDCD1,target,nivolumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R classic Hodgkin,Anti-PD1 — CheckMate-205; approved R/R cHL,PMID:25482239
+HL,,PDCD1,target,pembrolizumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R classic Hodgkin,Anti-PD1 — KEYNOTE-204 (vs brentuximab),PMID:34264741
+B_ALL,,CD19,biomarker,,,,,,,,Pan-B-cell surface — blinatumomab + tisa-cel epitope; near-universal in B-ALL,PMID:25795067
+B_ALL,,CD22,biomarker,,,,,,,,Pan-B-cell surface — inotuzumab / moxetumomab epitope,PMID:27959700
+B_ALL,,CD20,biomarker,,,,,,,,Variable expression in B-ALL — rituximab candidate in CD20+ subset,PMID:26919009
+B_ALL,,BCR,biomarker,,,,,,,,BCR-ABL1 (Philadelphia chromosome) — TKI-eligible subset (~25% adult),PMID:26183700
+B_ALL,,BCR,target,imatinib + chemo,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,Ph+ (BCR-ABL1) B-ALL,First-gen BCR-ABL TKI — added to induction for Ph+ B-ALL,PMID:16837215
+B_ALL,,BCR,target,ponatinib + chemo,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,Ph+ B-ALL (incl T315I),Third-gen BCR-ABL TKI — active against T315I; PhALLCON trial,PMID:37917421
+B_ALL,,CD19,target,blinatumomab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R B-ALL + MRD+ B-ALL,CD19 x CD3 BiTE — approved 2014 R/R; 2018 MRD+ setting,PMID:25795067
+B_ALL,,CD19,target,tisagenlecleucel (tisa-cel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R pediatric / young adult B-ALL,CD19 CAR-T — first-of-kind FDA approval 2017,PMID:28562253
+B_ALL,,CD19,target,brexucabtagene autoleucel (brexu-cel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R adult B-ALL,CD19 CAR-T — approved 2021; ZUMA-3 trial,PMID:34214213
+B_ALL,,CD22,target,inotuzumab ozogamicin,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R B-ALL,CD22 calicheamicin ADC — approved 2017; INO-VATE trial,PMID:27386334
+OS,,RB1,biomarker,,,,,,,,Loss (~50%) — tumor suppressor; germline RB1 loss predisposes to OS,PMID:29156804
+OS,,TP53,biomarker,,,,,,,,Mutation / Li-Fraumeni germline — ubiquitous driver,PMID:29156804
+OS,,ATRX,biomarker,,,,,,,,Loss — ALT telomere-maintenance phenotype,PMID:29156804
+OS,,MDM2,biomarker,,,,,,,,Amplification in parosteal OS variant — MDM2-p53 axis,PMID:24909179
+OS,,CDK4,biomarker,,,,,,,,Co-amplified with MDM2 in parosteal OS; palbociclib rationale,PMID:24909179
+OS,,RUNX2,biomarker,,,,,,,,Osteoblast master TF — lineage marker; retained in OS tumors,PMID:29156804
+OS,,COL1A1,biomarker,,,,,,,,Osteoid matrix production — tumor-intrinsic (not TME) in OS,PMID:29156804
+OS,,GD2_SYN,biomarker,,,,,,,,ST8SIA1 encodes GD2 synthase — variable surface GD2 expression,PMID:34648686
+OS,,B4GALNT1,target,dinutuximab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced / metastatic OS,Anti-GD2 — AOST1421 trial; active in subset,PMID:34648686
+OS,,ERBB2,target,trastuzumab deruxtecan,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HER2-expressing OS,Trastuzumab + chemo backbone trials in HER2+ OS,PMID:22271477
+OS,,IGF1R,target,ganitumab + chemo,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,metastatic OS,IGF1R inhibitor — SARC021 + AEWS1221 trials,PMID:32762005
+OS,,VEGFA,target,cabozantinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R OS,CABONE / CABOSARC trials — activity documented,PMID:33008784
+EWS,,EWSR1,biomarker,,,,,,,,EWSR1 fusion partner — defines Ewing family; translocation partner FLI1 (most) / ERG (~10%),PMID:26009011
+EWS,,FLI1,biomarker,,,,,,,,EWSR1-FLI1 fusion — pathognomonic; EWS master driver,PMID:26009011
+EWS,,ERG,biomarker,,,,,,,,EWSR1-ERG fusion in ~10% — alternative to FLI1; indistinguishable clinically,PMID:26009011
+EWS,,CD99,biomarker,,,,,,,,MIC2 — diffuse membrane IHC; diagnostic for Ewing,PMID:2185739
+EWS,,NKX2-2,biomarker,,,,,,,,Downstream EWS-FLI1 target; diagnostic IHC,PMID:18812539
+EWS,,STAG2,biomarker,,,,,,,,Recurrent loss in Ewing — cohesin complex; poor prognosis subset,PMID:24814251
+EWS,,IGF1R,target,ganitumab,antibody,phase_3,late_clinical,late_clinical,late-clinical follow-up; confirm trial or local availability,high-risk EWS,AEWS1221 phase 3 — IGF1R inhibitor + VDC/IE in high-risk EWS,PMID:32762005
+EWS,,ERG,target,TK216,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R EWS,EWS-FLI1 direct inhibitor (small molecule) — phase 2 trials,PMID:33712479
+EWS,,KDM1A,target,seclidemstat,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R Ewing,LSD1 inhibitor — EWS-FLI1-dependent program,PMID:29438748
+EWS,,PRAME,target,IMA203,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,PRAME+ HLA-A*02+ Ewing,PRAME-directed TCR-T in EWS-expressing samples,PMID:38197793
+RMS_ERMS,,MYOD1,biomarker,,,,,,,,Myogenic regulatory factor — embryonal skeletal-muscle program; diagnostic IHC,PMID:22290179
+RMS_ERMS,,MYOG,biomarker,,,,,,,,Myogenin — downstream MYOD1; focal IHC pattern (vs diffuse in ARMS),PMID:22290179
+RMS_ERMS,,DES,biomarker,,,,,,,,Desmin — skeletal-muscle lineage IHC,PMID:22290179
+RMS_ERMS,,NRAS,biomarker,,,,,,,,Recurrent activating mutation in ERMS — RAS-pathway driver,PMID:24703002
+RMS_ERMS,,TYMS,target,vincristine + actinomycin + cyclophosphamide (VAC),small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,ERMS first-line,VAC is pediatric RMS chemotherapy backbone — IRS/COG trials,PMID:19901112
+RMS_ARMS,,FOXO1,biomarker,,,,,,,,PAX3-FOXO1 or PAX7-FOXO1 fusion — pathognomonic for fusion-positive RMS,PMID:19901112
+RMS_ARMS,,PAX3,biomarker,,,,,,,,Majority PAX3-FOXO1 variant — worst prognosis,PMID:19901112
+RMS_ARMS,,PAX7,biomarker,,,,,,,,PAX7-FOXO1 variant — better prognosis than PAX3,PMID:19901112
+RMS_ARMS,,MYOG,biomarker,,,,,,,,Diffuse myogenin IHC (vs focal in ERMS) — diagnostic,PMID:22290179
+RMS_ARMS,,FGFR4,biomarker,,,,,,,,Recurrent activating mutation in fusion-negative RMS — erdafitinib candidate,PMID:24703002
+RMS_ARMS,,FGFR4,target,erdafitinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,FGFR4-mut fusion-neg RMS,FGFR-selective TKI — activity in FGFR-altered tumors,PMID:31378236
+WILMS,,WT1,biomarker,,,,,,,,Wilms tumor gene — recurrent loss; metanephric lineage,PMID:18612257
+WILMS,,CTNNB1,biomarker,,,,,,,,Activating mutation — Wnt pathway; co-occurs with WT1 mutation,PMID:18612257
+WILMS,,AMER1,biomarker,,,,,,,,Loss — Wnt-pathway component; recurrent,PMID:18612257
+WILMS,,TP53,biomarker,,,,,,,,Anaplastic variant — poor prognosis; chemo-resistant,PMID:15044706
+WILMS,,DROSHA,biomarker,,,,,,,,Recurrent mutation — miRNA biogenesis; WT-specific,PMID:24909177
+WILMS,,DGCR8,biomarker,,,,,,,,Recurrent mutation — miRNA biogenesis; WT-specific,PMID:24909177
+WILMS,,TYMS,target,vincristine + actinomycin + doxorubicin,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,favorable-histology Wilms,COG / SIOP chemo backbone — risk-stratified intensity,PMID:23965906
+NBL,,MYCN,biomarker,,,,,,,,Amplification — defines high-risk NBL; single strongest prognostic biomarker,PMID:3822889
+NBL,,ALK,biomarker,,,,,,,,Activating mutation or amplification — ~10% NBL; crizotinib / lorlatinib rationale,PMID:18724361
+NBL,,ATRX,biomarker,,,,,,,,Loss — ALT phenotype; older-age NBL subset,PMID:22367537
+NBL,,PHOX2B,biomarker,,,,,,,,Sympathetic-nervous-system lineage TF — pan-NBL IHC,PMID:16636671
+NBL,,TH,biomarker,,,,,,,,Tyrosine hydroxylase — catecholamine synthesis; neuroblastic IHC,PMID:16636671
+NBL,,B4GALNT1,biomarker,,,,,,,,GD2 synthase — surface GD2 near-universal in NBL,PMID:21045144
+NBL,,B4GALNT1,target,dinutuximab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,high-risk NBL,Anti-GD2 + GM-CSF / IL2 — approved first-line maintenance,PMID:20879881
+NBL,,B4GALNT1,target,naxitamab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R high-risk NBL (bone / marrow),Anti-GD2 humanized — approved 2020,PMID:34380744
+NBL,,ALK,target,lorlatinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,ALK-mut NBL,Third-gen ALK TKI — NANT trial in R/R ALK-altered NBL,PMID:34480566
+NBL,,ALK,target,crizotinib,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,ALK-mut NBL,First-gen ALK TKI — pediatric trials in ALK-altered NBL,PMID:21926007
+NBL,,MYCN,target,aurora A kinase inhibitors,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,MYCN-amp NBL,Aurora-A stabilises MYCN — alisertib / LY3295668 trials,PMID:29514830
+MBL,,MYC,biomarker,,,,,,,,Amplification — defines Group 3 MBL; worst prognosis,PMID:22265402
+MBL,,MYCN,biomarker,,,,,,,,Amplification — subset of Group 4 + SHH-TP53-mut MBL,PMID:22265402
+MBL,,CTNNB1,biomarker,,,,,,,,Activating mutation — WNT subgroup; best prognosis,PMID:22265402
+MBL,,PTCH1,biomarker,,,,,,,,Germline or somatic loss — SHH subgroup; vismodegib candidate,PMID:22265402
+MBL,,SMO,biomarker,,,,,,,,Activating mutation — SHH subgroup; vismodegib target,PMID:22265402
+MBL,,TP53,biomarker,,,,,,,,Germline (Li-Fraumeni) — SHH subgroup high-risk anaplastic variant,PMID:24493713
+MBL,,SMO,target,vismodegib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,SHH-subgroup MBL,Smoothened inhibitor — SHH-specific activity; limited pediatric approval,PMID:24493713
+MBL,,TYMS,target,cisplatin + CCNU + vincristine,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,newly-diagnosed MBL,Standard-risk / high-risk backbone — Packer regimen,PMID:16614307
+ATRT,,SMARCB1,biomarker,,,,,,,,Biallelic loss — pathognomonic for ATRT (and non-CNS RT),PMID:21062906
+ATRT,,VIM,biomarker,,,,,,,,Mesenchymal marker — frequently expressed in rhabdoid tumors,PMID:21062906
+ATRT,,EZH2,target,tazemetostat,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R SMARCB1-deficient ATRT,EZH2 inhibitor — SMARCB1-loss synthetic-lethal; pediatric trials,PMID:32750541
+ATRT,,TYMS,target,intensive chemo + radiation,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,newly-diagnosed ATRT,Multi-agent pediatric regimens — no single-agent backbone,PMID:25825194
+RB,,RB1,biomarker,,,,,,,,Biallelic inactivation — defines retinoblastoma; germline or somatic,PMID:12399767
+RB,,MYCN,biomarker,,,,,,,,Amplification in rare RB1-wildtype variant — distinct entity,PMID:24606874
+RB,,TYMS,target,intra-arterial melphalan,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced unilateral RB (globe salvage),Intra-arterial chemotherapy — globe-preservation standard,PMID:24030949
+RB,,TYMS,target,carboplatin + etoposide + vincristine,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,bilateral / recently-diagnosed RB,Systemic chemoreduction — first-line bilateral RB,PMID:19289752
+HEPB,,CTNNB1,biomarker,,,,,,,,Activating mutation — Wnt-pathway driver in ~70% hepatoblastoma,PMID:24691097
+HEPB,,AFP,biomarker,,,,,,,,Alpha-fetoprotein — near-universal serum elevation in hepatoblastoma,PMID:24691097
+HEPB,,TP53,biomarker,,,,,,,,Rare in HEPB — high-risk subset; hepatocellular carcinoma overlap,PMID:24691097
+HEPB,,TYMS,target,cisplatin + doxorubicin (PLADO),small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,newly-diagnosed HEPB,International cooperative backbone — SIOPEL / COG regimens,PMID:28445040
+PANNET,,MEN1,biomarker,,,,,,,,Most common driver — ~45% panNETs; MEN1 syndrome predisposition,PMID:28280049
+PANNET,,ATRX,biomarker,,,,,,,,Loss — ALT phenotype; associated with larger tumors / worse prognosis,PMID:28280049
+PANNET,,DAXX,biomarker,,,,,,,,Loss — alternative to ATRX; ALT/chromatin axis,PMID:28280049
+PANNET,,MTOR,biomarker,,,,,,,,Pathway activation frequent — everolimus rationale,PMID:21306238
+PANNET,,CHGA,biomarker,,,,,,,,Chromogranin A — serum marker + NE lineage IHC,PMID:26398321
+PANNET,,SYP,biomarker,,,,,,,,Synaptophysin — NE lineage IHC,PMID:26398321
+PANNET,,SSTR2,biomarker,,,,,,,,Somatostatin receptor 2 — octreotide / 177Lu-DOTATATE target,PMID:28185094
+PANNET,,SSTR2,target,octreotide long-acting,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced panNET,Somatostatin analog — first-line antiproliferative,PMID:19726064
+PANNET,,SSTR2,target,lanreotide,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced panNET,Somatostatin analog — CLARINET trial; PFS benefit,PMID:25014687
+PANNET,,SSTR2,target,[177Lu]Lu-DOTA-TATE,radioligand,approved,approved_later_line,later_line_approved,confirm imaging/eligibility and prior-line requirements,SSTR2+ advanced GEP-NET,NETTER-1 — first approved radioligand therapy,PMID:28076709
+PANNET,,MTOR,target,everolimus,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced panNET,mTOR inhibitor — RADIANT-3; PFS benefit,PMID:21306238
+PANNET,,VEGFA,target,sunitinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced panNET,VEGFR/PDGFR TKI — approved 2011; PFS benefit,PMID:21306235
+MID_NET,,CHGA,biomarker,,,,,,,,Chromogranin A — serum marker in midgut carcinoid,PMID:26398321
+MID_NET,,SYP,biomarker,,,,,,,,Synaptophysin — NE lineage IHC,PMID:26398321
+MID_NET,,SSTR2,biomarker,,,,,,,,Somatostatin receptor 2 — defining for octreoscan / 177Lu-DOTATATE eligibility,PMID:28185094
+MID_NET,,TPH1,biomarker,,,,,,,,Tryptophan hydroxylase — serotonin synthesis enzyme; carcinoid-specific,PMID:25538161
+MID_NET,,SSTR2,target,octreotide long-acting,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,midgut carcinoid (carcinoid syndrome + antiproliferative),First-line for functional and nonfunctional midgut NETs,PMID:19726064
+MID_NET,,SSTR2,target,[177Lu]Lu-DOTA-TATE,radioligand,approved,approved_later_line,later_line_approved,confirm imaging/eligibility and prior-line requirements,SSTR2+ advanced midgut NET,NETTER-1 — approved for progressive midgut NETs,PMID:28076709
+MID_NET,,TPH1,target,telotristat ethyl,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,carcinoid syndrome diarrhea,Oral inhibitor of TPH — approved 2017 for carcinoid-syndrome diarrhea,PMID:28444947
+LUNG_NET_LC,,CHGA,biomarker,,,,,,,,Chromogranin A — serum + IHC; lung carcinoid diagnostic,PMID:26398321
+LUNG_NET_LC,,SYP,biomarker,,,,,,,,Synaptophysin — NE lineage,PMID:26398321
+LUNG_NET_LC,,SSTR2,biomarker,,,,,,,,Somatostatin receptor 2 — octreotide-scan positivity,PMID:28185094
+LUNG_NET_LC,,MEN1,biomarker,,,,,,,,MEN1 loss — subset of atypical lung carcinoid,PMID:24584669
+LUNG_NET_LC,,SSTR2,target,octreotide long-acting,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced well-differentiated lung NET,Antiproliferative + symptom control,PMID:19726064
+LUNG_NET_LC,,MTOR,target,everolimus,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced well-differentiated lung NET,RADIANT-4 — approved 2016 for non-functional NETs incl lung,PMID:26703889
+MEC,,TNFRSF9,biomarker,,,,,,,,Merkel cell lineage — CK20-positive perinuclear dot-like IHC characteristic,PMID:17189037
+MEC,,CD274,biomarker,,,,,,,,PD-L1 expression — predictive for avelumab response,PMID:27093365
+MEC,,CHGA,biomarker,,,,,,,,Chromogranin A — NE lineage; diffuse in MEC,PMID:17189037
+MEC,,SYP,biomarker,,,,,,,,Synaptophysin — NE lineage,PMID:17189037
+MEC,,PDCD1,target,avelumab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,metastatic Merkel cell carcinoma,Anti-PD-L1 — JAVELIN-200; approved 2017; first MEC IO approval,PMID:27093365
+MEC,,PDCD1,target,pembrolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced MEC,Anti-PD1 — approved in first-line MEC,PMID:31158039
+MEC,,PDCD1,target,nivolumab + ipilimumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced MEC,Combination IO — improved responses in IO-refractory subset,PMID:30242127
+MTC,,RET,biomarker,,,,,,,,Germline (MEN2A/B) or somatic RET mutation — driver; gates selpercatinib/pralsetinib,PMID:23590294
+MTC,,CALCA,biomarker,,,,,,,,Calcitonin — diagnostic + treatment-response serum marker,PMID:24488796
+MTC,,CEACAM5,biomarker,,,,,,,,CEA — adjunct serum marker; prognostic when calcitonin elevated,PMID:24488796
+MTC,,CHGA,biomarker,,,,,,,,Chromogranin A — NE lineage; universal in MTC,PMID:26398321
+MTC,,RET,target,selpercatinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RET-mut metastatic MTC,Selective RET TKI — LIBRETTO-531; approved 2020,PMID:32846062
+MTC,,RET,target,pralsetinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,RET-mut metastatic MTC,Selective RET TKI — approved 2020; ARROW trial,PMID:33534865
+MTC,,VEGFA,target,cabozantinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced metastatic MTC,Multi-TKI (incl RET) — approved pre-selective era; EXAM trial,PMID:24092931
+MTC,,VEGFA,target,vandetanib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,symptomatic advanced MTC,Multi-TKI — ZETA trial; first approved MTC-specific agent,PMID:22331954
+NPC,,EBV_LMP1,biomarker,,,,,,,,EBV-encoded — near-universal in endemic NPC; distinguishes from HNSC,PMID:27832553
+NPC,,EBV_BZLF1,biomarker,,,,,,,,Lytic-phase marker — EBV-reactivation axis,PMID:27832553
+NPC,,CD274,biomarker,,,,,,,,PD-L1 — elevated in NPC tumor + immune infiltrate; IO-sensitive,PMID:30249639
+NPC,,PDCD1,target,toripalimab + gemcitabine/cisplatin,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,recurrent/metastatic NPC,JUPITER-02 — approved 2023 first-line; anti-PD1,PMID:34516835
+NPC,,PDCD1,target,tislelizumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R NPC,RATIONALE-309 — approved in NPC 2023,PMID:36933560
+NPC,,PDCD1,target,pembrolizumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R NPC,Basket approval PD-L1+ solid tumors; KEYNOTE-122,PMID:32163866
+ACINIC,,BCL6,biomarker,,,,,,,,Translocation (ACIN) — MSA-B family marker; salivary acinic carcinoma,PMID:26811196
+ACINIC,,DOG1,biomarker,,,,,,,,Anoctamin 1 — distinctive IHC for acinic cell carcinoma,PMID:19820346
+ACINIC,,NR4A3,biomarker,,,,,,,,HTN3-MSANTD3 fusion → NR4A3 overexpression; diagnostic for ACC variant,PMID:30980744
+ACINIC,,TYMS,target,carboplatin + paclitaxel,small_molecule,off_label,off_label,off_label,off-label follow-up; confirm rationale and alternatives,advanced acinic cell carcinoma,Rarely needed — mostly indolent; reserved for high-grade transformed variant,PMID:25974463
+ADCC,,MYB,biomarker,,,,,,,,MYB-NFIB translocation — pathognomonic for adenoid cystic carcinoma (~60%),PMID:20093190
+ADCC,,NFIB,biomarker,,,,,,,,MYB-NFIB fusion — more rarely MYBL1-NFIB,PMID:24002401
+ADCC,,NOTCH1,biomarker,,,,,,,,Recurrent activating mutation — subset has aggressive phenotype + NOTCH-inhibitor rationale,PMID:27149988
+ADCC,,KIT,biomarker,,,,,,,,Near-universal expression — historically imatinib trialed (largely negative),PMID:17762320
+ADCC,,MYB,target,brontictuzumab,antibody,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NOTCH1-mut ADCC,Anti-NOTCH1 monoclonal — limited activity; high-toxicity,PMID:31064789
+ADCC,,FGF2,target,lenvatinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced ADCC,Multikinase TKI — modest activity in advanced ADCC,PMID:30496135
+CHOR,,T,biomarker,,,,,,,,Brachyury (TBXT) — pathognomonic for chordoma; defining nuclear IHC,PMID:18094074
+CHOR,,CDKN2A,biomarker,,,,,,,,Frequent homozygous deletion — prognostic,PMID:24509719
+CHOR,,LYST,biomarker,,,,,,,,Recurrent loss — subset of chordoma,PMID:30266954
+CHOR,,EGFR,target,erlotinib / gefitinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced chordoma,EGFR inhibitors — activity observed in subset; small series,PMID:21775476
+CHOR,,PDGFRB,target,imatinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced chordoma,Case reports + small series of durable responses in PDGFR-expressing chordoma,PMID:15751962
+CHOR,,T,target,brachyury vaccine,vaccine,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,resectable chordoma,GI-6301 brachyury yeast vaccine — immunotherapy trials,PMID:29391359
+CHON,,IDH1,biomarker,,,,,,,,Recurrent mutation in conventional chondrosarcoma — driver; potential ivosidenib-eligible,PMID:22057233
+CHON,,IDH2,biomarker,,,,,,,,Recurrent mutation; complementary to IDH1; enasidenib rationale,PMID:22057233
+CHON,,EXT1,biomarker,,,,,,,,Germline inactivation — hereditary multiple exostoses + secondary chondrosarcoma risk,PMID:19255577
+CHON,,EXT2,biomarker,,,,,,,,Germline inactivation — hereditary multiple exostoses,PMID:19255577
+CHON,,COL2A1,biomarker,,,,,,,,Mutation in small subset; cartilage-lineage driver in hereditary enchondromatosis,PMID:21643004
+CHON,,HEY1,biomarker,,,,,,,,HEY1-NCOA2 fusion — defining for mesenchymal chondrosarcoma variant,PMID:22836606
+CHON,,IDH1,target,ivosidenib,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,IDH1-mut advanced chondrosarcoma,Selective IDH1 inhibitor — activity in IDH1-R132 chondrosarcoma subset,PMID:32679069
+CHON,,VEGFA,target,pazopanib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced chondrosarcoma,VEGFR multi-TKI — modest PFS benefit; pan-sarcoma data,PMID:22749852
+BL,,MYC,biomarker,,,,,,,,"Defining oncogene — t(8;14) IGH-MYC (~80%), t(2;8) or t(8;22) variants; drives aggressive proliferation",PMID:16760443
+BL,,MS4A1,biomarker,,,,,,,,CD20 — B-cell lineage; rituximab target,PMID:11807147
+BL,,CD79A,biomarker,,,,,,,,B-cell receptor — BCR pathway component,PMID:19194475
+BL,,BCL6,biomarker,,,,,,,,Germinal-center B-cell transcription factor — Burkitt cell of origin,PMID:14688368
+BL,,TP53,biomarker,,,,,,,,Frequently mutated (~40%); high-risk in HIV-associated BL,PMID:22343534
+BL,,MS4A1,target,rituximab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,BL (DA-EPOCH-R),Anti-CD20 — standard of care with DA-EPOCH chemo backbone,PMID:32356518
+BL,,CD19,target,tisagenlecleucel,CAR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R BL (pediatric),CD19 CAR-T — pediatric R/R BL activity in JULIET / ELIANA follow-ups,PMID:29262281
+BL,,CD22,target,inotuzumab ozogamicin,ADC,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R BL,CD22 ADC — activity in R/R BCR signaling B-cell lymphomas including BL,PMID:22431578
+FL,,MS4A1,biomarker,,,,,,,,CD20 — germinal-center B-cell; anti-CD20 backbone of FL therapy,PMID:18836437
+FL,,BCL2,biomarker,,,,,,,,t(14;18) IGH-BCL2 (~85%) — defining cytogenetic — anti-apoptotic driver,PMID:15033871
+FL,,BCL6,biomarker,,,,,,,,Germinal-center TF; retained in FL vs lost in transformed aggressive variants,PMID:11432899
+FL,,CD10,biomarker,,,,,,,,MME — germinal-center marker; differentiates FL from other B-NHLs,PMID:11432899
+FL,,EZH2,biomarker,,,,,,,,Gain-of-function mutations (~25%); tazemetostat-sensitive subset,PMID:30692609
+FL,,MS4A1,target,rituximab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,FL (first-line maintenance + R/R),"Anti-CD20 — R-bendamustine / R-CHOP backbone, rituximab maintenance extends PFS",PMID:21890466
+FL,,MS4A1,target,obinutuzumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,FL (R/R rituximab-refractory),Type-2 anti-CD20 — GADOLIN trial in rituximab-refractory FL,PMID:27686830
+FL,,EZH2,target,tazemetostat,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R EZH2-mutant FL,EZH2 inhibitor — approved 2020; response enriched in EZH2-mutant subset,PMID:33035457
+FL,,MS4A1,target,mosunetuzumab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R FL (≥2 prior lines),CD20xCD3 bispecific — approved 2022; GO29781 trial,PMID:36463577
+FL,,MS4A1,target,epcoritamab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R FL,CD20xCD3 bispecific — EPCORE NHL-1 trial,PMID:37192387
+FL,,CD19,target,axicabtagene ciloleucel (axi-cel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R FL,CD19 CAR-T — ZUMA-5 trial; approved 2021,PMID:35045297
+FL,,CD19,target,lisocabtagene maraleucel (liso-cel),CAR-T,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R FL,CD19 CAR-T — TRANSCEND FL trial,PMID:37125909
+HCL,,BRAF,biomarker,,,,,,,,V600E mutation — pathognomonic for classical HCL; ~100% of cases,PMID:21666225
+HCL,,CD20,biomarker,,,,,,,,Strong B-cell surface expression — rituximab target,PMID:22689687
+HCL,,CD22,biomarker,,,,,,,,B-cell surface — moxetumomab pasudotox target,PMID:30093631
+HCL,,CD25,biomarker,,,,,,,,IL2RA — characteristic of classical HCL (vs HCL-v which is CD25-),PMID:22689687
+HCL,,BRAF,target,vemurafenib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R classical HCL,BRAF V600E inhibitor — FDA approved 2024 for R/R HCL after purine analogs,PMID:26352686
+HCL,,BRAF,target,dabrafenib + trametinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R HCL,BRAF + MEK combo — clinical trial data in purine-analog refractory cases,PMID:35404892
+HCL,,CD22,target,moxetumomab pasudotox,ADC,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R classical HCL,CD22 immunotoxin — approved 2018 for multiply-relapsed HCL,PMID:30093631
+CML,,BCR,biomarker,,,,,,,,BCR-ABL1 fusion — t(9;22) Philadelphia chromosome; pathognomonic for CML,PMID:10086668
+CML,,ABL1,biomarker,,,,,,,,Kinase domain of BCR-ABL1 fusion — T315I mutation confers resistance to 1st/2nd-gen TKIs,PMID:11337484
+CML,,ABL1,target,imatinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CML chronic phase,First-gen BCR-ABL TKI — first-line standard since 2001; IRIS trial,PMID:12637609
+CML,,ABL1,target,dasatinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CML first-line or imatinib-resistant,Second-gen BCR-ABL TKI — DASISION trial,PMID:20525993
+CML,,ABL1,target,nilotinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,CML first-line or imatinib-resistant,Second-gen BCR-ABL TKI — ENESTnd trial,PMID:20525997
+CML,,ABL1,target,bosutinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,CML R/R or intolerant to imatinib,Second-gen BCR-ABL TKI — approved 2012,PMID:22829185
+CML,,ABL1,target,ponatinib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,T315I-mutant or multi-TKI-refractory CML,Third-gen BCR-ABL TKI — only approved agent with T315I activity,PMID:23770846
+CML,,ABL1,target,asciminib,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R CML including T315I,STAMP inhibitor — myristoyl-pocket allosteric inhibitor; approved 2021,PMID:34407557
+SCLC,,DLL3,biomarker,,,,,,,,NOTCH ligand — overexpressed on SCLC; low in normal tissues except testis/brain,PMID:26330465
+SCLC,,ASCL1,biomarker,,,,,,,,Subtype-defining TF — SCLC-A predominant subtype (Rudin 2019),PMID:30804526
+SCLC,,NEUROD1,biomarker,,,,,,,,Subtype-defining TF — SCLC-N subtype,PMID:30804526
+SCLC,,POU2F3,biomarker,,,,,,,,Subtype-defining TF — SCLC-P tuft-cell-like variant,PMID:30804526
+SCLC,,YAP1,biomarker,,,,,,,,Subtype-defining TF — SCLC-Y inflammatory variant,PMID:30804526
+SCLC,,TP53,biomarker,,,,,,,,Near-universal loss (~90%) — smoker-associated LoF,PMID:26168399
+SCLC,,RB1,biomarker,,,,,,,,Near-universal loss (~90%) alongside TP53 — biallelic inactivation defines SCLC,PMID:26168399
+SCLC,,DLL3,target,tarlatamab,bispecific,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R SCLC (≥2 prior lines),DLL3xCD3 bispecific — approved 2024; DeLLphi-301 trial,PMID:37830521
+SCLC,,TOP1,target,lurbinectedin,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R SCLC,Transcription-inhibitor alkylator — accelerated approval 2020,PMID:32622651
+SCLC,,TOP1,target,topotecan,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,R/R SCLC,TOP1 inhibitor — standard second-line SCLC chemo,PMID:16880325
+SCLC,,CD274,target,atezolizumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,ES-SCLC first-line (+ chemo),Anti-PD-L1 — IMpower133; first chemo-IO approval in SCLC,PMID:30280641
+SCLC,,CD274,target,durvalumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,ES-SCLC first-line (+ chemo),Anti-PD-L1 — CASPIAN trial,PMID:31590988
+T_ALL,,CD7,biomarker,,,,,,,,T-cell surface — broadly expressed on T-ALL blasts; CAR-T target,PMID:30020014
+T_ALL,,NOTCH1,biomarker,,,,,,,,Activating mutation (~60%) — HES1/MYC axis driver,PMID:15472075
+T_ALL,,FBXW7,biomarker,,,,,,,,Co-occurs with NOTCH1 — sensitizes to γ-secretase inhibitors in preclinical,PMID:17641202
+T_ALL,,TP53,biomarker,,,,,,,,Loss-of-function — high-risk relapsed T-ALL,PMID:24132215
+T_ALL,,CD7,target,WU-CART-007,CAR-T,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R T-ALL,Allogeneic CD7 CAR-T — early-phase data in R/R T-ALL,PMID:37523543
+T_ALL,,NT5E,target,nelarabine,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R T-ALL,Ara-G prodrug — selectively toxic to T-lineage blasts; approved 2005,PMID:16287964
+T_ALL,,CD38,target,daratumumab,antibody,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,R/R T-ALL (CD38+),Anti-CD38 — activity in CD38+ T-ALL per investigator trials,PMID:35316844
+CTCL,,CD4,biomarker,,,,,,,,Helper-T lineage; CTCL blasts are CD4+ CD26-,PMID:29997202
+CTCL,,DPP4,biomarker,,,,,,,,CD26 loss on CTCL blasts is diagnostic,PMID:29997202
+CTCL,,PTK7,biomarker,,,,,,,,Overexpressed on Sézary cells — cofetuzumab pelidotin target,PMID:28765115
+CTCL,,CCR4,biomarker,,,,,,,,Elevated on CTCL blasts — mogamulizumab target,PMID:30366567
+CTCL,,TNFRSF8,biomarker,,,,,,,,"CD30 — positive in ~50% CTCL cases, defines BV-eligible subset",PMID:28024975
+CTCL,,CCR4,target,mogamulizumab,antibody,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R mycosis fungoides / Sézary,Anti-CCR4 — approved 2018; MAVORIC trial,PMID:30366567
+CTCL,,TNFRSF8,target,brentuximab vedotin,ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,CD30+ CTCL,CD30 MMAE ADC — approved 2017; ALCANZA trial,PMID:28433508
+CTCL,,HDAC1,target,romidepsin,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R CTCL,Class-1 HDAC inhibitor — approved 2009,PMID:19451442
+CTCL,,HDAC1,target,vorinostat,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R CTCL,Pan-HDAC inhibitor — approved 2006,PMID:17227786
+SARC,MPNST,NF1,biomarker,,,,,,,,Biallelic NF1 loss drives constitutive RAS/MAPK signaling in MPNST (up to 50% NF1-associated; sporadic cases also NF1-null),PMID:37173835
+SARC,MPNST,CDKN2A,biomarker,,,,,,,,CDKN2A/B loss near-obligate in MPNST progression; marker of malignant transformation from plexiform NF,PMID:37173835
+SARC,MPNST,CDKN2B,biomarker,,,,,,,,Co-deleted with CDKN2A in MPNST,PMID:37173835
+SARC,MPNST,TP53,biomarker,,,,,,,,TP53 inactivation frequent in high-grade MPNST,PMID:37173835
+SARC,MPNST,SUZ12,biomarker,,,,,,,,PRC2 loss-of-function (SUZ12/EED) yields global H3K27me3 loss — diagnostically useful IHC correlate,PMID:24857941
+SARC,MPNST,EED,biomarker,,,,,,,,PRC2 loss-of-function partner of SUZ12 — global H3K27me3 loss,PMID:24857941
+SARC,MPNST,SMARCB1,biomarker,,,,,,,,SMARCB1 loss in a subset of MPNST (epithelioid variant); overlaps with epithelioid sarcoma biology,PMID:25348869
+SARC,MPNST,SOX10,biomarker,,,,,,,,Schwann-cell lineage confirmation — frequently retained in MPNST despite differentiation drift,PMID:37173835
+SARC,MPNST,S100B,biomarker,,,,,,,,Schwann-cell lineage marker; loss often accompanies high-grade / dedifferentiated MPNST,PMID:37173835
+SARC,MPNST,MEK1,target,trametinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,unresectable/metastatic NF1-associated MPNST,RAS-pathway dependency from NF1 loss; SARC031 trial investigating trametinib ± SHP2i,PMID:37173835
+SARC,MPNST,MEK1,target,selumetinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NF1-associated MPNST (investigational),FDA-approved for inoperable plexiform NF (the MPNST precursor); extending into MPNST trials,PMID:32029004
+SARC,MPNST,MDM2,target,brigimadlin (BI 907828),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,MDM2-amplified TP53-retained MPNST,MDM2 inhibition where TP53 wild-type preserved,PMID:35551194
+SARC,MPNST,EZH2,target,tazemetostat,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,PRC2-null / SMARCB1-null MPNST,Synthetic lethal with PRC2 loss; FDA-approved for epithelioid sarcoma (SMARCB1-null) precedent,PMID:32507290
+SARC,MPNST,PTPN11,target,SHP2 inhibitors (trials),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,RAS-driven MPNST (MEK-combo trials),SHP2 inhibition as MEK-resistance mitigator,PMID:37173835
+SARC,MPNST,BRD4,target,BET inhibitors (trials),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,MPNST (preclinical / early-phase),BRD4 dependency in PRC2-null contexts — synergy with MEK inhibition,PMID:29203800

--- a/pirlygenes/healthy_vs_tumor.py
+++ b/pirlygenes/healthy_vs_tumor.py
@@ -337,7 +337,7 @@ class TissueCompositionSignal:
         cohort_rho = self.top_tcga_cohorts[0][1] if self.top_tcga_cohorts else 0.0
         if self.cancer_hint == "healthy-dominant":
             return (
-                f"**⚠ Step-0 hint: healthy tissue dominant.** Sample profile "
+                f"**Step-0 hint: healthy tissue dominant.** Sample profile "
                 f"correlates with normal **{tissue_name}** (ρ={rho:.2f}) more "
                 f"than any TCGA cohort (best {cohort} ρ={cohort_rho:.2f}); "
                 f"proliferation panel quiet "

--- a/pirlygenes/load_dataset.py
+++ b/pirlygenes/load_dataset.py
@@ -40,7 +40,7 @@ def load_all_dataframes():
     the on-disk compression format.
     """
     for csv_path in get_all_csv_paths():
-        df = pd.read_csv(str(csv_path))
+        df = pd.read_csv(str(csv_path), low_memory=False)
         key = csv_path.name.removesuffix(".gz")
         yield key, df
 

--- a/pirlygenes/load_expression.py
+++ b/pirlygenes/load_expression.py
@@ -73,6 +73,31 @@ def _guess_col(columns, patterns):
 def _select_sample_rows(df, sample_id_col=None, sample_id_value=None, verbose=True):
     if sample_id_col is None and sample_id_value is None:
         return df
+    if sample_id_col is None and sample_id_value is not None:
+        sample_col = str(sample_id_value)
+        if sample_col not in df.columns:
+            available = sorted(str(col) for col in df.columns)
+            if len(available) > 8:
+                available_preview = available[:8] + ["..."]
+            else:
+                available_preview = available
+            raise ValueError(
+                f"Sample value {sample_id_value!r} was provided without "
+                f"sample_id_col, but no matching expression column was found; "
+                f"available columns include: {available_preview}"
+            )
+        keep = [
+            col
+            for col in df.columns
+            if col == sample_col
+            or re.search(r"(^|[_\s])gene([_\s]?id|[_\s]?name)?$", str(col), re.IGNORECASE)
+            or str(col).lower() in {"gene", "symbol", "ensembl_gene_id"}
+        ]
+        out = df.loc[:, keep].copy()
+        out = out.rename(columns={sample_col: "TPM"})
+        if verbose:
+            print(f"[load] Selected wide expression column {sample_col!r} as TPM")
+        return out
     if not sample_id_col or sample_id_value is None:
         raise ValueError(
             "Both sample_id_col and sample_id_value must be provided to select a sample"
@@ -250,6 +275,46 @@ def _detect_and_convert_to_tpm(df, verbose=True):
             if verbose:
                 print(f"[load] Converted FPKM column '{fpkm_col}' to TPM (sum was {total:.0f})")
     return df
+
+
+def _detect_kallisto_gene_abundance_tpm(df, verbose=True):
+    """Normalize kallisto/BostonGene gene_abundance.tsv TPM naming.
+
+    Some kallisto-derived gene-level tables call the TPM-like value
+    ``abundance`` and carry ``counts`` + ``length`` beside it. Treat that
+    exact shape as a TPM input, while avoiding broad "abundance" guesses in
+    unrelated tables.
+    """
+    if "TPM" in set(df.columns) or "abundance" not in set(df.columns):
+        return df
+    lower_cols = {str(col).lower() for col in df.columns}
+    if not {"counts", "length"}.issubset(lower_cols):
+        return df
+    if verbose:
+        print("[load] Auto-detected kallisto gene-level 'abundance' column as TPM")
+    return df.rename(columns={"abundance": "TPM"})
+
+
+def _normalize_bostongene_gene_columns(df, verbose=True):
+    """Normalize BostonGene/kallisto gene-level column naming.
+
+    Their ``gene_abundance.tsv`` has ``gene_name`` = symbol and ``gene`` =
+    Ensembl gene ID. The generic aliases otherwise treat ``gene`` as the
+    symbol and lose the Ensembl IDs.
+    """
+    if not {"gene_name", "gene"}.issubset(set(df.columns)):
+        return df
+    if "ensembl_gene_id" in set(df.columns):
+        return df
+    gene_values = df["gene"].dropna().astype(str)
+    if gene_values.empty:
+        return df
+    ensg_fraction = gene_values.str.startswith("ENSG").mean()
+    if ensg_fraction < 0.5:
+        return df
+    if verbose:
+        print("[load] Auto-detected BostonGene gene_name/gene columns")
+    return df.rename(columns={"gene": "ensembl_gene_id", "gene_name": "gene"})
 
 
 def _first_non_empty(series):
@@ -738,9 +803,11 @@ def load_expression_data(
         sample_id_value=sample_id_value,
         verbose=verbose,
     )
+    df = _normalize_bostongene_gene_columns(df, verbose=verbose)
     # FPKM→TPM: convert BEFORE any aggregation or ID remapping so downstream
     # consolidation (which sums values) operates on consistent units.
     df = _detect_and_convert_to_tpm(df, verbose=verbose)
+    df = _detect_kallisto_gene_abundance_tpm(df, verbose=verbose)
     if used_sidecar and aggregate_gene_expression:
         if verbose:
             print("[load] Input is already gene-level via Gene.csv sidecar; skipping transcript aggregation")

--- a/pirlygenes/load_expression.py
+++ b/pirlygenes/load_expression.py
@@ -70,7 +70,14 @@ def _guess_col(columns, patterns):
     return None
 
 
-def _select_sample_rows(df, sample_id_col=None, sample_id_value=None, verbose=True):
+def _select_sample_rows(
+    df,
+    sample_id_col=None,
+    sample_id_value=None,
+    gene_name_col=None,
+    gene_id_col=None,
+    verbose=True,
+):
     if sample_id_col is None and sample_id_value is None:
         return df
     if sample_id_col is None and sample_id_value is not None:
@@ -86,10 +93,15 @@ def _select_sample_rows(df, sample_id_col=None, sample_id_value=None, verbose=Tr
                 f"sample_id_col, but no matching expression column was found; "
                 f"available columns include: {available_preview}"
             )
+        explicit_gene_cols = {
+            col for col in (gene_name_col, gene_id_col)
+            if col is not None and str(col).strip()
+        }
         keep = [
             col
             for col in df.columns
             if col == sample_col
+            or col in explicit_gene_cols
             or re.search(r"(^|[_\s])gene([_\s]?id|[_\s]?name)?$", str(col), re.IGNORECASE)
             or str(col).lower() in {"gene", "symbol", "ensembl_gene_id"}
         ]
@@ -801,6 +813,8 @@ def load_expression_data(
         df,
         sample_id_col=sample_id_col,
         sample_id_value=sample_id_value,
+        gene_name_col=gene_name_col,
+        gene_id_col=gene_id_col,
         verbose=verbose,
     )
     df = _normalize_bostongene_gene_columns(df, verbose=verbose)

--- a/pirlygenes/plot.py
+++ b/pirlygenes/plot.py
@@ -107,6 +107,8 @@ from .plot_embedding import (  # noqa: F401
     _reference_site_feature_matrix,
     _hierarchy_embedding_metadata,
     _cancer_type_hierarchy_matrix,
+    _sanitize_embedding_matrix,
+    _subtype_expression_values_for_ref,
     _cancer_type_feature_matrix,
     get_embedding_feature_metadata,
     _plot_embedding_with_labels,

--- a/pirlygenes/plot_embedding.py
+++ b/pirlygenes/plot_embedding.py
@@ -929,11 +929,101 @@ def _cancer_type_hierarchy_matrix(df_gene_expr):
     return matrix, out_labels
 
 
+def _subtype_expression_values_for_ref(
+    ref_norm,
+    *,
+    normalize_housekeeping=False,
+    exclude_codes=None,
+):
+    """Return subtype-reference expression columns aligned to ``ref_norm``.
+
+    The main pan-cancer table has one ``FPKM_<TCGA>`` column per parent
+    cohort. Additional curated cancer types live in the registry and, for
+    some subtypes, in ``subtype-deconvolved-expression`` as long-form
+    tumor-TPM medians. This helper widens only those subtype references
+    that have measured/deconvolved expression rather than fabricating
+    centroids from marker panels.
+    """
+    import pandas as pd
+
+    if ref_norm is None or len(ref_norm) == 0 or "Symbol" not in ref_norm.columns:
+        return [], np.zeros((len(ref_norm), 0), dtype=float)
+
+    try:
+        from .gene_sets_cancer import subtype_deconvolved_expression, housekeeping_gene_names
+
+        subtype_df = subtype_deconvolved_expression()
+    except Exception:
+        return [], np.zeros((len(ref_norm), 0), dtype=float)
+
+    if subtype_df is None or subtype_df.empty:
+        return [], np.zeros((len(ref_norm), 0), dtype=float)
+
+    symbols = [str(symbol) for symbol in ref_norm["Symbol"].astype(str)]
+    symbol_set = set(symbols)
+    sub = subtype_df[subtype_df["symbol"].astype(str).isin(symbol_set)].copy()
+    if sub.empty:
+        return [], np.zeros((len(ref_norm), 0), dtype=float)
+
+    subtype_code = sub.get("subtype", pd.Series("", index=sub.index)).fillna("").astype(str).str.strip()
+    cancer_code = sub["cancer_code"].fillna("").astype(str).str.strip()
+    sub["_embed_code"] = subtype_code.where(subtype_code.ne("") & subtype_code.ne("nan"), cancer_code)
+    sub = sub[sub["_embed_code"].ne("") & sub["_embed_code"].ne("nan")]
+    if sub.empty:
+        return [], np.zeros((len(ref_norm), 0), dtype=float)
+
+    pivot = sub.pivot_table(
+        index="symbol",
+        columns="_embed_code",
+        values="tumor_tpm_median",
+        aggfunc="median",
+    )
+    exclude_codes = set(exclude_codes or [])
+    labels = sorted(str(label) for label in pivot.columns if str(label) not in exclude_codes)
+    if not labels:
+        return [], np.zeros((len(ref_norm), 0), dtype=float)
+
+    if normalize_housekeeping:
+        hk_symbols = set(housekeeping_gene_names())
+        hk = subtype_df[subtype_df["symbol"].astype(str).isin(hk_symbols)].copy()
+        if not hk.empty:
+            hk_subtype = hk.get("subtype", pd.Series("", index=hk.index)).fillna("").astype(str).str.strip()
+            hk_cancer = hk["cancer_code"].fillna("").astype(str).str.strip()
+            hk["_embed_code"] = hk_subtype.where(hk_subtype.ne("") & hk_subtype.ne("nan"), hk_cancer)
+            hk = hk[hk["_embed_code"].isin(labels)]
+            hk_medians = hk.groupby("_embed_code")["tumor_tpm_median"].median()
+            for label in labels:
+                denom = float(hk_medians.get(label, 1.0) or 1.0)
+                if denom > 0:
+                    pivot[label] = pivot[label].astype(float) / denom
+
+    values = pivot.reindex(index=symbols, columns=labels).fillna(0.0).astype(float).to_numpy()
+    return labels, values
+
+
+def _sanitize_embedding_matrix(matrix):
+    """Remove all-NaN/non-finite feature columns before distance geometry."""
+    matrix = np.asarray(matrix, dtype=float)
+    if matrix.ndim != 2:
+        return np.nan_to_num(matrix, nan=0.0, posinf=0.0, neginf=0.0)
+    if matrix.shape[1] == 0:
+        return np.zeros((matrix.shape[0], 1), dtype=float)
+    finite_cols = np.isfinite(matrix).all(axis=0)
+    if finite_cols.any():
+        matrix = matrix[:, finite_cols]
+    elif matrix.shape[1] > 0:
+        matrix = np.zeros((matrix.shape[0], 1), dtype=float)
+    if matrix.shape[1] == 0:
+        matrix = np.zeros((matrix.shape[0], 1), dtype=float)
+    return np.nan_to_num(matrix, nan=0.0, posinf=0.0, neginf=0.0)
+
+
 def _cancer_type_feature_matrix(
     df_gene_expr,
     n_genes=10,
     method="zscore",
     include_normals=False,
+    include_subtypes=False,
 ):
     """Build feature matrix for PCA/MDS of cancer types + sample.
 
@@ -954,6 +1044,10 @@ def _cancer_type_feature_matrix(
         When true, append normal-tissue nTPM centroids to the embedded
         reference rows. Supported for expression-space methods; ignored for
         score/hierarchy spaces where the normal vectors are not defined.
+    include_subtypes : bool
+        When true, append available subtype-deconvolved tumor-TPM references
+        (for example SARC_LMS, OS, EWS) in addition to TCGA parent cohorts.
+        Registry-only rows without expression medians are still not embedded.
     """
     import warnings
 
@@ -1031,6 +1125,14 @@ def _cancer_type_feature_matrix(
         for _, row in ref_norm.iterrows()
     ])
     ref_vals = ref_norm[fpkm_cols].astype(float).values  # (genes, cancers)
+    subtype_labels, subtype_vals = (
+        _subtype_expression_values_for_ref(
+            ref_norm,
+            normalize_housekeeping=method in ("hk", "hk_zscore"),
+            exclude_codes=set(labels),
+        )
+        if include_subtypes else ([], np.zeros((len(ref_norm), 0), dtype=float))
+    )
     normal_vals = (
         ref_norm[normal_cols].astype(float).values
         if normal_cols else np.zeros((len(ref_norm), 0), dtype=float)
@@ -1039,11 +1141,14 @@ def _cancer_type_feature_matrix(
     if method in ("zscore", "hk_zscore", "tme", "bottleneck"):
         log_ref = np.log2(ref_vals + 1)
         log_sample = np.log2(sample_vals + 1)
+        log_subtypes = np.log2(subtype_vals + 1) if subtype_labels else None
         log_normals = np.log2(normal_vals + 1) if normal_cols else None
         g_std = log_ref.std(axis=1)
         var_mask = g_std >= 0.1
         log_ref = log_ref[var_mask]
         log_sample = log_sample[var_mask]
+        if log_subtypes is not None:
+            log_subtypes = log_subtypes[var_mask]
         if log_normals is not None:
             log_normals = log_normals[var_mask]
         g_std = g_std[var_mask]
@@ -1051,6 +1156,13 @@ def _cancer_type_feature_matrix(
         z_ref = np.clip((log_ref - g_mean[:, None]) / g_std[:, None], -3, 3)
         z_sample = np.clip((log_sample - g_mean) / g_std, -3, 3)
         parts = [z_ref.T]
+        if log_subtypes is not None and log_subtypes.shape[1]:
+            z_subtypes = np.clip(
+                (log_subtypes - g_mean[:, None]) / g_std[:, None],
+                -3,
+                3,
+            )
+            parts.append(z_subtypes.T)
         if log_normals is not None and log_normals.shape[1]:
             z_normals = np.clip(
                 (log_normals - g_mean[:, None]) / g_std[:, None],
@@ -1062,6 +1174,8 @@ def _cancer_type_feature_matrix(
         matrix = np.vstack(parts)
     elif method == "hk":
         parts = [ref_vals.T]
+        if subtype_labels:
+            parts.append(subtype_vals.T)
         if normal_cols:
             parts.append(normal_vals.T)
         parts.append(sample_vals[None, :])
@@ -1069,6 +1183,8 @@ def _cancer_type_feature_matrix(
         matrix = np.log2(combined + 1)
     elif method == "rank":
         parts = [ref_vals.T]
+        if subtype_labels:
+            parts.append(subtype_vals.T)
         if normal_cols:
             parts.append(normal_vals.T)
         parts.append(sample_vals[None, :])
@@ -1081,9 +1197,10 @@ def _cancer_type_feature_matrix(
     else:
         raise ValueError(f"Unknown method: {method}")
 
+    labels.extend(subtype_labels)
     labels.extend(normal_labels)
     labels.append("SAMPLE")
-    return matrix, labels
+    return _sanitize_embedding_matrix(matrix), labels
 
 
 def get_embedding_feature_metadata(method="hierarchy", n_genes=10):
@@ -1906,6 +2023,7 @@ def plot_cancer_type_pca(
     n_genes=10,
     method="zscore",
     include_normals=False,
+    include_subtypes=False,
     save_to_filename=None,
     save_dpi=300,
     figsize=(12, 10),
@@ -1917,11 +2035,18 @@ def plot_cancer_type_pca(
         n_genes=n_genes,
         method=method,
         include_normals=include_normals,
+        include_subtypes=include_subtypes,
     )
     pca = PCA(n_components=2)
     coords = pca.fit_transform(X)
     mlabel = _METHOD_LABELS.get(method)
-    title = "Sample among TCGA cancer types — PCA"
+    title = "Sample among TCGA parent cancer cohorts — PCA"
+    if include_subtypes and include_normals:
+        title = "Sample among TCGA parent cohorts, subtype references, and normal tissues — PCA"
+    elif include_subtypes:
+        title = "Sample among TCGA parent cohorts and subtype references — PCA"
+    elif include_normals:
+        title = "Sample among TCGA parent cancer cohorts and normal tissues — PCA"
     if mlabel:
         title += f" ({mlabel})"
     return _plot_embedding_with_labels(
@@ -1942,6 +2067,7 @@ def plot_cancer_type_mds(
     n_genes=10,
     method="zscore",
     include_normals=False,
+    include_subtypes=False,
     label_nearest_cancers=None,
     label_nearest_normals=None,
     label_all=True,
@@ -1958,6 +2084,7 @@ def plot_cancer_type_mds(
         n_genes=n_genes,
         method=method,
         include_normals=include_normals,
+        include_subtypes=include_subtypes,
     )
     distances = pairwise_distances(X, metric="euclidean")
     coords = MDS(
@@ -1966,9 +2093,13 @@ def plot_cancer_type_mds(
         random_state=42,
     ).fit_transform(distances)
     mlabel = _METHOD_LABELS.get(method)
-    title = "Sample among TCGA cancer types — MDS"
-    if include_normals:
-        title = "Sample among TCGA cancer and normal tissue types — MDS"
+    title = "Sample among TCGA parent cancer cohorts — MDS"
+    if include_subtypes and include_normals:
+        title = "Sample among TCGA parent cohorts, subtype references, and normal tissues — MDS"
+    elif include_subtypes:
+        title = "Sample among TCGA parent cohorts and subtype references — MDS"
+    elif include_normals:
+        title = "Sample among TCGA parent cancer cohorts and normal tissues — MDS"
     if mlabel:
         title += f" ({mlabel})"
     xlabel = "MDS1"

--- a/pirlygenes/plot_embedding.py
+++ b/pirlygenes/plot_embedding.py
@@ -929,7 +929,12 @@ def _cancer_type_hierarchy_matrix(df_gene_expr):
     return matrix, out_labels
 
 
-def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
+def _cancer_type_feature_matrix(
+    df_gene_expr,
+    n_genes=10,
+    method="zscore",
+    include_normals=False,
+):
     """Build feature matrix for PCA/MDS of cancer types + sample.
 
     Gene selection is unified: a single biologically-informed gene set is
@@ -945,6 +950,10 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
         ``"rank"`` — percentile rank within each gene across cancer types.
         ``"score"`` — cancer-type signature scores (33-d vector).
         ``"hierarchy"`` — family-aware support-score space with purity anchor.
+    include_normals : bool
+        When true, append normal-tissue nTPM centroids to the embedded
+        reference rows. Supported for expression-space methods; ignored for
+        score/hierarchy spaces where the normal vectors are not defined.
     """
     import warnings
 
@@ -990,6 +999,14 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
 
     fpkm_cols = [c for c in ref_full.columns if c.startswith("FPKM_")]
     labels = [c.replace("FPKM_", "") for c in fpkm_cols]
+    normal_cols = []
+    normal_labels = []
+    if include_normals:
+        normal_cols = [c for c in ref_full.columns if c.startswith("nTPM_")]
+        normal_labels = [
+            "normal:" + c.replace("nTPM_", "").replace("_", " ")
+            for c in normal_cols
+        ]
 
     # Gene selection
     if method == "tme":
@@ -1014,24 +1031,48 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
         for _, row in ref_norm.iterrows()
     ])
     ref_vals = ref_norm[fpkm_cols].astype(float).values  # (genes, cancers)
+    normal_vals = (
+        ref_norm[normal_cols].astype(float).values
+        if normal_cols else np.zeros((len(ref_norm), 0), dtype=float)
+    )
 
     if method in ("zscore", "hk_zscore", "tme", "bottleneck"):
         log_ref = np.log2(ref_vals + 1)
         log_sample = np.log2(sample_vals + 1)
+        log_normals = np.log2(normal_vals + 1) if normal_cols else None
         g_std = log_ref.std(axis=1)
         var_mask = g_std >= 0.1
         log_ref = log_ref[var_mask]
         log_sample = log_sample[var_mask]
+        if log_normals is not None:
+            log_normals = log_normals[var_mask]
         g_std = g_std[var_mask]
         g_mean = log_ref.mean(axis=1)
         z_ref = np.clip((log_ref - g_mean[:, None]) / g_std[:, None], -3, 3)
         z_sample = np.clip((log_sample - g_mean) / g_std, -3, 3)
-        matrix = np.vstack([z_ref.T, z_sample[None, :]])
+        parts = [z_ref.T]
+        if log_normals is not None and log_normals.shape[1]:
+            z_normals = np.clip(
+                (log_normals - g_mean[:, None]) / g_std[:, None],
+                -3,
+                3,
+            )
+            parts.append(z_normals.T)
+        parts.append(z_sample[None, :])
+        matrix = np.vstack(parts)
     elif method == "hk":
-        combined = np.vstack([ref_vals.T, sample_vals[None, :]])
+        parts = [ref_vals.T]
+        if normal_cols:
+            parts.append(normal_vals.T)
+        parts.append(sample_vals[None, :])
+        combined = np.vstack(parts)
         matrix = np.log2(combined + 1)
     elif method == "rank":
-        combined = np.vstack([ref_vals.T, sample_vals[None, :]])  # (34, genes)
+        parts = [ref_vals.T]
+        if normal_cols:
+            parts.append(normal_vals.T)
+        parts.append(sample_vals[None, :])
+        combined = np.vstack(parts)
         ranked = np.apply_along_axis(
             lambda col: rankdata(col, method="average") / len(col),
             axis=0, arr=combined,
@@ -1040,6 +1081,7 @@ def _cancer_type_feature_matrix(df_gene_expr, n_genes=10, method="zscore"):
     else:
         raise ValueError(f"Unknown method: {method}")
 
+    labels.extend(normal_labels)
     labels.append("SAMPLE")
     return matrix, labels
 
@@ -1063,11 +1105,24 @@ def _plot_embedding_with_labels(
     xlabel,
     ylabel,
     method=None,
+    label_nearest_cancers=None,
+    label_nearest_normals=None,
+    label_all=True,
     save_to_filename=None,
     save_dpi=300,
     figsize=(12, 10),
 ):
     from matplotlib.lines import Line2D
+
+    def _label_kind(label):
+        if label == "SAMPLE":
+            return "sample"
+        if str(label).startswith("normal:"):
+            return "normal"
+        return "cancer"
+
+    def _display_label(label):
+        return str(label).replace("normal:", "")
 
     fig, ax = plt.subplots(figsize=figsize)
     texts = []
@@ -1078,7 +1133,7 @@ def _plot_embedding_with_labels(
 
         family_order = []
         for label in labels:
-            if label == "SAMPLE":
+            if label == "SAMPLE" or _label_kind(label) == "normal":
                 continue
             family = _CANCER_FAMILY_BY_CODE.get(label, label)
             label_to_family[label] = family
@@ -1095,8 +1150,41 @@ def _plot_embedding_with_labels(
             if label == "SAMPLE":
                 continue
             dist = float(np.linalg.norm(coords[i] - sample_coords))
-            nearest_neighbors.append((dist, label))
+            nearest_neighbors.append((dist, label, _label_kind(label)))
         nearest_neighbors.sort(key=lambda item: (item[0], item[1]))
+
+    nearest_cancer_ordered = [
+        label
+        for _, label, kind in nearest_neighbors
+        if kind == "cancer"
+    ]
+    nearest_normal_ordered = [
+        label
+        for _, label, kind in nearest_neighbors
+        if kind == "normal"
+    ]
+    nearest_cancer_labels = set(nearest_cancer_ordered)
+    nearest_normal_labels = set(nearest_normal_ordered)
+    if label_nearest_cancers is not None:
+        nearest_cancer_labels = set(
+            nearest_cancer_ordered[: int(label_nearest_cancers)]
+        )
+    if label_nearest_normals is not None:
+        nearest_normal_labels = set(
+            nearest_normal_ordered[: int(label_nearest_normals)]
+        )
+
+    def _should_label(label):
+        if label == "SAMPLE":
+            return True
+        if label_all:
+            return True
+        kind = _label_kind(label)
+        if kind == "cancer":
+            return label in nearest_cancer_labels
+        if kind == "normal":
+            return label in nearest_normal_labels
+        return False
 
     for i, label in enumerate(labels):
         if label == "SAMPLE":
@@ -1122,27 +1210,41 @@ def _plot_embedding_with_labels(
                 )
             )
         else:
-            point_color = family_palette.get(label_to_family.get(label), "steelblue")
+            kind = _label_kind(label)
+            if kind == "normal":
+                point_color = "#8da08d"
+                edge_color = "#f8f8f8"
+                marker = "s"
+                size = 38
+                alpha = 0.52
+            else:
+                point_color = family_palette.get(label_to_family.get(label), "steelblue")
+                edge_color = "white"
+                marker = "o"
+                size = 60
+                alpha = 0.7
             ax.scatter(
                 coords[i, 0],
                 coords[i, 1],
-                s=60,
-                alpha=0.7,
+                s=size,
+                alpha=alpha,
                 color=point_color,
-                edgecolors="white",
+                edgecolors=edge_color,
                 linewidths=0.5,
                 zorder=2,
+                marker=marker,
             )
-            texts.append(
-                ax.text(
-                    coords[i, 0],
-                    coords[i, 1],
-                    label,
-                    fontsize=7,
-                    alpha=0.8,
-                    va="center",
+            if _should_label(label):
+                texts.append(
+                    ax.text(
+                        coords[i, 0],
+                        coords[i, 1],
+                        _display_label(label),
+                        fontsize=7,
+                        alpha=0.85,
+                        va="center",
+                    )
                 )
-            )
 
     adjust_text(
         texts,
@@ -1156,13 +1258,35 @@ def _plot_embedding_with_labels(
     ax.grid(True, alpha=0.2)
 
     if nearest_neighbors:
-        nearest_text = "\n".join(
-            f"{label} ({dist:.2f})" for dist, label in nearest_neighbors[:5]
-        )
+        if any(kind == "normal" for _, _, kind in nearest_neighbors):
+            n_cancers = 5 if label_nearest_cancers is None else int(label_nearest_cancers)
+            n_normals = 5 if label_nearest_normals is None else int(label_nearest_normals)
+            cancer_text = "\n".join(
+                f"{_display_label(label)} ({dist:.2f})"
+                for dist, label, kind in nearest_neighbors
+                if kind == "cancer"
+            )
+            normal_text = "\n".join(
+                f"{_display_label(label)} ({dist:.2f})"
+                for dist, label, kind in nearest_neighbors
+                if kind == "normal"
+            )
+            nearest_text = (
+                "Nearest TCGA cancers\n"
+                + "\n".join(cancer_text.splitlines()[:n_cancers])
+                + "\n\nNearest normal tissues\n"
+                + "\n".join(normal_text.splitlines()[:n_normals])
+            )
+            nearest_title = ""
+        else:
+            nearest_text = "\n".join(
+                f"{label} ({dist:.2f})" for dist, label, _kind in nearest_neighbors[:5]
+            )
+            nearest_title = "Nearest TCGA centroids\n"
         ax.text(
             0.98,
             0.02,
-            "Nearest TCGA centroids\n" + nearest_text,
+            nearest_title + nearest_text,
             transform=ax.transAxes,
             ha="right",
             va="bottom",
@@ -1177,6 +1301,16 @@ def _plot_embedding_with_labels(
             for family, color in list(family_palette.items())[:10]
         ]
         ax.legend(handles=handles, title="Family", loc="upper left", fontsize=8, title_fontsize=9, framealpha=0.9)
+    elif any(_label_kind(label) == "normal" for label in labels):
+        handles = [
+            Line2D([0], [0], marker="o", color="none", markerfacecolor="steelblue",
+                   markeredgecolor="white", markersize=7, label="TCGA cancer"),
+            Line2D([0], [0], marker="s", color="none", markerfacecolor="#8da08d",
+                   markeredgecolor="white", markersize=6, label="normal tissue"),
+            Line2D([0], [0], marker="*", color="red", markeredgecolor="black",
+                   markersize=10, linestyle="none", label="sample"),
+        ]
+        ax.legend(handles=handles, loc="upper left", fontsize=8, framealpha=0.9)
 
     fig.tight_layout()
     if save_to_filename:
@@ -1307,6 +1441,17 @@ def plot_cancer_type_genes(
     # Fix x-axis limits before adjustText to prevent blowout
     ax.set_xlim(left=0.005)
     ax.autoscale_view(scalex=True, scaley=False)
+    try:
+        from .common import build_sample_tpm_by_symbol
+        from .plot_reference_lines import add_p90_reference_line
+
+        add_p90_reference_line(
+            ax,
+            build_sample_tpm_by_symbol(df_gene_expr),
+            orientation="vertical",
+        )
+    except Exception:
+        pass
 
     adjust_text(
         texts,
@@ -1760,13 +1905,19 @@ def plot_cancer_type_pca(
     df_gene_expr,
     n_genes=10,
     method="zscore",
+    include_normals=False,
     save_to_filename=None,
     save_dpi=300,
     figsize=(12, 10),
 ):
     """PCA scatter showing where the sample falls among cancer-type centroids."""
     from sklearn.decomposition import PCA
-    X, labels = _cancer_type_feature_matrix(df_gene_expr, n_genes=n_genes, method=method)
+    X, labels = _cancer_type_feature_matrix(
+        df_gene_expr,
+        n_genes=n_genes,
+        method=method,
+        include_normals=include_normals,
+    )
     pca = PCA(n_components=2)
     coords = pca.fit_transform(X)
     mlabel = _METHOD_LABELS.get(method)
@@ -1790,6 +1941,10 @@ def plot_cancer_type_mds(
     df_gene_expr,
     n_genes=10,
     method="zscore",
+    include_normals=False,
+    label_nearest_cancers=None,
+    label_nearest_normals=None,
+    label_all=True,
     save_to_filename=None,
     save_dpi=300,
     figsize=(12, 10),
@@ -1798,7 +1953,12 @@ def plot_cancer_type_mds(
     from sklearn.manifold import MDS
     from sklearn.metrics import pairwise_distances
 
-    X, labels = _cancer_type_feature_matrix(df_gene_expr, n_genes=n_genes, method=method)
+    X, labels = _cancer_type_feature_matrix(
+        df_gene_expr,
+        n_genes=n_genes,
+        method=method,
+        include_normals=include_normals,
+    )
     distances = pairwise_distances(X, metric="euclidean")
     coords = MDS(
         n_components=2,
@@ -1807,15 +1967,25 @@ def plot_cancer_type_mds(
     ).fit_transform(distances)
     mlabel = _METHOD_LABELS.get(method)
     title = "Sample among TCGA cancer types — MDS"
+    if include_normals:
+        title = "Sample among TCGA cancer and normal tissue types — MDS"
     if mlabel:
         title += f" ({mlabel})"
+    xlabel = "MDS1"
+    ylabel = "MDS2"
+    if method in {"zscore", "hk_zscore", "tme", "bottleneck", "hk"}:
+        xlabel = "MDS1 (log-expression distance)"
+        ylabel = "MDS2 (log-expression distance)"
     return _plot_embedding_with_labels(
         coords,
         labels,
         title=title,
-        xlabel="MDS1",
-        ylabel="MDS2",
+        xlabel=xlabel,
+        ylabel=ylabel,
         method=method,
+        label_nearest_cancers=label_nearest_cancers,
+        label_nearest_normals=label_nearest_normals,
+        label_all=label_all,
         save_to_filename=save_to_filename,
         save_dpi=save_dpi,
         figsize=figsize,

--- a/pirlygenes/plot_reference_lines.py
+++ b/pirlygenes/plot_reference_lines.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 import numpy as np
 
 
-_P90_LINE_COLOR = "#888888"
-_P90_LINE_DASHES = (1, 4)
-_P90_LINE_WIDTH = 0.8
-_P90_LINE_ALPHA = 0.55
+_P90_LINE_COLOR = "#d81b60"
+_P90_LINE_DASHES = (4, 2)
+_P90_LINE_WIDTH = 1.2
+_P90_LINE_ALPHA = 0.72
 _P90_LABEL_FONTSIZE = 7
-_P90_LABEL_COLOR = "#555555"
+_P90_LABEL_COLOR = "#a31348"
 
 
 def compute_sample_p90_tpm(sample_tpm_by_symbol, *, min_tpm=0.0, percentile=90.0):
@@ -72,6 +72,7 @@ def add_p90_reference_line(
     label_fmt=None,
     min_tpm=0.0,
     percentile=90.0,
+    value_transform=None,
 ):
     """Overlay a faint dashed line at the sample's 90th-percentile TPM.
 
@@ -84,6 +85,10 @@ def add_p90_reference_line(
     be computed (too few expressed genes). A tiny label is placed
     near the line so the reader knows what the threshold represents.
 
+    ``value_transform`` is for plots whose axis is already in a derived
+    TPM coordinate, e.g. ``log10(TPM + 1)``. The label still reports the
+    raw TPM percentile.
+
     Returns the p90 TPM (float) or ``None`` when skipped.
     """
     p90 = compute_sample_p90_tpm(
@@ -93,11 +98,48 @@ def add_p90_reference_line(
         return None
 
     if label_fmt is None:
-        label_fmt = f"sample p{int(percentile)} ({{:.0f}} TPM)"
+        label_fmt = f"bulk sample p{int(percentile)} ({{:.0f}} TPM)"
+
+    line_value = p90
+    if value_transform is not None:
+        try:
+            line_value = float(value_transform(p90))
+        except Exception:
+            return None
+    if not np.isfinite(line_value):
+        return None
+
+    def _expand_axis_for_value(axis_orientation, value):
+        if axis_orientation == "vertical":
+            low, high = ax.get_xlim()
+            scale = ax.get_xscale()
+            set_lim = ax.set_xlim
+        else:
+            low, high = ax.get_ylim()
+            scale = ax.get_yscale()
+            set_lim = ax.set_ylim
+        lo, hi = sorted((float(low), float(high)))
+        if lo <= value <= hi:
+            return
+        if scale == "log" and value > 0:
+            pad_low = value / 1.25
+            pad_high = value * 1.25
+        else:
+            pad = max(abs(value) * 0.08, 0.1)
+            pad_low = value - pad
+            pad_high = value + pad
+        new_lo = min(lo, pad_low)
+        new_hi = max(hi, pad_high)
+        if low <= high:
+            set_lim(new_lo, new_hi)
+        else:
+            set_lim(new_hi, new_lo)
+
+    _expand_axis_for_value(orientation, line_value)
 
     if orientation == "vertical":
         ax.axvline(
-            p90,
+            line_value,
             color=_P90_LINE_COLOR,
             linestyle=(0, _P90_LINE_DASHES),
             linewidth=_P90_LINE_WIDTH,
@@ -105,7 +147,7 @@ def add_p90_reference_line(
             zorder=0.5,
         )
         ax.text(
-            p90, ax.get_ylim()[1],
+            line_value, ax.get_ylim()[1],
             " " + label_fmt.format(p90),
             ha="left", va="top",
             fontsize=_P90_LABEL_FONTSIZE,
@@ -114,7 +156,7 @@ def add_p90_reference_line(
         )
     elif orientation == "horizontal":
         ax.axhline(
-            p90,
+            line_value,
             color=_P90_LINE_COLOR,
             linestyle=(0, _P90_LINE_DASHES),
             linewidth=_P90_LINE_WIDTH,
@@ -122,7 +164,7 @@ def add_p90_reference_line(
             zorder=0.5,
         )
         ax.text(
-            ax.get_xlim()[1], p90,
+            ax.get_xlim()[1], line_value,
             label_fmt.format(p90) + " ",
             ha="right", va="bottom",
             fontsize=_P90_LABEL_FONTSIZE,

--- a/pirlygenes/plot_target_deep_dive.py
+++ b/pirlygenes/plot_target_deep_dive.py
@@ -486,6 +486,13 @@ def plot_tumor_attribution(
     ax.legend(loc="lower right", fontsize=8)
     cat_label = "CTAs" if category == "CTA" else "Actionable Targets"
     ax.set_title(f"Tumor vs TME Attribution — {cat_label} — {cancer_code} (purity={purity:.0%})")
+
+    try:
+        from .plot_reference_lines import add_p90_reference_line
+
+        add_p90_reference_line(ax, sample_tpm, orientation="vertical")
+    except Exception:
+        pass
     fig.tight_layout()
 
     if save_to_filename:
@@ -498,20 +505,13 @@ def plot_curated_target_evidence(
     target_panel,
     cancer_type,
     top_n=12,
+    df_gene_expr=None,
     save_to_filename=None,
     save_dpi=300,
 ):
-    """Integrated view for curated targets: tumor range + normal context.
-
-    The existing matched-normal / safety / attribution plots each show
-    one axis of the story. This plot intentionally combines the three
-    questions the markdown now asks for each curated target:
-
-    - how much estimated tumor TPM remains across the range,
-    - what kind of normal-expression context that target carries, and
-    - how clinically mature the target class is.
-    """
+    """Integrated view for curated targets: expression evidence + context."""
     from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
 
     if (
         ranges_df is None
@@ -610,11 +610,24 @@ def plot_curated_target_evidence(
     if not rows:
         return None
 
-    fig, ax = plt.subplots(figsize=(12, max(4.5, 0.6 * len(rows) + 1.2)))
+    fig, (ax_expr, ax_ctx) = plt.subplots(
+        1,
+        2,
+        figsize=(13.5, max(4.8, 0.55 * len(rows) + 1.8)),
+        gridspec_kw={"width_ratios": [1.1, 1.15]},
+    )
     y_pos = np.arange(len(rows))
     for i, row in enumerate(rows):
-        ax.hlines(i, row["low"], row["high"], color=row["color"], lw=4, alpha=0.75)
-        ax.scatter(
+        ax_expr.hlines(
+            i,
+            row["low"],
+            row["high"],
+            color=row["color"],
+            lw=5,
+            alpha=0.78,
+            zorder=2,
+        )
+        ax_expr.scatter(
             row["mid"],
             i,
             s=90,
@@ -624,7 +637,7 @@ def plot_curated_target_evidence(
             linewidth=0.8,
             zorder=3,
         )
-        ax.scatter(
+        ax_expr.scatter(
             row["observed"],
             i,
             s=45,
@@ -633,34 +646,64 @@ def plot_curated_target_evidence(
             linewidth=1.2,
             zorder=4,
         )
-        note = f"{row['source']['label']} | {row['normal']['label']} | {row['maturity']}"
-        ax.text(
-            max(row["high"], row["observed"]) * 1.08 + 0.5,
+
+        ax_ctx.text(
+            0.02,
             i,
-            note,
+            row["source"]["label"],
             va="center",
-            fontsize=8,
-            color="#555555",
+            fontsize=8.5,
+            color="#222222",
+        )
+        ax_ctx.text(
+            1.05,
+            i,
+            row["normal"]["label"],
+            va="center",
+            fontsize=8.5,
+            color="#222222",
+        )
+        ax_ctx.text(
+            2.25,
+            i,
+            row["maturity"],
+            va="center",
+            fontsize=8.5,
+            color="#222222",
         )
 
-    ax.set_yticks(y_pos)
-    ax.set_yticklabels([row["symbol"] for row in rows], fontsize=9)
-    ax.invert_yaxis()
-    ax.set_xscale("symlog", linthresh=1.0)
-    ax.set_xlabel("Estimated tumor TPM range (dot = midpoint, tick = observed TPM)")
-    ax.set_title(f"Curated Targets — {cancer_code}")
+    ax_expr.set_yticks(y_pos)
+    ax_expr.set_yticklabels([row["symbol"] for row in rows], fontsize=9.5)
+    ax_expr.invert_yaxis()
+    ax_expr.set_xscale("symlog", linthresh=1.0)
+    ax_expr.set_xlabel("Purity-adjusted tumor TPM range; black tick = bulk TPM")
+    ax_expr.set_title("Expression Evidence", fontsize=12, fontweight="bold")
+    ax_expr.grid(axis="x", color="#dddddd", linewidth=0.6, alpha=0.7)
+    ax_expr.spines["top"].set_visible(False)
+    ax_expr.spines["right"].set_visible(False)
+
+    ax_ctx.set_xlim(0.0, 4.0)
+    ax_ctx.set_ylim(-0.5, len(rows) - 0.5)
+    ax_ctx.invert_yaxis()
+    ax_ctx.axis("off")
+    for xpos, label in [
+        (0.02, "Tumor source"),
+        (1.05, "Healthy tissues"),
+        (2.25, "Maturity"),
+    ]:
+        ax_ctx.text(
+            xpos,
+            -0.85,
+            label,
+            fontsize=9.5,
+            fontweight="bold",
+            color="#333333",
+            clip_on=False,
+        )
+    ax_ctx.set_title("Context", fontsize=12, fontweight="bold")
 
     normal_handles = [
-        Line2D(
-            [0],
-            [0],
-            marker="o",
-            color="none",
-            markerfacecolor=color,
-            markeredgecolor="black",
-            markersize=8,
-            label=label,
-        )
+        Patch(facecolor=color, edgecolor="black", label=label)
         for label, color in [
             ("same-lineage expected", normal_colors["same_lineage_expected"]),
             ("restricted / CTA-like", normal_colors["restricted_outside_lineage"]),
@@ -682,20 +725,52 @@ def plot_curated_target_evidence(
         )
         for label, marker in source_markers.items()
     ]
-    legend1 = ax.legend(
+    range_handles = [
+        Line2D([0], [0], color="#555555", lw=5, label="purity-adjusted tumor range"),
+        Line2D(
+            [0],
+            [0],
+            marker="|",
+            color="black",
+            linestyle="none",
+            markersize=12,
+            markeredgewidth=1.5,
+            label="bulk TPM",
+        ),
+    ]
+    legend1 = fig.legend(
+        handles=range_handles + source_handles,
+        loc="lower center",
+        bbox_to_anchor=(0.34, 0.015),
+        fontsize=8,
+        title="Expression / source",
+        frameon=False,
+        ncol=2,
+    )
+    fig.add_artist(legend1)
+    fig.legend(
         handles=normal_handles,
-        loc="lower right",
+        loc="lower center",
+        bbox_to_anchor=(0.76, 0.015),
         fontsize=8,
-        title="Normal-expression context",
+        title="Healthy-tissue context",
+        frameon=False,
+        ncol=2,
     )
-    ax.add_artist(legend1)
-    ax.legend(
-        handles=source_handles,
-        loc="upper right",
-        fontsize=8,
-        title="Tumor-source support",
-    )
-    fig.tight_layout()
+    if df_gene_expr is not None:
+        try:
+            from .common import build_sample_tpm_by_symbol
+            from .plot_reference_lines import add_p90_reference_line
+
+            add_p90_reference_line(
+                ax_expr,
+                build_sample_tpm_by_symbol(df_gene_expr),
+                orientation="vertical",
+            )
+        except Exception:
+            pass
+    fig.suptitle(f"Curated Targets — {cancer_code}", fontsize=13, y=0.985)
+    fig.tight_layout(rect=[0.0, 0.11, 1.0, 0.93])
 
     if save_to_filename:
         fig.savefig(save_to_filename, dpi=save_dpi, bbox_inches="tight")
@@ -809,7 +884,6 @@ def _priority_target_rows(
             maturity = clinical_maturity_info(curated, target_panel=target_panel)
             phase = str(curated.get("phase") or "")
             points = _PRIORITY_PHASE_POINTS.get(phase, 0.8)
-            points += 0.8
             points += min(0.4, 0.15 * max(0, maturity.get("n_modalities", 0) - 1))
             points += min(0.3, 0.05 * max(0, maturity.get("n_agents", 0) - 1))
             label = maturity["summary"]
@@ -850,6 +924,7 @@ def _priority_target_rows(
         source_points = _source_component(source, row)
         normal_points = _normal_component(normal)
         strength_points = _strength_component(source, row)
+        curation_points = 0.8 if matched_panel else 0.0
         rows.append(
             {
                 "symbol": sym,
@@ -865,7 +940,14 @@ def _priority_target_rows(
                 "actionability_points": actionability_points,
                 "normal_points": normal_points,
                 "strength_points": strength_points,
-                "total_score": source_points + actionability_points + normal_points + strength_points,
+                "curation_points": curation_points,
+                "total_score": (
+                    source_points
+                    + actionability_points
+                    + normal_points
+                    + strength_points
+                    + curation_points
+                ),
                 "phase_key": _PRIORITY_PHASE_PRIORITY.get(
                     str(curated.get("phase") or "") if curated is not None else "",
                     99 if curated is None else 9,
@@ -913,7 +995,8 @@ def plot_priority_targets(
     score_parts = [
         ("Tumor support", "source_points", "#2e8b57"),
         ("Clinical readiness", "actionability_points", "#4a90d9"),
-        ("Healthy-tissue fit", "normal_points", "#9b59b6"),
+        ("Disease-matched curation", "curation_points", "#f39c12"),
+        ("Healthy-tissue specificity", "normal_points", "#9b59b6"),
         ("Tumor level", "strength_points", "#8c8c8c"),
     ]
     left = np.zeros(len(rows))
@@ -941,7 +1024,7 @@ def plot_priority_targets(
             color="#444444",
         )
 
-    labels = [f"{row['symbol']}{'*' if row['matched_panel'] else ''}" for row in rows]
+    labels = [row["symbol"] for row in rows]
     ax.set_yticks(y_pos)
     ax.set_yticklabels(labels, fontsize=10)
     ax.invert_yaxis()
@@ -953,20 +1036,11 @@ def plot_priority_targets(
     fig.text(
         0.5,
         0.965,
-        "Higher scores reflect better tumor support, stronger clinical maturity, safer healthy-tissue context, and higher estimated tumor expression.",
+        "Higher scores reflect better tumor support, stronger clinical maturity, disease-matched curation, healthy-tissue specificity/safety, and higher estimated tumor expression.",
         ha="center",
         va="top",
         fontsize=9,
         color="#555555",
-    )
-    fig.text(
-        0.99,
-        0.01,
-        "* disease-matched curated target",
-        ha="right",
-        va="bottom",
-        fontsize=8,
-        color="#666666",
     )
     fig.tight_layout(rect=[0.0, 0.03, 1.0, 0.93])
 
@@ -1005,7 +1079,7 @@ def plot_priority_target_context(
         gridspec_kw={"width_ratios": [1.2, 1.0]},
     )
     y_pos = np.arange(len(rows))
-    labels = [f"{row['symbol']}{'*' if row['matched_panel'] else ''}" for row in rows]
+    labels = [row["symbol"] for row in rows]
     source_labels = {row["source"]["label"] for row in rows}
     normal_labels = {row["normal"]["label"] for row in rows}
     show_source_col = len(source_labels) > 1
@@ -1052,6 +1126,15 @@ def plot_priority_target_context(
         if show_normal_col:
             ax_note.text(x, i, row["normal"]["label"], va="center", fontsize=9, color="#222222")
             x += 1.0
+        ax_note.text(
+            x,
+            i,
+            "disease-matched" if row["matched_panel"] else "generic",
+            va="center",
+            fontsize=9,
+            color="#222222",
+        )
+        x += 1.0
         ax_note.text(x, i, row["clinical_label"], va="center", fontsize=9, color="#222222")
         ax_note.text(x + 1.0, i, f"{row['total_score']:.1f}", va="center", fontsize=9, color="#222222")
 
@@ -1065,12 +1148,25 @@ def plot_priority_target_context(
     ax_range.set_xticks([_log_tpm(tick) for tick in raw_ticks])
     ax_range.set_xticklabels([f"{tick:g}" for tick in raw_ticks])
     ax_range.set_xlim(left=0.0, right=_log_tpm(max_raw) + 0.12)
-    ax_range.set_xlabel("Tumor-core TPM, log10(TPM+1); black tick = bulk measured TPM")
+    ax_range.set_xlabel("Purity-adjusted tumor TPM, log10(TPM+1); black tick = bulk TPM")
     ax_range.set_title("Tumor Range", fontsize=12, fontweight="bold")
     ax_range.grid(axis="x", color="#dddddd", linewidth=0.6, alpha=0.7)
     ax_range.set_axisbelow(True)
+    if df_gene_expr is not None:
+        try:
+            from .common import build_sample_tpm_by_symbol
+            from .plot_reference_lines import add_p90_reference_line
 
-    note_cols = int(show_source_col) + int(show_normal_col) + 2
+            add_p90_reference_line(
+                ax_range,
+                build_sample_tpm_by_symbol(df_gene_expr),
+                orientation="vertical",
+                value_transform=_log_tpm,
+            )
+        except Exception:
+            pass
+
+    note_cols = int(show_source_col) + int(show_normal_col) + 3
     ax_note.set_xlim(0.0, note_cols + 0.05)
     ax_note.set_ylim(-0.5, len(rows) - 0.5)
     ax_note.invert_yaxis()
@@ -1083,6 +1179,8 @@ def plot_priority_target_context(
     if show_normal_col:
         header_cols.append((x, "Healthy tissues"))
         x += 1.0
+    header_cols.append((x, "Curation"))
+    x += 1.0
     header_cols.append((x, "Clinical maturity"))
     header_cols.append((x + 1.0, "Priority"))
     for xpos, text in header_cols:
@@ -1134,14 +1232,6 @@ def plot_priority_target_context(
         )
         for label, marker in _PRIORITY_SOURCE_MARKERS.items()
     ]
-    panel_handle = Line2D(
-        [0],
-        [0],
-        marker=None,
-        color="none",
-        linestyle="none",
-        label="* disease-matched curated target",
-    )
     normal_legend = fig.legend(
         handles=normal_handles,
         loc="lower center",
@@ -1153,7 +1243,7 @@ def plot_priority_target_context(
     )
     fig.add_artist(normal_legend)
     fig.legend(
-        handles=source_handles + [panel_handle],
+        handles=source_handles,
         loc="lower center",
         bbox_to_anchor=(0.76, 0.015),
         fontsize=8,

--- a/pirlygenes/plot_therapy.py
+++ b/pirlygenes/plot_therapy.py
@@ -234,7 +234,7 @@ def _apply_therapy_support_gate(symbol, therapies, fn1_support):
 
 
 ESSENTIAL_TISSUES = [
-    "brain", "heart_muscle", "liver", "lung", "kidney",
+    "brain", "heart", "liver", "lung", "kidney",
     "bone_marrow", "spleen", "pancreas", "colon", "stomach",
 ]
 
@@ -662,13 +662,12 @@ def plot_therapy_target_safety(
             ]
             max_ess = max(vals) if vals else 0
         y_value = max_ess + 0.1
-        marker = "^" if record["has_approved"] else "o"
         _draw_therapy_marker(
             ax,
             tpm,
             y_value,
             record["therapies"],
-            marker=marker,
+            marker="o",
             size=80,
             alpha=0.85,
             zorder=3,
@@ -702,27 +701,6 @@ def plot_therapy_target_safety(
         )
         for therapy in _THERAPY_PLOT_ORDER
     ]
-    marker_handles = [
-        Line2D(
-            [],
-            [],
-            marker="o",
-            linestyle="None",
-            color="#666666",
-            label="Trial-only target",
-            markersize=8,
-        ),
-        Line2D(
-            [],
-            [],
-            marker="^",
-            linestyle="None",
-            color="#666666",
-            markeredgecolor="black",
-            label="Approved target",
-            markersize=8,
-        ),
-    ]
     legend = ax.legend(
         handles=therapy_handles,
         loc="upper left",
@@ -732,14 +710,6 @@ def plot_therapy_target_safety(
         title_fontsize=9,
     )
     ax.add_artist(legend)
-    ax.legend(
-        handles=marker_handles,
-        loc="lower right",
-        fontsize=8,
-        frameon=False,
-        title="Marker",
-        title_fontsize=9,
-    )
 
     ax.set_xscale("log")
     ax.set_yscale("log")
@@ -753,6 +723,17 @@ def plot_therapy_target_safety(
         "(brain, heart, liver, lung, kidney, bone marrow, spleen, pancreas, colon, stomach)",
         fontsize=11,
     )
+    try:
+        from .common import build_sample_tpm_by_symbol
+        from .plot_reference_lines import add_p90_reference_line
+
+        add_p90_reference_line(
+            ax,
+            build_sample_tpm_by_symbol(df_gene_expr),
+            orientation="vertical",
+        )
+    except Exception:
+        pass
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
 
@@ -992,6 +973,17 @@ def plot_geneset_vs_vital_tissues(
     ax.set_xlim(0.05, 10_000)
     ax.axvline(toxicity_tpm_threshold, linestyle="--", color="#d62728",
                linewidth=0.8, alpha=0.5, zorder=1)
+    try:
+        from .common import build_sample_tpm_by_symbol
+        from .plot_reference_lines import add_p90_reference_line
+
+        add_p90_reference_line(
+            ax,
+            build_sample_tpm_by_symbol(df_gene_expr),
+            orientation="vertical",
+        )
+    except Exception:
+        pass
     ax.set_yticks(y)
     ax.set_yticklabels([r[0] for r in rows], fontsize=9)
     ax.invert_yaxis()
@@ -1256,6 +1248,12 @@ def plot_ctas_vs_cancer_type_detail(
         f"CTA detail — {cancer_code} (sample vs cohort / {origin_display} / testis / worst vital tissue)",
         fontweight="bold",
     )
+    try:
+        from .plot_reference_lines import add_p90_reference_line
+
+        add_p90_reference_line(ax, sample_tpm, orientation="vertical")
+    except Exception:
+        pass
     ax.grid(axis="x", alpha=0.25, zorder=0)
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
@@ -1380,11 +1378,51 @@ def plot_therapy_pathway_state(
     bucket_priority = {"up": 0, "down": 0, "mixed": 1, "indeterminate": 2}
     items.sort(key=lambda r: bucket_priority.get(r["state"], 2))
 
-    n_rows = len(items)
+    plot_rows = []
+    for axis_idx, item in enumerate(items):
+        panels = []
+        if item["up_fold"] is not None:
+            panels.append(
+                {
+                    "panel": "up",
+                    "fold": item["up_fold"],
+                    "n": item["up_n"],
+                    "marker": "o",
+                    "arrow": "\u2191",
+                    "panel_label": "expected-up genes",
+                    "legend_label": "genes expected up when pathway active",
+                }
+            )
+        if item["down_fold"] is not None:
+            panels.append(
+                {
+                    "panel": "down",
+                    "fold": item["down_fold"],
+                    "n": item["down_n"],
+                    "marker": "s",
+                    "arrow": "\u2193",
+                    "panel_label": "expected-down genes",
+                    "legend_label": "genes expected down when pathway active",
+                }
+            )
+        for panel_idx, panel in enumerate(panels):
+            plot_rows.append(
+                {
+                    **item,
+                    **panel,
+                    "axis_index": axis_idx,
+                    "axis_first_row": panel_idx == 0,
+                    "axis_last_row": panel_idx == len(panels) - 1,
+                    "axis_panel_count": len(panels),
+                }
+            )
+
+    n_rows = len(plot_rows)
     if figsize is None:
         # Reserve vertical room for the caption wrap. Width accommodates
-        # fold-range labels without the legend overflowing.
-        figsize = (12, max(4.0, 0.7 * n_rows + 2.8))
+        # fold labels without the legend overflowing. Up- and down-panel
+        # folds are separate rows because they are opposite evidence streams.
+        figsize = (12, max(4.0, 0.55 * n_rows + 2.8))
 
     fig = plt.figure(figsize=figsize)
     # Top area for the dumbbells, bottom for the narrative caption.
@@ -1398,42 +1436,47 @@ def plot_therapy_pathway_state(
 
     # --- Dumbbell plot ---
     y_positions = np.arange(n_rows)
-    for i, row in enumerate(items):
+    legend_seen = set()
+    for i, row in enumerate(plot_rows):
         color = _AXIS_STATE_COLOR.get(row["state"], "#555555")
 
-        up_fold = row["up_fold"]
-        down_fold = row["down_fold"]
+        fold = row["fold"]
+        if fold is None or fold <= 0:
+            continue
+        # Anchor each panel to baseline. Do not connect up- and down-panel
+        # folds: for suppressed pathways they move in opposite directions and
+        # connecting them implies a single continuum that is not biological.
+        ax.plot(
+            [min(1.0, fold), max(1.0, fold)],
+            [i, i],
+            color=color,
+            linewidth=3,
+            alpha=0.24,
+            solid_capstyle="round",
+            zorder=2,
+        )
+        legend_label = None
+        if row["panel"] not in legend_seen:
+            legend_label = row["legend_label"]
+            legend_seen.add(row["panel"])
+        ax.plot([fold], [i], marker=row["marker"], markersize=10.5,
+                color=color, markeredgecolor="white", markeredgewidth=1.4,
+                linestyle="", zorder=3, label=legend_label)
+        text_x = fold * (1.08 if fold >= 1.0 else 0.92)
+        ha = "left" if fold >= 1.0 else "right"
+        ax.text(text_x, i, f"{row['arrow']} {fold:.2f}\u00d7",
+                ha=ha, va="center", fontsize=8, color=color, fontweight="bold")
 
-        # X positions in log space — label axis as log for
-        # interpretability but compute on linear folds.
-        xs = [f for f in (up_fold, down_fold) if f is not None]
-        if len(xs) == 2:
-            x_min, x_max = min(xs), max(xs)
-            ax.plot([x_min, x_max], [i, i], color=color, linewidth=3, alpha=0.45,
-                    solid_capstyle="round", zorder=2)
-
-        if up_fold is not None:
-            ax.plot([up_fold], [i], marker="o", markersize=11,
-                    color=color, markeredgecolor="white", markeredgewidth=1.4,
-                    linestyle="", zorder=3,
-                    label="genes up when pathway active" if i == 0 else None)
-            ax.text(up_fold, i + 0.20, f"\u2191 {up_fold:.2f}\u00d7",
-                    ha="center", va="bottom", fontsize=8, color=color, fontweight="bold")
-        if down_fold is not None:
-            ax.plot([down_fold], [i], marker="s", markersize=10,
-                    color=color, markeredgecolor="white", markeredgewidth=1.4,
-                    linestyle="", zorder=3,
-                    label="genes down when pathway active" if i == 0 else None)
-            ax.text(down_fold, i - 0.26, f"\u2193 {down_fold:.2f}\u00d7",
-                    ha="center", va="top", fontsize=8, color=color, fontweight="bold")
+        if row["axis_last_row"] and i < n_rows - 1:
+            ax.axhline(i + 0.5, color="#eeeeee", linewidth=0.8, zorder=0)
 
     ax.axvline(1.0, color="#888888", linestyle="--", linewidth=1.0, alpha=0.7, zorder=1)
     ax.set_xscale("log")
     x_vals = []
-    for r in items:
-        for f in (r["up_fold"], r["down_fold"]):
-            if f is not None and f > 0:
-                x_vals.append(f)
+    for r in plot_rows:
+        f = r["fold"]
+        if f is not None and f > 0:
+            x_vals.append(f)
     if x_vals:
         lo = min(0.1, min(x_vals) * 0.7)
         hi = max(10.0, max(x_vals) * 1.4)
@@ -1444,19 +1487,16 @@ def plot_therapy_pathway_state(
     # Y-axis: label + state tag (color-coded)
     ax.set_yticks(y_positions)
     labels = []
-    for row in items:
+    for row in plot_rows:
         state_tag = {"up": "active", "down": "suppressed",
                      "mixed": "mixed", "indeterminate": "near baseline"}.get(
                          row["state"], row["state"])
-        n_info = ""
-        parts = []
-        if row["up_n"]:
-            parts.append(f"{row['up_n']} up")
-        if row["down_n"]:
-            parts.append(f"{row['down_n']} down")
-        if parts:
-            n_info = f"  ({', '.join(parts)})"
-        labels.append(f"{row['label']}  \u2014  {state_tag}{n_info}")
+        n_info = f" ({row['n']})" if row["n"] else ""
+        panel_text = f"{row['panel_label']}{n_info}"
+        if row["axis_first_row"]:
+            labels.append(f"{row['label']}  \u2014  {state_tag}\n  {panel_text}")
+        else:
+            labels.append(f"  \u21b3 {panel_text}")
     ax.set_yticklabels(labels, fontsize=10)
     ax.invert_yaxis()
     ax.spines["top"].set_visible(False)

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -494,7 +494,7 @@ def estimate_tumor_expression_ranges(
     # HPA tissues express the gene above the detection threshold) and
     # the **mean of the top-N healthy tissues**. Broadly-expressed genes
     # can't be attributed to one compartment cleanly; the per-gene
-    # attribution was silently inflating tumor-core residuals for
+    # attribution was silently inflating tumor-inferred residuals for
     # universally-expressed housekeeping-like and surface genes. These
     # two metrics drive a breadth floor on non-tumor attribution and a
     # new ``broadly_expressed`` reliability flag.
@@ -964,7 +964,7 @@ def estimate_tumor_expression_ranges(
         # (~26%) + T_cell (3%) + endothelial (3%) compartments couldn't
         # absorb the signal of broadly-expressed genes like CRIM1,
         # HLA-F, IL6ST, TBCE, NPM1 — so the residual defaulted into
-        # the "tumor core" and every one of these came out as 95–99%
+        # the tumor-inferred compartment and every one of these came out as 95–99%
         # tumor-attributed, which isn't defensible for genes expressed
         # in 15+ HPA tissues. The floor says: **for genes broadly
         # expressed, non-tumor cells in the sample carry a baseline

--- a/pirlygenes/plot_tumor_expr.py
+++ b/pirlygenes/plot_tumor_expr.py
@@ -1383,9 +1383,9 @@ def plot_matched_normal_attribution(
     For each of the top ``top_n`` genes in ``category`` (ranked by
     ``median_est``), draw a horizontal bar broken into:
 
-    - ``tumor``: ``observed_tpm - matched_normal_tpm - tme_only_tpm``
-    - ``matched_normal_tpm``: benign parent-tissue contribution
-    - ``tme_only_tpm``: stromal / immune / host-tissue contribution
+    - tumor-attributed bulk TPM from the decomposition residual
+    - matched-normal / benign parent-tissue contribution
+    - other background compartments from the decomposition attribution
 
     Only useful when ``df_ranges`` carries non-zero ``matched_normal_tpm``
     for at least one gene in the category (i.e. the decomposition ran
@@ -1413,13 +1413,63 @@ def plot_matched_normal_attribution(
     if figsize is None:
         figsize = (10, max(3.0, 0.4 * n + 1.5))
 
-    observed = sub["observed_tpm"].astype(float).values
-    mn = sub["matched_normal_tpm"].astype(float).values
-    tme = sub["tme_only_tpm"].astype(float).values
-    # Tumor-cell attribution is whatever observed signal remains after
-    # TME and matched-normal are subtracted. Floor at 0 to guard against
-    # tiny over-subtractions from solver jitter.
-    tumor_attr = np.maximum(0.0, observed - mn - tme)
+    def _safe_float_value(value, default=0.0):
+        try:
+            result = float(value)
+        except Exception:
+            return float(default)
+        if not np.isfinite(result):
+            return float(default)
+        return result
+
+    def _attribution_dict(value):
+        return value if isinstance(value, dict) else {}
+
+    def _split_display_components(row):
+        observed_value = _safe_float_value(row.get("observed_tpm"), 0.0)
+        matched_value = _safe_float_value(row.get("matched_normal_tpm"), 0.0)
+        other_value = _safe_float_value(row.get("tme_only_tpm"), 0.0)
+        tumor_value = max(0.0, observed_value - matched_value - other_value)
+
+        attr = _attribution_dict(row.get("attribution"))
+        if "attr_tumor_tpm" in row:
+            tumor_value = _safe_float_value(row.get("attr_tumor_tpm"), tumor_value)
+        if attr:
+            matched_from_attr = sum(
+                _safe_float_value(value)
+                for name, value in attr.items()
+                if str(name).startswith("matched_normal")
+            )
+            other_from_attr = sum(
+                _safe_float_value(value)
+                for name, value in attr.items()
+                if str(name) != "tumor"
+                and not str(name).startswith("matched_normal")
+            )
+            matched_value = max(matched_value, matched_from_attr)
+            other_value = max(other_value, other_from_attr)
+
+        tumor_value = max(0.0, min(tumor_value, observed_value))
+        matched_value = max(0.0, matched_value)
+        other_value = max(0.0, other_value)
+        # If robust attribution says tumor is small but the explicit
+        # background compartments are sparse/thresholded, do not put the
+        # unexplained remainder back into tumor. Keep the displayed stack
+        # faithful to the tumor-attribution residual.
+        other_value = max(other_value, observed_value - tumor_value - matched_value)
+
+        total = tumor_value + matched_value + other_value
+        if observed_value > 0 and total > observed_value:
+            scale = observed_value / total
+            tumor_value *= scale
+            matched_value *= scale
+            other_value *= scale
+        return tumor_value, matched_value, other_value
+
+    split_components = [_split_display_components(row) for _, row in sub.iterrows()]
+    tumor_attr = np.array([parts[0] for parts in split_components], dtype=float)
+    mn = np.array([parts[1] for parts in split_components], dtype=float)
+    tme = np.array([parts[2] for parts in split_components], dtype=float)
 
     y = np.arange(n)
     fig, ax = plt.subplots(figsize=figsize)
@@ -1428,16 +1478,6 @@ def plot_matched_normal_attribution(
     ax.barh(y, mn, left=tumor_attr, color="#3498db", label="matched-normal tissue")
     ax.barh(y, tme, left=tumor_attr + mn, color="#95a5a6", label="other TME (stromal/immune)")
 
-    # Symbols on the y-axis. Therapy-target annotation appended when present.
-    #
-    # Flag legend (kept short because they share the y-tick label):
-    #   ⚠  = a single healthy reference tissue could explain >= 50% of
-    #        observed (tme_explainable)
-    #   MN>obs = the fitted matched-normal reference alone predicts more
-    #        of this gene than the sample contains — attribution is
-    #        unreliable, expect tumor = 0 regardless of real biology
-    #        (#131). Replaces the cryptic "clamp" marker — the old
-    #        label read like a typo in the report.
     labels = []
     for _, row in sub.iterrows():
         sym = str(row["symbol"])
@@ -1445,7 +1485,7 @@ def plot_matched_normal_attribution(
             sym = f"{sym}  [{row['therapies']}]"
         flags = []
         if row.get("tme_explainable"):
-            flags.append("\u26a0")
+            flags.append("tissue-explainable")
         if row.get("matched_normal_over_predicted"):
             flags.append("MN>obs")
         elif str(row.get("estimation_path", "")) == "clamped":
@@ -1468,7 +1508,7 @@ def plot_matched_normal_attribution(
             if prior > 0:
                 ax.plot([prior], [i], marker="|", color="black", markersize=14, markeredgewidth=2)
 
-    ax.set_xlabel("TPM (stacked: tumor + matched-normal + other TME = observed)", fontsize=10)
+    ax.set_xlabel("Bulk TPM attribution (stacked: tumor + matched-normal + other background)", fontsize=10)
     ax.set_xscale("symlog", linthresh=1.0)
     ax.grid(axis="x", alpha=0.2)
     ax.legend(loc="lower right", fontsize=9, framealpha=0.9)
@@ -1490,7 +1530,7 @@ def plot_matched_normal_attribution(
             mn_tissue = nonempty[0]
     title = f"Matched-normal attribution \u2014 {cancer_code} {category}"
     if mn_tissue:
-        title += f"\n(benign {mn_tissue} subtracted before purity division; black tick = TCGA cohort prior)"
+        title += f"\n(benign {mn_tissue} and other decomposition background; black tick = TCGA cohort prior)"
     ax.set_title(title, fontsize=11, fontweight="bold")
 
     plt.tight_layout()
@@ -1625,13 +1665,10 @@ def plot_target_attribution(
         sym = str(row["symbol"])
         if row.get("therapies"):
             sym = f"{sym}  [{row['therapies']}]"
-        flags = []
         if row.get("tme_dominant"):
-            flags.append("\u26a0\u26a0")
+            sym = f"{sym}  tumor-low"
         elif row.get("tme_explainable"):
-            flags.append("\u26a0")
-        if flags:
-            sym = f"{sym}  {' '.join(flags)}"
+            sym = f"{sym}  tissue-explainable"
         labels.append(sym)
     ax.set_yticks(y)
     ax.set_yticklabels(labels, fontsize=9)
@@ -1650,8 +1687,7 @@ def plot_target_attribution(
     }.get(category, category.replace("_", " "))
     ax.set_title(
         f"Target source breakdown — {cat_label} — {cancer_code}\n"
-        "Selected to show clinically relevant genes plus mixed/background cases "
-        "(\u26a0\u26a0 = tumor < 30% of observed; \u26a0 = single-tissue-explainable)",
+        "Selected to show clinically relevant genes plus mixed/background cases",
         fontsize=10, fontweight="bold",
     )
     # Sample-wide 90th-percentile reference line (faint dashed).
@@ -2037,6 +2073,17 @@ def plot_purity_adjusted_targets(
     ax1.set_title(f"Purity-adjusted tumor expression \u2014 {cancer_code} (purity={purity:.0%})")
     ax1.invert_yaxis()
     ax1.legend(fontsize=8, loc="lower right")
+    try:
+        from .common import build_sample_tpm_by_symbol
+        from .plot_reference_lines import add_p90_reference_line
+
+        add_p90_reference_line(
+            ax1,
+            build_sample_tpm_by_symbol(df_gene_expr),
+            orientation="vertical",
+        )
+    except Exception:
+        pass
 
     # Right: TCGA percentile heatmap
     pctiles = selected["tcga_percentile"].values

--- a/pirlygenes/provenance.py
+++ b/pirlygenes/provenance.py
@@ -5,7 +5,7 @@
 The existing reports (summary, analysis, targets, brief, actionable)
 each surface different parts of the 5-step attribution chain:
 
-    library prep -> preservation -> coarse TME -> fine subtypes -> tumor core
+    library prep -> preservation -> coarse TME -> fine subtypes -> tumor-inferred expression
 
 Readers have to reassemble the chain mentally. The provenance page is
 the assembled view in one ~30-line document plus a simple stacked-bar
@@ -52,7 +52,7 @@ def build_provenance_md(
 
     Each step states its input and what it deducts from the naive
     "all signal is tumor" interpretation so the reader can follow the
-    chain from raw TPMs to a conservative tumor core.
+    chain from raw TPMs to conservative tumor-inferred expression.
     """
     sample_context = analysis.get("sample_context")
     purity = analysis.get("purity") or {}

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -828,6 +828,16 @@ def _therapy_path_context_for_tier(target_row, tier: str, note: str = "") -> str
         return ""
 
     suffix = _clean_text(note) or _THERAPY_PATH_DEFAULT_NOTE.get(tier, "")
+    suffix_lc = suffix.lower()
+    prefix_lc = prefix.lower()
+    if suffix_lc == prefix_lc:
+        suffix = ""
+    elif suffix_lc.startswith(prefix_lc + ";"):
+        suffix = suffix[len(prefix):].lstrip(" ;")
+    elif suffix_lc.startswith(prefix_lc + ","):
+        suffix = suffix[len(prefix):].lstrip(" ,")
+    elif suffix_lc.startswith(prefix_lc + " -"):
+        suffix = suffix[len(prefix):].lstrip(" -")
     if suffix:
         return f"{prefix}; {suffix}"
     return prefix

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -481,6 +481,30 @@ def normal_expression_context(row):
 
 def clinical_maturity_info(target_row, target_panel=None):
     """Summarize maturity from the current row and its curated siblings."""
+    def _display_agent_class(value):
+        text = _clean_text(value).replace("_", " ")
+        if not text:
+            return ""
+        acronym_map = {
+            "adc": "ADC",
+            "tce": "TCE",
+            "car t": "CAR-T",
+            "cart": "CAR-T",
+            "tcr t": "TCR-T",
+            "tcrt": "TCR-T",
+            "pmhc": "pMHC",
+            "mhc": "MHC",
+        }
+        lowered = text.lower()
+        if lowered in acronym_map:
+            return acronym_map[lowered]
+        return re.sub(
+            r"\b(adc|tce|car-t|tcr-t|pmhc|mhc)\b",
+            lambda match: acronym_map.get(match.group(1).lower(), match.group(1).upper()),
+            text,
+            flags=re.IGNORECASE,
+        )
+
     phase = _clean_text(target_row.get("phase"))
     phase_label = {
         "approved": "approved",
@@ -489,7 +513,7 @@ def clinical_maturity_info(target_row, target_panel=None):
         "phase_1": "early clinical",
         "preclinical": "preclinical",
     }.get(phase, phase or "curated")
-    agent_class = _clean_text(target_row.get("agent_class")).replace("_", " ")
+    agent_class = _display_agent_class(target_row.get("agent_class"))
     summary = phase_label
     if agent_class:
         summary += f" {agent_class}"
@@ -536,7 +560,7 @@ def clinical_maturity_info(target_row, target_panel=None):
     )
     extras = []
     if n_agents > 1:
-        extras.append(f"{n_agents} curated agents")
+        extras.append(f"{n_agents} agents")
     if n_modalities > 1:
         extras.append(f"{n_modalities} modalities")
     if extras:

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -600,6 +600,35 @@ _MAPK_RTK_AGENTS = re.compile(
     r")\b",
     re.IGNORECASE,
 )
+THERAPY_PATH_TIERS = frozenset(
+    {
+        "approved_standard",
+        "approved_indication_matched",
+        "approved_later_line",
+        "late_clinical",
+        "trial_follow_up",
+        "preclinical",
+        "off_label",
+    }
+)
+_THERAPY_PATH_RANK = {
+    "approved_standard": 0,
+    "approved_indication_matched": 1,
+    "approved_later_line": 2,
+    "late_clinical": 3,
+    "trial_follow_up": 4,
+    "preclinical": 6,
+    "off_label": 7,
+}
+_THERAPY_PATH_DEFAULT_NOTE = {
+    "approved_standard": "confirm indication and line of therapy",
+    "approved_indication_matched": "confirm clinical eligibility",
+    "approved_later_line": "confirm prior therapies and indication-specific eligibility",
+    "late_clinical": "not default standard",
+    "trial_follow_up": "not default standard",
+    "preclinical": "not a clinical recommendation",
+    "off_label": "confirm rationale and alternatives",
+}
 _THERAPY_EXPOSURE_RULES = (
     {
         "axis": "AR_signaling",
@@ -711,7 +740,56 @@ def _therapy_row_matches_exposure_rule(target_row, rule: dict) -> bool:
     return False
 
 
-def _therapy_path_info(target_row) -> dict:
+def _therapy_path_context_for_tier(target_row, tier: str, note: str = "") -> str:
+    agent_class = _agent_class_text(target_row)
+    if tier == "approved_standard":
+        prefix = "guideline-standard approved pathway"
+    elif tier == "approved_indication_matched":
+        prefix = "approved biomarker/indication-matched pathway"
+    elif tier == "approved_later_line":
+        prefix = (
+            "approved radioligand pathway"
+            if "radioligand" in agent_class
+            else "approved later-line pathway"
+        )
+    elif tier == "late_clinical":
+        prefix = "late-clinical follow-up"
+    elif tier == "trial_follow_up":
+        prefix = "clinical-trial follow-up"
+    elif tier == "preclinical":
+        prefix = "preclinical follow-up"
+    elif tier == "off_label":
+        prefix = "off-label follow-up"
+    else:
+        return ""
+
+    suffix = _clean_text(note) or _THERAPY_PATH_DEFAULT_NOTE.get(tier, "")
+    if suffix:
+        return f"{prefix}; {suffix}"
+    return prefix
+
+
+def _explicit_therapy_path_info(target_row) -> dict | None:
+    tier = _clean_text(
+        target_row.get("treatment_path_tier")
+        if hasattr(target_row, "get") else ""
+    ).lower()
+    if not tier:
+        return None
+    if tier not in THERAPY_PATH_TIERS:
+        return None
+    note = _clean_text(
+        target_row.get("eligibility_note") if hasattr(target_row, "get") else ""
+    )
+    return {
+        "tier": tier,
+        "rank": _THERAPY_PATH_RANK.get(tier, 99),
+        "context": _therapy_path_context_for_tier(target_row, tier, note),
+        "source": "curated",
+    }
+
+
+def _inferred_therapy_path_info(target_row) -> dict:
     phase = _phase_text(target_row)
     agent_class = _agent_class_text(target_row)
     text = _therapy_row_text(target_row)
@@ -727,6 +805,7 @@ def _therapy_path_info(target_row) -> dict:
                     "approved radioligand pathway; confirm imaging/eligibility "
                     "and prior-line requirements"
                 ),
+                "source": "inferred",
             }
         if is_standard:
             return {
@@ -736,6 +815,7 @@ def _therapy_path_info(target_row) -> dict:
                     "guideline-standard approved pathway; confirm the indication "
                     "and line of therapy"
                 ),
+                "source": "inferred",
             }
         if is_later_line:
             return {
@@ -745,6 +825,7 @@ def _therapy_path_info(target_row) -> dict:
                     "approved later-line pathway; confirm prior therapies and "
                     "indication-specific eligibility"
                 ),
+                "source": "inferred",
             }
         return {
             "tier": "approved_indication_matched",
@@ -753,6 +834,7 @@ def _therapy_path_info(target_row) -> dict:
                 "approved biomarker/indication-matched pathway; confirm clinical "
                 "eligibility"
             ),
+            "source": "inferred",
         }
 
     phase_context = {
@@ -763,7 +845,11 @@ def _therapy_path_info(target_row) -> dict:
         "off_label": ("off_label", 7, "off-label follow-up; confirm rationale and alternatives"),
     }
     tier, rank, context = phase_context.get(phase, ("unknown", 99, ""))
-    return {"tier": tier, "rank": rank, "context": context}
+    return {"tier": tier, "rank": rank, "context": context, "source": "inferred"}
+
+
+def _therapy_path_info(target_row) -> dict:
+    return _explicit_therapy_path_info(target_row) or _inferred_therapy_path_info(target_row)
 
 
 def therapy_path_tier(target_row) -> str:

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -188,11 +188,11 @@ def tumor_attribution_context(row):
 
 
 def tpm_semantics_note() -> str:
-    """One reader-facing explanation of bulk vs modeled tumor-core TPM."""
+    """One reader-facing explanation of bulk vs modeled tumor-inferred TPM."""
     return (
         "**TPM semantics:** Bulk TPM is the measured RNA abundance in the mixed "
-        "specimen. Tumor-core TPM is a model-derived estimate after subtracting "
-        "matched-normal and TME-attributable signal. Use tumor-core TPM for "
+        "specimen. Tumor-inferred TPM is a model-derived estimate after subtracting "
+        "matched-normal and TME-attributable signal. Use tumor-inferred TPM for "
         "tumor-cell target prioritization only when attribution is tumor-supported "
         "or mixed-source; for immune/stromal markers, agent-only rows, and "
         "expression-independent indications, bulk RNA is contextual and the "
@@ -337,12 +337,50 @@ def target_reliability_reasons(row, *, category=None):
     return reasons
 
 
+def same_lineage_material_target_candidate(
+    row,
+    target_row=None,
+    *,
+    min_tumor_tpm=10.0,
+) -> bool:
+    """Whether a same-lineage clinical target should remain reviewable.
+
+    Matched-normal attribution for a lineage marker is different from
+    unrelated immune/stromal attribution: it is a source and specificity
+    caveat, not automatic evidence that the target is clinically irrelevant.
+    Keep such rows provisional when there is a named clinical agent and a
+    material tumor-inferred signal.
+    """
+    if target_row is None or expression_independent_indication(target_row):
+        return False
+    phase = _clean_text(target_row.get("phase"))
+    if phase not in {"approved", "phase_3", "phase_2", "phase_1"}:
+        return False
+    if not _clean_text(target_row.get("agent")):
+        return False
+    if _truthy(row.get("tme_dominant")) and not _truthy(row.get("matched_normal_over_predicted")):
+        return False
+    if _safe_float(row.get("attr_tumor_tpm"), 0.0) < float(min_tumor_tpm):
+        return False
+    normal = normal_expression_context(row)
+    if normal.get("tier") != "same_lineage_expected":
+        return False
+    top_compartment = _clean_text(row.get("attr_top_compartment")).replace("_", " ")
+    return (
+        top_compartment.startswith("matched normal ")
+        or _truthy(row.get("matched_normal_over_predicted"))
+        or _safe_float(row.get("matched_normal_tpm"), 0.0) > 0.0
+    )
+
+
 def target_reliability_status(row, *, category=None, target_row=None):
     """Classify a row as ``supported``, ``provisional``, or ``unsupported``."""
     if target_row is not None and expression_independent_indication(target_row):
         return "provisional"
     source = tumor_attribution_context(row)
     if source["tier"] == "background_dominant":
+        if same_lineage_material_target_candidate(row, target_row=target_row):
+            return "provisional"
         return "unsupported"
     if _truthy(row.get("matched_normal_over_predicted")):
         return "provisional"
@@ -426,6 +464,8 @@ def normal_expression_context(row):
     matched_normal_tpm = _safe_float(row.get("matched_normal_tpm"), 0.0)
     tumor_tpm = _safe_float(row.get("attr_tumor_tpm"), 0.0)
     attr_top = _clean_text(row.get("attr_top_compartment")).replace("_", " ")
+    if not matched_tissue and attr_top.startswith("matched normal "):
+        matched_tissue = attr_top.replace("matched normal ", "", 1)
     details = []
     same_lineage = False
     if matched_tissue:
@@ -977,7 +1017,7 @@ def target_interpretation_summary(
 
 
 def partition_tumor_core_rows(ranges_df, min_tumor_tpm=1.0):
-    """Split expression rows by report-facing tumor-core reliability."""
+    """Split expression rows by report-facing tumor-inferred reliability."""
     if ranges_df is None or len(ranges_df) == 0 or "attr_tumor_tpm" not in ranges_df.columns:
         empty = ranges_df.iloc[0:0] if ranges_df is not None else None
         return empty, empty, empty

--- a/pirlygenes/reporting.py
+++ b/pirlygenes/reporting.py
@@ -102,7 +102,11 @@ def subtype_curation_scope_note(
     base_label = cancer_code_display_name(base_code, fallback=base_name).lower()
     subtype_label = _clean_text(panel_subtype).replace("_", " ").lower()
     if subtype_label:
-        focus = f"{subtype_label} {panel_name}".strip()
+        focus = (
+            subtype_label
+            if subtype_label.endswith(panel_name)
+            else f"{subtype_label} {panel_name}".strip()
+        )
     else:
         focus = panel_name
     if not base_label or focus == base_label:
@@ -139,7 +143,7 @@ def tumor_attribution_context(row):
     if _truthy(row.get("low_purity_cap_applied")):
         notes.append("low-purity cap is active")
     if _truthy(row.get("tme_explainable")) and support_fraction < 1.0:
-        notes.append("healthy-tissue-only explanations remain plausible")
+        notes.append("non-tumor tissue explanations remain plausible")
     if _truthy(row.get("tme_dominant")):
         notes.append("most fitted signal remains non-tumor")
 
@@ -283,6 +287,35 @@ def expression_independent_interpretation(target_row) -> str:
     if indication_biomarker(target_row) == "histology_only":
         return "expression-independent indication — confirm clinical eligibility"
     return f"expression-independent indication — confirm {label} status"
+
+
+def expression_independent_rna_context(expression_row) -> str:
+    """Explain RNA values for eligibility that is not expression-gated."""
+    if expression_row is None:
+        return "target RNA not measured; eligibility is not inferred from expression"
+    observed = _safe_float(expression_row.get("observed_tpm"), 0.0)
+    return (
+        f"target RNA is contextual only (bulk {observed:.1f} TPM; "
+        "eligibility is not inferred from expression)"
+    )
+
+
+def report_disease_state_text(disease_state: str | None, analysis=None) -> str:
+    """Consistent disease-state sentence for Markdown reports.
+
+    ``compose_disease_state_narrative`` intentionally returns an empty
+    string when no positive state rule fires. In clinician-facing
+    Markdown, silence reads like missing propagation rather than a
+    negative finding, so reports render a bounded no-pattern statement
+    when therapy-state panels were actually evaluated.
+    """
+    text = _clean_text(disease_state)
+    if text:
+        return text
+    scores = analysis.get("therapy_response_scores") if isinstance(analysis, dict) else None
+    if scores:
+        return "No strong RNA-defined therapy-exposure or pathway-state pattern passed reporting thresholds."
+    return ""
 
 
 def tumor_attribution_band_text(row):
@@ -1001,13 +1034,19 @@ def target_interpretation_summary(
         clinical_maturity_summary(target_row, target_panel=target_panel)
         if target_row is not None else ""
     )
-    if target_row is not None and expression_independent_indication(target_row):
-        parts = [expression_independent_interpretation(target_row), source["band"]]
+    expr_independent = (
+        target_row is not None and expression_independent_indication(target_row)
+    )
+    if expr_independent:
+        parts = [
+            expression_independent_interpretation(target_row),
+            expression_independent_rna_context(expression_row),
+        ]
     else:
         parts = [source["label"], source["band"]]
-    parts.append(normal["label"])
+        parts.append(normal["label"])
     details = list(normal.get("details") or [])
-    if details:
+    if details and not expr_independent:
         parts.append(details[0])
     path_context = (
         therapy_path_context(target_row, analysis=analysis, disease_state=disease_state)

--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -957,7 +957,7 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
         ),
     ]
     if sample_context.missing_mt:
-        header_lines.append("⚠ MT genes missing from quant table")
+        header_lines.append("MT genes missing from quant table")
 
     ax_text.text(
         0.02, 0.95, "Sample context",
@@ -1055,7 +1055,7 @@ def plot_sample_context(sample_context: SampleContext, save_to_filename: str,
     for yi, val, band in zip(y, values, bar_bands):
         if band is not None:
             lo, hi, _ = band
-            status = "✓" if lo <= val <= hi else ("⚠" if val < lo * 0.5 or val > hi * 2 else "~")
+            status = "ok" if lo <= val <= hi else ("out" if val < lo * 0.5 or val > hi * 2 else "~")
         else:
             status = ""
         ax_bars.text(val, yi, f"  {val:.3f} {status}", va="center", fontsize=9)

--- a/pirlygenes/sample_context.py
+++ b/pirlygenes/sample_context.py
@@ -103,6 +103,15 @@ def library_prep_display_label(prep: str | None, *, title_case: bool = False) ->
     return label
 
 
+def library_prep_clause(prep: str | None, *, title_case: bool = False) -> str:
+    """Human phrase for report prose, including ``library`` when helpful."""
+    label = library_prep_display_label(prep, title_case=title_case)
+    low = label.lower()
+    if "library" in low or "prep" in low:
+        return label
+    return f"{label} library"
+
+
 # ── Thresholds ────────────────────────────────────────────────────────────
 # Calibrated from ENCODE total-RNA vs poly-A replicates and a TCGA
 # poly-A-capture snapshot. Values are conservative — the inference

--- a/scripts/audit_therapy_path_curation.py
+++ b/scripts/audit_therapy_path_curation.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate structured therapy-path curation in cancer-key-genes.csv."""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+import sys
+
+from pirlygenes.reporting import THERAPY_PATH_TIERS
+
+
+PHASE_BY_TIER = {
+    "approved_standard": {"approved"},
+    "approved_indication_matched": {"approved"},
+    "approved_later_line": {"approved"},
+    "late_clinical": {"phase_3"},
+    "trial_follow_up": {"phase_1", "phase_2"},
+    "preclinical": {"preclinical"},
+    "off_label": {"off_label"},
+}
+
+
+def main() -> int:
+    path = Path("pirlygenes/data/cancer-key-genes.csv")
+    rows = list(csv.DictReader(path.open(newline="")))
+    targets = [row for row in rows if (row.get("role") or "").strip() == "target"]
+    errors = []
+    counts = Counter()
+
+    for idx, row in enumerate(targets, start=2):
+        label = (
+            f"line {idx} {row.get('cancer_code')}:{row.get('symbol')}:"
+            f"{row.get('agent')}"
+        )
+        tier = (row.get("treatment_path_tier") or "").strip()
+        line = (row.get("line_of_therapy") or "").strip()
+        note = (row.get("eligibility_note") or "").strip()
+        phase = (row.get("phase") or "").strip()
+
+        if not tier:
+            errors.append(f"{label}: missing treatment_path_tier")
+            continue
+        if tier not in THERAPY_PATH_TIERS:
+            errors.append(f"{label}: invalid treatment_path_tier={tier!r}")
+            continue
+        if not line:
+            errors.append(f"{label}: missing line_of_therapy")
+        if not note:
+            errors.append(f"{label}: missing eligibility_note")
+        if phase not in PHASE_BY_TIER[tier]:
+            errors.append(f"{label}: phase {phase!r} incompatible with tier {tier!r}")
+        counts[tier] += 1
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(targets)} target rows")
+    for tier, count in sorted(counts.items()):
+        print(f"{tier}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_therapy_path_curation.py
+++ b/scripts/audit_therapy_path_curation.py
@@ -28,6 +28,8 @@ def main() -> int:
     targets = [row for row in rows if (row.get("role") or "").strip() == "target"]
     errors = []
     counts = Counter()
+    sourced_rows = 0
+    pmid_sourced_rows = 0
 
     for idx, row in enumerate(targets, start=2):
         label = (
@@ -51,6 +53,11 @@ def main() -> int:
             errors.append(f"{label}: missing eligibility_note")
         if phase not in PHASE_BY_TIER[tier]:
             errors.append(f"{label}: phase {phase!r} incompatible with tier {tier!r}")
+        source = (row.get("source") or "").strip()
+        if source:
+            sourced_rows += 1
+            if "PMID:" in source:
+                pmid_sourced_rows += 1
         counts[tier] += 1
 
     if errors:
@@ -59,6 +66,11 @@ def main() -> int:
         return 1
 
     print(f"Validated {len(targets)} target rows")
+    print(
+        f"Rows with source citations: {sourced_rows}/{len(targets)} "
+        f"({sourced_rows / max(len(targets), 1):.1%})"
+    )
+    print(f"Rows with PMID citations: {pmid_sourced_rows}/{len(targets)}")
     for tier, count in sorted(counts.items()):
         print(f"{tier}: {count}")
     return 0

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from pirlygenes.brief import build_brief, build_actionable
+from pirlygenes.brief import build_brief, build_actionable, _shortlist_omission_note
 from pirlygenes.confidence import ConfidenceTier
 
 
@@ -147,6 +147,19 @@ def test_brief_reports_tumor_attributed_for_present_targets():
     assert "128" in md or "**FOLH1**" in md
 
 
+def test_brief_renders_no_pattern_disease_state_when_scores_exist():
+    analysis = _make_analysis()
+    analysis["therapy_response_scores"] = {"IFN_response": object()}
+    ranges_df = _make_ranges_df()
+    md = build_brief(
+        analysis,
+        ranges_df,
+        cancer_code="PRAD",
+        disease_state="",
+    )
+    assert "No strong RNA-defined therapy-exposure" in md
+
+
 def test_brief_prioritizes_ar_path_and_flags_possible_current_therapy():
     from pirlygenes.therapy_response import TherapyAxisScore
 
@@ -201,6 +214,32 @@ def test_brief_uses_path_maturity_across_cancer_types_not_prad_special_case():
     assert "guideline-standard approved pathway" in erbb2_line
     tacstd2_line = next(line for line in md.splitlines() if line.startswith("- **TACSTD2**"))
     assert "approved later-line pathway" in tacstd2_line
+
+
+def test_expression_independent_therapy_summary_keeps_rna_contextual():
+    analysis = _make_analysis()
+    analysis["cancer_type"] = "COAD"
+    analysis["cancer_name"] = "Colon adenocarcinoma"
+    ranges_df = pd.DataFrame([
+        {
+            "symbol": "CD274", "observed_tpm": 0.0,
+            "attr_tumor_tpm": 0.0, "attr_tumor_fraction": 0.0,
+            "attr_top_compartment": "", "attr_top_compartment_tpm": 0.0,
+            "tme_dominant": False, "tme_explainable": False,
+        },
+    ])
+    md = build_brief(
+        analysis,
+        ranges_df,
+        cancer_code="COAD",
+        disease_state="",
+    )
+    pdcd1_line = next(line for line in md.splitlines() if line.startswith("- **CD274**"))
+    assert "expression-independent indication" in pdcd1_line
+    assert "target RNA is contextual only" in pdcd1_line
+    assert "Clinical maturity: approved antibody" in pdcd1_line
+    assert "; Clinical maturity" not in pdcd1_line
+    assert "model interval" not in pdcd1_line
 
 
 def test_brief_flags_possible_current_endocrine_therapy_beyond_prad():
@@ -272,6 +311,78 @@ def test_brief_explains_bulk_present_targets_that_fail_source_gate():
     assert "KLK2" in md
     assert "matched-normal prostate" in md
     assert "phase 1 exploratory" in md
+
+
+def test_source_trace_renders_when_top_trial_rows_are_mixed_source():
+    target = pd.Series({
+        "symbol": "TARGET1",
+        "phase": "phase_2",
+        "agent": "trial drug",
+        "agent_class": "antibody",
+        "treatment_path_tier": "trial_follow_up",
+        "eligibility_note": "not default standard",
+    })
+    expr = pd.Series({
+        "symbol": "TARGET1",
+        "observed_tpm": 20.0,
+        "attr_tumor_tpm": 8.0,
+        "attr_tumor_fraction": 0.40,
+        "attr_top_compartment": "",
+        "attr_top_compartment_tpm": 0.0,
+        "tme_dominant": False,
+        "tme_explainable": False,
+    })
+    md = _shortlist_omission_note(
+        pd.DataFrame([target]),
+        pd.DataFrame([expr]),
+        [(target, expr)],
+    )
+    assert "Target expression source trace" in md
+    assert "none modeled" in md
+
+
+def test_source_trace_does_not_call_non_lineage_component_lineage_background():
+    top = pd.Series({
+        "symbol": "TOP",
+        "phase": "phase_2",
+        "agent": "trial drug",
+        "agent_class": "antibody",
+    })
+    top_expr = pd.Series({
+        "symbol": "TOP",
+        "observed_tpm": 20.0,
+        "attr_tumor_tpm": 12.0,
+        "attr_tumor_fraction": 0.60,
+        "attr_top_compartment": "osteoblast",
+        "attr_top_compartment_tpm": 1.0,
+        "tme_dominant": False,
+        "tme_explainable": False,
+    })
+    omitted = pd.Series({
+        "symbol": "ERBB2",
+        "phase": "phase_2",
+        "agent": "trial drug",
+        "agent_class": "ADC",
+    })
+    omitted_expr = pd.Series({
+        "symbol": "ERBB2",
+        "observed_tpm": 25.0,
+        "attr_tumor_tpm": 0.0,
+        "attr_tumor_fraction": 0.0,
+        "attr_top_compartment": "osteoblast",
+        "attr_top_compartment_tpm": 8.0,
+        "matched_normal_over_predicted": True,
+        "tme_dominant": True,
+        "tme_explainable": True,
+    })
+    md = _shortlist_omission_note(
+        pd.DataFrame([top, omitted]),
+        pd.DataFrame([top_expr, omitted_expr]),
+        [(top, top_expr)],
+    )
+    erbb2_line = next(line for line in md.splitlines() if line.startswith("| ERBB2 "))
+    assert "osteoblast over-predicts / non-tumor background" in erbb2_line
+    assert "osteoblast over-predicts / lineage background" not in erbb2_line
 
 
 def test_brief_no_internal_jargon():

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -240,9 +240,13 @@ def test_brief_explains_bulk_present_targets_that_fail_source_gate():
         cancer_code="PRAD",
         disease_state="",
     )
-    assert "Not short-listed despite bulk RNA" in md
+    assert "Target expression source trace" in md
+    assert "Tumor-inferred TPM" in md
+    assert "Top non-tumor attribution" in md
     assert "STEAP2" in md
     assert "KLK2" in md
+    assert "matched-normal prostate" in md
+    assert "phase 1 exploratory" in md
 
 
 def test_brief_no_internal_jargon():

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -99,6 +99,31 @@ def test_brief_is_compact():
     assert "Top candidate therapies" in md
 
 
+def test_low_confidence_call_punctuation_is_clean():
+    analysis = _make_analysis()
+    analysis["candidate_trace"] = [{
+        "code": "PRAD",
+        "support_geomean": 0.4,
+        "signature_score": 0.4,
+    }]
+    analysis["fit_quality"] = {"label": "weak", "message": "flat signature"}
+    ranges_df = _make_ranges_df()
+
+    md = build_brief(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="",
+    )
+    cancer_line = next(line for line in md.splitlines() if line.startswith("**Cancer call:**"))
+    assert "). —" not in cancer_line
+
+    actionable = build_actionable(
+        analysis, ranges_df, cancer_code="PRAD",
+        disease_state="",
+    )
+    working_line = next(line for line in actionable.splitlines() if line.startswith("Working call:"))
+    assert "). —" not in working_line
+
+
 def test_brief_excludes_absent_targets():
     analysis = _make_analysis()
     ranges_df = _make_ranges_df()

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -2,6 +2,7 @@
 
 from pirlygenes.confidence import (
     ConfidenceTier,
+    concise_confidence_reasons,
     compute_purity_confidence,
     compute_target_confidence,
 )
@@ -32,6 +33,18 @@ def test_wide_ci_low_tier():
     assert tier.tier == "low"
     assert "wide purity CI" in tier.inline_note
     assert tier.badge == "low"
+
+
+def test_concise_call_confidence_reasons_keep_summary_skimmable():
+    tier = ConfidenceTier(
+        tier="moderate",
+        reasons=[
+            "fit quality is ambiguous — preserve alternate cancer hypotheses (long detail)",
+            "top candidate SARC beats runner-up ESCA by only 4% on geomean (0.498 vs 0.477) — call is ambiguous",
+            "Step-0 correlation favored BLCA but the classifier picked SARC",
+        ],
+    )
+    assert concise_confidence_reasons(tier) == "ambiguous fit; near tie with ESCA; Step-0 favors BLCA"
 
 
 def test_low_purity_regime_bumps_tier():

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,7 +1,5 @@
 """Tests for the confidence-tier module (#109)."""
 
-import pytest
-
 from pirlygenes.confidence import (
     ConfidenceTier,
     compute_purity_confidence,
@@ -33,7 +31,7 @@ def test_wide_ci_low_tier():
     tier = compute_purity_confidence(_purity(0.64, 0.19, 1.00))
     assert tier.tier == "low"
     assert "wide purity CI" in tier.inline_note
-    assert tier.badge == "⚠⚠"
+    assert tier.badge == "low"
 
 
 def test_low_purity_regime_bumps_tier():

--- a/tests/test_load_expression.py
+++ b/tests/test_load_expression.py
@@ -283,6 +283,37 @@ def test_load_expression_selects_wide_sample_column(tmp_path, monkeypatch):
     assert list(out["TPM"]) == [7.0, 8.0]
 
 
+def test_load_expression_wide_sample_preserves_explicit_gene_columns(tmp_path, monkeypatch):
+    p = tmp_path / "wide_custom_gene_cols.tsv"
+    pd.DataFrame(
+        {
+            "Stable ID": ["ENSG1", "ENSG2"],
+            "Hugo_Symbol": ["A", "B"],
+            "sample_a": [7.0, 8.0],
+            "sample_b": [99.0, 100.0],
+        }
+    ).to_csv(p, sep="\t", index=False)
+
+    monkeypatch.setattr(
+        le,
+        "find_gene_name_from_ensembl_gene_id",
+        lambda gid: {"ENSG1": "A", "ENSG2": "B"}[gid],
+    )
+
+    out = le.load_expression_data(
+        str(p),
+        sample_id_value="sample_a",
+        gene_name_col="Hugo_Symbol",
+        gene_id_col="Stable ID",
+        verbose=False,
+        progress=False,
+    )
+
+    assert list(out["ensembl_gene_id"]) == ["ENSG1", "ENSG2"]
+    assert list(out["gene"]) == ["A", "B"]
+    assert list(out["TPM"]) == [7.0, 8.0]
+
+
 def test_load_expression_error_paths(tmp_path):
     p = tmp_path / "expr.csv"
     pd.DataFrame({"TPM": [1.0]}).to_csv(p, index=False)

--- a/tests/test_load_expression.py
+++ b/tests/test_load_expression.py
@@ -1,5 +1,4 @@
 import warnings
-from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -171,6 +170,30 @@ def test_load_expression_gene_id_only_with_tpm_alias(tmp_path, monkeypatch):
     assert list(out["TPM"]) == [1.5, 2.5]
 
 
+def test_load_expression_accepts_kallisto_gene_abundance_column(tmp_path, monkeypatch):
+    p = tmp_path / "gene_abundance.tsv"
+    pd.DataFrame(
+        {
+            "gene_name": ["A", "B"],
+            "gene": ["ENSG1", "ENSG2"],
+            "abundance": [4.0, 5.0],
+            "counts": [40, 50],
+            "length": [1000, 1200],
+        }
+    ).to_csv(p, sep="\t", index=False)
+
+    monkeypatch.setattr(
+        le,
+        "find_gene_name_from_ensembl_gene_id",
+        lambda gid: {"ENSG1": "A", "ENSG2": "B"}[gid],
+    )
+
+    out = le.load_expression_data(str(p), verbose=False, progress=False)
+
+    assert list(out["ensembl_gene_id"]) == ["ENSG1", "ENSG2"]
+    assert list(out["TPM"]) == [4.0, 5.0]
+
+
 def test_load_expression_prebuilds_indexes_before_canonical_name_progress(tmp_path, monkeypatch):
     p = tmp_path / "expr.csv"
     pd.DataFrame(
@@ -229,6 +252,35 @@ def test_load_expression_select_sample_rows(tmp_path, monkeypatch):
     )
     assert list(out["ensembl_gene_id"]) == ["ENSG1", "ENSG2"]
     assert list(out["TPM"]) == [5.0, 6.0]
+
+
+def test_load_expression_selects_wide_sample_column(tmp_path, monkeypatch):
+    p = tmp_path / "wide.tsv"
+    pd.DataFrame(
+        {
+            "gene_id": ["ENSG1", "ENSG2"],
+            "gene_name": ["A", "B"],
+            "sample_a": [7.0, 8.0],
+            "sample_b": [99.0, 100.0],
+        }
+    ).to_csv(p, sep="\t", index=False)
+
+    monkeypatch.setattr(
+        le,
+        "find_gene_name_from_ensembl_gene_id",
+        lambda gid: {"ENSG1": "A", "ENSG2": "B"}[gid],
+    )
+
+    out = le.load_expression_data(
+        str(p),
+        sample_id_value="sample_a",
+        verbose=False,
+        progress=False,
+    )
+
+    assert list(out["ensembl_gene_id"]) == ["ENSG1", "ENSG2"]
+    assert list(out["gene"]) == ["A", "B"]
+    assert list(out["TPM"]) == [7.0, 8.0]
 
 
 def test_load_expression_error_paths(tmp_path):

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -36,6 +36,16 @@ def test_guess_gene_cols_and_pick_genes():
         plot_mod._guess_gene_cols(pd.DataFrame({"TPM": [1.0]}))
 
 
+def test_purity_ci_phrase_uses_text_not_warning_icon():
+    phrase = cli_mod._purity_ci_phrase({
+        "overall_estimate": 0.50,
+        "overall_lower": 0.10,
+        "overall_upper": 1.00,
+    })
+    assert "low confidence" in phrase
+    assert "\u26a0" not in phrase
+
+
 def test_resolve_always_label_gene_ids(monkeypatch):
     df = pd.DataFrame(
         {"gene_id": ["ENSG1", "ENSG2"], "gene_display_name": ["GENE1", "B7-H3"]}

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -220,11 +220,17 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     # plot_cancer_type_genes / plot_cancer_type_disjoint_genes were
     # removed from the default plot set (polish/4.40.1).
     assert len(cancer_gene_calls) == 0
-    # Only MDS-TME is emitted now — PCA and hierarchy-method plots have
+    # MDS-TME plus the normal-inclusive nearest-label MDS are emitted now;
+    # PCA and hierarchy-method plots have
     # been removed from the default output (see pirl-unc/pirlygenes#36).
     assert len(pca_calls) == 0
-    assert len(mds_calls) == 1
+    assert len(mds_calls) == 2
     assert mds_calls[0]["method"] == "tme"
+    assert mds_calls[1]["method"] == "tme"
+    assert mds_calls[1]["include_normals"] is True
+    assert mds_calls[1]["label_nearest_cancers"] == 5
+    assert mds_calls[1]["label_nearest_normals"] == 5
+    assert mds_calls[1]["label_all"] is False
     assert len(report_calls) == 2
     assert len(target_report_calls) == 1
     assert (tmp_path / "test-output" / "out-summary.md").exists()
@@ -237,7 +243,7 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     assert "tumor_purity" in params
     assert "decomposition" in params
     assert params["selected_sample_mode"] == "solid"
-    assert params["embedding_methods"] == ["tme"]
+    assert params["embedding_methods"] == ["tme", "tme_with_normals"]
     assert params["input"]["tumor_context"] == "met"
     assert params["input"]["site_hint"] == "liver"
     assert params["input"]["decomposition_templates"] == ["met_liver"]
@@ -607,6 +613,57 @@ def test_generate_text_reports_mentions_analysis_constraints(tmp_path):
     detailed = (tmp_path / "constrained-analysis.md").read_text()
     assert "User-constrained cancer type" in detailed
     assert "Requested tumor context" in detailed
+
+
+def test_matched_normal_attribution_uses_decomposition_residual():
+    import matplotlib
+    matplotlib.use("Agg")
+
+    ranges_df = pd.DataFrame(
+        [
+            {
+                "symbol": "CD74",
+                "category": "surface",
+                "median_est": 50.0,
+                "observed_tpm": 100.0,
+                "attr_tumor_tpm": 5.0,
+                "matched_normal_tpm": 0.0,
+                "tme_only_tpm": 0.0,
+                "attribution": {"B_cell": 80.0, "macrophage": 15.0},
+                "therapies": "",
+                "tme_explainable": True,
+            },
+            {
+                "symbol": "KLK3",
+                "category": "surface",
+                "median_est": 80.0,
+                "observed_tpm": 80.0,
+                "attr_tumor_tpm": 20.0,
+                "matched_normal_tpm": 45.0,
+                "tme_only_tpm": 15.0,
+                "attribution": {
+                    "matched_normal_prostate": 45.0,
+                    "fibroblast": 15.0,
+                },
+                "therapies": "",
+                "tme_explainable": False,
+            },
+        ]
+    )
+
+    fig = plot_mod.plot_matched_normal_attribution(
+        ranges_df,
+        cancer_type="PRAD",
+        category="surface",
+    )
+
+    assert fig is not None
+    ax = fig.axes[0]
+    tumor_widths = [patch.get_width() for patch in ax.patches[:2]]
+    assert tumor_widths[0] == pytest.approx(5.0)
+    labels = "\n".join(label.get_text() for label in ax.get_yticklabels())
+    assert "tissue-explainable" in labels
+    assert "\u26a0" not in labels
 
 
 def test_select_actionable_plot_genes_prefers_therapy_linked_surface_hits():
@@ -1109,6 +1166,37 @@ def test_hierarchy_embedding_plot_adds_family_legend_and_neighbors(monkeypatch):
     assert "COAD" in all_text
 
 
+def test_embedding_plot_can_label_nearest_cancers_and_normals_only(monkeypatch):
+    import pirlygenes.plot_embedding as _pe
+    monkeypatch.setattr(_pe, "adjust_text", lambda *a, **k: None)
+    coords = np.array([
+        [0.0, 0.0],
+        [2.0, 2.0],
+        [0.1, 0.0],
+        [3.0, 3.0],
+        [0.05, 0.05],
+    ])
+    labels = ["PRAD", "COAD", "normal:prostate", "normal:liver", "SAMPLE"]
+
+    _fig, ax = plot_mod._plot_embedding_with_labels(
+        coords,
+        labels,
+        title="Test",
+        xlabel="x",
+        ylabel="y",
+        label_nearest_cancers=1,
+        label_nearest_normals=1,
+        label_all=False,
+    )
+
+    all_text = "\n".join(text.get_text() for text in ax.texts)
+    assert "PRAD" in all_text
+    assert "prostate" in all_text
+    assert "COAD" not in all_text
+    assert "liver" not in all_text
+    assert "Nearest normal tissues" in all_text
+
+
 def test_singleton_family_is_not_rendered_as_family_call():
     summary = _summarize_candidate_family(
         [
@@ -1279,6 +1367,49 @@ def test_plot_ctas_vs_cancer_type_detail_saves_png(tmp_path):
     assert fig is not None
     assert out.exists()
     assert out.stat().st_size > 5_000
+
+
+def test_plot_ctas_vs_cancer_type_detail_worst_vital_excludes_testis_and_thymus(
+    monkeypatch,
+):
+    """CTA max-vital tissue excludes reproductive/immune-privileged tissues."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import pirlygenes.plot_therapy as therapy_mod
+
+    monkeypatch.setattr(
+        therapy_mod,
+        "CTA_gene_id_to_name",
+        lambda: {"ENSGCTA": "CTA1"},
+    )
+    monkeypatch.setattr(
+        therapy_mod,
+        "pan_cancer_expression",
+        lambda: pd.DataFrame({
+            "Ensembl_Gene_ID": ["ENSGCTA"],
+            "Symbol": ["CTA1"],
+            "FPKM_PRAD": [1.0],
+            "nTPM_prostate": [0.5],
+            "nTPM_testis": [300.0],
+            "nTPM_thymus": [250.0],
+            "nTPM_heart_muscle": [35.0],
+            "nTPM_liver": [4.0],
+        }),
+    )
+
+    sample = pd.DataFrame({
+        "gene_id": ["ENSGCTA"],
+        "gene_name": ["CTA1"],
+        "TPM": [50.0],
+    })
+    fig = therapy_mod.plot_ctas_vs_cancer_type_detail(
+        sample, cancer_type="PRAD", min_sample_tpm=1.0,
+    )
+
+    text = "\n".join(t.get_text() for t in fig.axes[0].texts)
+    assert "heart 35" in text
+    assert "thymus" not in text
+    assert "testis" not in text
 
 
 def test_plot_ctas_vs_cancer_type_detail_min_sample_tpm_filters_rows():

--- a/tests/test_plot_and_cli.py
+++ b/tests/test_plot_and_cli.py
@@ -228,6 +228,7 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     assert mds_calls[0]["method"] == "tme"
     assert mds_calls[1]["method"] == "tme"
     assert mds_calls[1]["include_normals"] is True
+    assert mds_calls[1]["include_subtypes"] is True
     assert mds_calls[1]["label_nearest_cancers"] == 5
     assert mds_calls[1]["label_nearest_normals"] == 5
     assert mds_calls[1]["label_all"] is False
@@ -243,7 +244,7 @@ def test_cli_plot_expression_and_main(monkeypatch, tmp_path):
     assert "tumor_purity" in params
     assert "decomposition" in params
     assert params["selected_sample_mode"] == "solid"
-    assert params["embedding_methods"] == ["tme", "tme_with_normals"]
+    assert params["embedding_methods"] == ["tme", "tme_with_subtypes_and_normals"]
     assert params["input"]["tumor_context"] == "met"
     assert params["input"]["site_hint"] == "liver"
     assert params["input"]["decomposition_templates"] == ["met_liver"]
@@ -1195,6 +1196,33 @@ def test_embedding_plot_can_label_nearest_cancers_and_normals_only(monkeypatch):
     assert "COAD" not in all_text
     assert "liver" not in all_text
     assert "Nearest normal tissues" in all_text
+
+
+def test_embedding_matrix_sanitizes_nonfinite_features():
+    matrix = np.array([
+        [1.0, np.nan, 2.0, np.inf],
+        [2.0, np.nan, 3.0, 4.0],
+        [3.0, np.nan, 4.0, 5.0],
+    ])
+
+    clean = plot_mod._sanitize_embedding_matrix(matrix)
+
+    assert clean.shape == (3, 2)
+    assert np.isfinite(clean).all()
+
+
+def test_embedding_can_include_available_subtype_references():
+    df = _tcga_sample("SARC")
+    matrix, labels = plot_mod._cancer_type_feature_matrix(
+        df,
+        method="tme",
+        include_subtypes=True,
+    )
+
+    assert matrix.shape[0] == len(labels)
+    assert "SARC_LMS" in labels
+    assert "OS" in labels
+    assert np.isfinite(matrix).all()
 
 
 def test_singleton_family_is_not_rendered_as_family_call():

--- a/tests/test_plot_therapy_pathway_state.py
+++ b/tests/test_plot_therapy_pathway_state.py
@@ -53,6 +53,9 @@ def test_renders_dumbbell_and_caption(tmp_path):
     assert any("AR signaling" in label for label in labels)
     assert any("NE differentiation" in label for label in labels)
     assert any("EMT" in label for label in labels)
+    assert any("expected-up genes" in label for label in labels)
+    assert any("expected-down genes" in label for label in labels)
+    assert len(labels) == 5
 
 
 def test_state_tag_matches_direction(tmp_path):
@@ -121,4 +124,4 @@ def test_state_ordering_active_suppressed_first(tmp_path):
     )
     labels = [t.get_text() for t in fig.axes[0].get_yticklabels()]
     assert "suppressed axis" in labels[0]
-    assert "near baseline" in labels[1]
+    assert "near baseline" in labels[2]

--- a/tests/test_report_clarity_and_met_site.py
+++ b/tests/test_report_clarity_and_met_site.py
@@ -465,7 +465,7 @@ def test_compose_disease_state_empty_when_no_pattern():
 
 
 def test_recommended_targets_skips_tme_dominant_rows():
-    """#79: ⚠⚠ (tme_dominant) rows must not appear in the Recommended
+    """#79: tme_dominant rows must not appear in the Recommended
     Targets Summary; they're called out as excluded."""
     import pandas as pd
     from pirlygenes.cli import _generate_target_report
@@ -529,7 +529,7 @@ def test_recommended_targets_skips_tme_dominant_rows():
     targets = open(f"{tmp_prefix}-targets.md").read()
 
     # The Recommended Targets section must not list CD74 as a best
-    # surface target — it was ⚠⚠ flagged.
+    # surface target — it was low-confidence flagged.
     recs_block = targets.split("## Recommended Targets Summary")[-1]
     assert "**Best surface targets**" in recs_block
     # Clean ADAM9 should be there

--- a/tests/test_robust_attribution.py
+++ b/tests/test_robust_attribution.py
@@ -7,7 +7,7 @@ Covers three invariants the new breadth-aware attribution must hold:
    detection crosses many tissues.
 2. Ubiquitously-expressed housekeeping-like genes (TBCE, NPM1, broad
    surface markers) MUST trip the flag.
-3. The breadth floor on non-tumor attribution dampens the tumor-core
+3. The breadth floor on non-tumor attribution dampens the tumor-inferred
    residual for broadly-expressed genes without zeroing it out, and
    doesn't touch restricted genes.
 """
@@ -475,6 +475,30 @@ def test_brief_keeps_same_lineage_targets_but_skips_background_dominant_rows():
     assert "same-lineage expected" in bullet
     assert "tumor-supported" in bullet
     assert "Provisional:" not in bullet
+
+
+def test_same_lineage_clinical_target_can_remain_provisional_when_bulk_background_dominant():
+    from pirlygenes.reporting import target_reliability_status
+
+    target = {
+        "symbol": "KLK2",
+        "agent": "JNJ-69086420",
+        "agent_class": "bispecific",
+        "phase": "phase_1",
+        "indication": "mCRPC",
+    }
+    row = {
+        "observed_tpm": 247.0,
+        "attr_tumor_tpm": 57.0,
+        "attr_tumor_fraction": 0.23,
+        "attr_top_compartment": "matched_normal_prostate",
+        "attr_top_compartment_tpm": 155.0,
+        "tme_dominant": False,
+        "tme_explainable": True,
+        "matched_normal_over_predicted": True,
+    }
+
+    assert target_reliability_status(row, target_row=target) == "provisional"
 
 
 def test_same_lineage_target_can_stay_supported_when_band_remains_material():

--- a/tests/test_sample_context.py
+++ b/tests/test_sample_context.py
@@ -4,6 +4,7 @@ from pirlygenes.gene_sets_cancer import pan_cancer_expression, degradation_gene_
 from pirlygenes.sample_context import (
     SampleContext,
     infer_sample_context,
+    library_prep_clause,
     _HISTONE_SYMBOL_PREFIXES,
     _MT_MRNA_SYMBOLS,
     _MT_RRNA_SYMBOLS,
@@ -35,6 +36,11 @@ def _fresh_degradation_pair_expectations():
 
 
 # ── Library-prep inference ────────────────────────────────────────────────
+
+
+def test_library_prep_clause_does_not_duplicate_library_word():
+    assert library_prep_clause("poly_a") == "poly-A capture library"
+    assert library_prep_clause("unknown") == "unknown library prep"
 
 
 def test_library_prep_polya_signature_is_detected():

--- a/tests/test_therapy_path_curation.py
+++ b/tests/test_therapy_path_curation.py
@@ -93,3 +93,19 @@ def test_reports_prefer_explicit_treatment_path_tier_over_rationale_text():
     assert therapy_path_tier(standard_row) == "approved_standard"
     assert therapy_path_rank(standard_row) == 0
     assert "guideline-standard approved pathway" in therapy_path_context(standard_row)
+
+
+def test_treatment_path_context_dedupes_curated_note_prefix():
+    row = {
+        "symbol": "TEST3",
+        "agent": "example TCE",
+        "agent_class": "TCE",
+        "phase": "phase_2",
+        "indication": "example cancer",
+        "rationale": "",
+        "treatment_path_tier": "trial_follow_up",
+        "eligibility_note": "clinical-trial follow-up; not default standard",
+    }
+    context = therapy_path_context(row)
+    assert context == "clinical-trial follow-up; not default standard"
+    assert "clinical-trial follow-up; clinical-trial follow-up" not in context

--- a/tests/test_therapy_path_curation.py
+++ b/tests/test_therapy_path_curation.py
@@ -1,0 +1,88 @@
+"""Audit structured therapy-path curation for cancer-key-genes rows."""
+
+import pandas as pd
+
+from pirlygenes.reporting import (
+    THERAPY_PATH_TIERS,
+    therapy_path_context,
+    therapy_path_rank,
+    therapy_path_tier,
+)
+
+
+def _target_rows():
+    df = pd.read_csv("pirlygenes/data/cancer-key-genes.csv").fillna("")
+    return df[df["role"].astype(str).str.strip() == "target"].copy()
+
+
+def test_target_rows_have_structured_treatment_path_curation():
+    targets = _target_rows()
+    assert len(targets) >= 300
+    for column in ("treatment_path_tier", "line_of_therapy", "eligibility_note"):
+        missing = targets[targets[column].astype(str).str.strip().eq("")]
+        assert missing.empty, (
+            f"{column} missing for target rows: "
+            + ", ".join(
+                f"{row.cancer_code}:{row.symbol}:{row.agent}"
+                for row in missing.head(10).itertuples()
+            )
+        )
+
+    invalid = targets[
+        ~targets["treatment_path_tier"].astype(str).isin(THERAPY_PATH_TIERS)
+    ]
+    assert invalid.empty, (
+        "invalid treatment_path_tier values: "
+        + ", ".join(sorted(set(invalid["treatment_path_tier"].astype(str))))
+    )
+
+
+def test_treatment_path_tier_is_phase_compatible():
+    targets = _target_rows()
+    allowed = {
+        "approved_standard": {"approved"},
+        "approved_indication_matched": {"approved"},
+        "approved_later_line": {"approved"},
+        "late_clinical": {"phase_3"},
+        "trial_follow_up": {"phase_1", "phase_2"},
+        "preclinical": {"preclinical"},
+        "off_label": {"off_label"},
+    }
+    bad = []
+    for row in targets.itertuples():
+        phase = str(row.phase)
+        tier = str(row.treatment_path_tier)
+        if phase not in allowed[tier]:
+            bad.append(f"{row.cancer_code}:{row.symbol}:{row.agent}:{phase}->{tier}")
+    assert not bad, "phase/tier mismatch: " + ", ".join(bad[:20])
+
+
+def test_reports_prefer_explicit_treatment_path_tier_over_rationale_text():
+    later_line_row = {
+        "symbol": "TEST1",
+        "agent": "example ADC",
+        "agent_class": "ADC",
+        "phase": "approved",
+        "indication": "example cancer",
+        "rationale": "frontline standard backbone wording should not win",
+        "treatment_path_tier": "approved_later_line",
+        "eligibility_note": "confirm prior therapy",
+    }
+    assert therapy_path_tier(later_line_row) == "approved_later_line"
+    assert therapy_path_rank(later_line_row) == 2
+    assert "approved later-line pathway" in therapy_path_context(later_line_row)
+    assert "guideline-standard" not in therapy_path_context(later_line_row)
+
+    standard_row = {
+        "symbol": "TEST2",
+        "agent": "example antibody",
+        "agent_class": "antibody",
+        "phase": "approved",
+        "indication": "example cancer",
+        "rationale": "",
+        "treatment_path_tier": "approved_standard",
+        "eligibility_note": "confirm first-line eligibility",
+    }
+    assert therapy_path_tier(standard_row) == "approved_standard"
+    assert therapy_path_rank(standard_row) == 0
+    assert "guideline-standard approved pathway" in therapy_path_context(standard_row)

--- a/tests/test_therapy_path_curation.py
+++ b/tests/test_therapy_path_curation.py
@@ -57,6 +57,13 @@ def test_treatment_path_tier_is_phase_compatible():
     assert not bad, "phase/tier mismatch: " + ", ".join(bad[:20])
 
 
+def test_target_row_sources_are_present_for_most_curation_rows():
+    targets = _target_rows()
+    sources = targets["source"].astype(str).str.strip()
+    assert sources.ne("").mean() >= 0.95
+    assert sources[sources.ne("")].str.contains("PMID:", regex=False).all()
+
+
 def test_reports_prefer_explicit_treatment_path_tier_over_rationale_text():
     later_line_row = {
         "symbol": "TEST1",

--- a/tests/test_therapy_path_curation.py
+++ b/tests/test_therapy_path_curation.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from pirlygenes.reporting import (
     THERAPY_PATH_TIERS,
+    subtype_curation_scope_note,
     therapy_path_context,
     therapy_path_rank,
     therapy_path_tier,
@@ -109,3 +110,14 @@ def test_treatment_path_context_dedupes_curated_note_prefix():
     context = therapy_path_context(row)
     assert context == "clinical-trial follow-up; not default standard"
     assert "clinical-trial follow-up; clinical-trial follow-up" not in context
+
+
+def test_subtype_scope_note_avoids_duplicate_parent_label():
+    note = subtype_curation_scope_note(
+        "SARC",
+        panel_subtype="synovial_sarcoma",
+        base_code="SARC",
+        noun="therapy evidence",
+    )
+    assert "synovial sarcoma-specific therapy evidence" in note
+    assert "synovial sarcoma sarcoma" not in note


### PR DESCRIPTION
## Summary

Adds explicit structured therapy-path curation fields to `cancer-key-genes.csv` so report ranking no longer has to infer standard-vs-later-line-vs-experimental status from `rationale` prose at report-render time.

Also hardens the Markdown reports after auditing reruns across RS, PFO002, PFO004, PFO017, PFO019, HCC1395, Alvin, and ASY outputs. The report changes are centralized in shared helpers so expression-independent indications, disease-state absence, sample prep wording, cancer-call confidence, source attribution, and maturity/path context render consistently across cancers and input formats.

Important provenance note: this PR normalizes the existing project curation into structured fields. It is not an NCCN-derived recuration. Existing target rows mostly cite PubMed sources in the `source` column, but the initial `treatment_path_tier` values are seeded from the existing `phase`/`indication`/`rationale` text and should be reviewed as clinical curation over time.

## Changes

- Adds `treatment_path_tier`, `line_of_therapy`, and `eligibility_note` for all curated target rows.
- Updates report ranking/context helpers to prefer explicit structured curation, with the existing prose classifier retained only as fallback for legacy rows.
- Adds a curation audit script and regression tests that require target rows to have valid path tiers and phase-compatible values.
- Audits source coverage: currently 335/347 target rows have source citations, all PMID-formatted.
- Silences the generic pandas `DtypeWarning` from `subtype-deconvolved-expression.csv.gz` by loading packaged datasets with `low_memory=False`.
- Adds BostonGene/kallisto `gene_abundance.tsv` loader support and wide-matrix sample selection via `--sample-id-value`.
- Makes expression-independent therapy rows explicitly say target RNA is contextual only and eligibility is not inferred from expression.
- Adds a bounded “no strong RNA-defined therapy-exposure/pathway-state pattern” disease-state sentence when panels were evaluated but no positive state fired.
- Adds concise cancer-call confidence reasons in one-page summaries while leaving full details in `analysis.md` / evidence outputs.
- Standardizes sample library-prep prose, target source-trace tables, source-attribution wording, and clinical maturity punctuation.

## Validation

- `python scripts/audit_therapy_path_curation.py`
- `ruff check pirlygenes/brief.py pirlygenes/reporting.py pirlygenes/cli.py pirlygenes/confidence.py pirlygenes/sample_context.py tests/test_brief.py tests/test_confidence.py tests/test_sample_context.py tests/test_therapy_path_curation.py tests/test_load_expression.py tests/test_plot_and_cli.py tests/test_report_clarity_and_met_site.py`
- `pytest tests/test_load_expression.py tests/test_brief.py tests/test_therapy_path_curation.py tests/test_confidence.py tests/test_sample_context.py tests/test_plot_and_cli.py::test_purity_ci_phrase_uses_text_not_warning_icon tests/test_report_clarity_and_met_site.py::test_compose_disease_state_empty_when_no_pattern tests/test_report_clarity_and_met_site.py::test_recommended_targets_skips_tme_dominant_rows tests/test_robust_attribution.py::test_expression_independent_indication_is_not_demoted_by_target_tpm -q` (98 passed)
- Full rerun across 13 available sample/input combinations into `/tmp/pirlygenes-rerun-20260424-final4`: 13/13 OK.
- Targeted post-wording rerun into `/tmp/pirlygenes-rerun-20260424-final5-source-trace`: Alvin + both HCC1395 inputs, 3/3 OK.
- Artifact scans found no `Traceback`, `Input contains NaN`, stale `Tumor-core`, warning-glyph, duplicate library-prep, stale healthy-tissue, or bad source-trace/maturity wording in checked outputs.
