### PR TITLE
chore: release 4.50.13

### DIFF
--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "4.50.12"
+__version__ = "4.50.13"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Summary

- Bump `pirlygenes.__version__` from `4.50.12` to `4.50.13`.
- Prepare a PyPI/tag release for the already-merged analyze reasoning docs update.

## Validation

- `python pirlygenes/version.py` -> `v4.50.13`

## Release Plan

After this PR merges, run `./deploy.sh`, which performs lint, tests, build, PyPI upload, tag creation, and tag push.