### PR TITLE
v5.0.1: point migration message at pirl-trufflepig PyPI name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ tumor-up-vs-matched-normal panels, ESTIMATE signatures) ship with
 pip install pirlygenes
 ```
 
-Run analyses with [trufflepig](https://github.com/pirl-unc/trufflepig):
+Run analyses with [trufflepig](https://github.com/pirl-unc/trufflepig)
+(distributed on PyPI as `pirl-trufflepig` — the bare `trufflepig`
+name is owned by an unrelated package; the command + Python import
+are both still `trufflepig`):
 
 ```bash
-pip install trufflepig
+pip install pirl-trufflepig
 trufflepig run --sample expr.tsv --workspace out --cancer-type PRAD
 ```
 

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -20,9 +20,12 @@ _MOVED_MESSAGE = """\
 pirlygenes no longer ships an analysis CLI as of v5.0.0.
 
 The `analyze`, `compare-analyze`, `plot-expression`, and
-`plot-cancer-cohorts` commands all moved to `trufflepig`:
+`plot-cancer-cohorts` commands all moved to `pirl-trufflepig`
+(distributed under that name on PyPI because the bare `trufflepig`
+name is owned by an unrelated package; the command + Python import
+are both still `trufflepig`):
 
-    pip install trufflepig
+    pip install pirl-trufflepig
     trufflepig run --sample expr.tsv --workspace out --cancer-type BLCA
     trufflepig compare --workspace out/long --inputs out/A,out/B
     trufflepig data

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 version_string = f"v{__version__}"
 


### PR DESCRIPTION
## Why

The PyPI name [`trufflepig`](https://pypi.org/project/trufflepig/) is
owned by an unrelated package (Chris Charlton's filesystem-rooting
utility, last published 2023). Our merged v5.0.0 \`cli.py\` migration
message tells users \`pip install trufflepig\` — which on PyPI today
installs the wrong package.

Our analysis package will distribute on PyPI as **\`pirl-trufflepig\`**
instead. The PyPI distribution name differs from the Python import
name, matching the \`scikit-learn\` → \`import sklearn\` pattern that
users already know.

## What changes

| What | Stays | Becomes |
|---|---|---|
| PyPI install command | — | \`pip install pirl-trufflepig\` |
| Python import path | \`import trufflepig\` | (unchanged) |
| CLI command on PATH | \`trufflepig …\` | (unchanged) |
| GitHub repo | \`pirl-unc/trufflepig\` | (unchanged) |

## In this PR

- \`pirlygenes/cli.py\` migration message → \`pip install pirl-trufflepig\`
- \`README.md\` install line → \`pip install pirl-trufflepig\`
- Both include a one-line note explaining the bare name was contested,
  so users who hit a stale doc / cached search result don't retry the
  old form.
- Version bump 5.0.0 → **5.0.1**.

## Companion change (separate repo)

The trufflepig repo needs two edits before this can ship:
1. \`trufflepig/pyproject.toml\` line 2: \`name = \"trufflepig\"\` →
   \`name = \"pirl-trufflepig\"\`
2. \`trufflepig/README.md\` line 87: \`pip install 'trufflepig[web]'\` →
   \`pip install 'pirl-trufflepig[web]'\`

Once those land + trufflepig is published on PyPI under the new name,
pirlygenes 5.0.1 can be published and the migration message is
actionable.

## Test plan

- [x] All 101 pirlygenes tests pass
- [ ] trufflepig PR with the matching rename lands
- [ ] trufflepig published to PyPI as \`pirl-trufflepig\`
- [ ] pirlygenes 5.0.1 tagged + published to PyPI
- [ ] \`pip install pirl-trufflepig\` from a clean env installs the
      right package and \`trufflepig --help\` works