### PR TITLE
Include XAGE1B in bundled CTA fallback

### DIFF
--- a/pirlygenes/data/cancer-testis-antigens.csv
+++ b/pirlygenes/data/cancer-testis-antigens.csv
@@ -7,7 +7,7 @@ PAGE2B,,,cancer-testis antigen,ENSG00000238269,CTpedia;CTexploreR_CTP;daSilva201
 PAGE3,,,cancer-testis antigen,ENSG00000204279,CTpedia;daSilva2017,no data,no data,no data,True,False,no data,1.0,1.0,1.0,1.0,ENST00000374951,protein_coding,True,True,True,True,True,7.4,False
 PAGE5,,,cancer-testis antigen,ENSG00000158639,CTpedia;CTexploreR_CT;daSilva2017,True,False,Supported,False,False,testis,0.8805,0.881,1.0,1.0,ENST00000374955,protein_coding,True,True,True,True,True,25.8,False
 XAGE1A,,,cancer-testis antigen,ENSG00000204379,CTpedia;CTexploreR_CT,no data,no data,no data,True,False,no data,0.9913,0.9913,1.0,1.0,ENST00000375602,protein_coding,True,True,True,True,True,45.7,False
-XAGE1B,,,cancer-testis antigen,ENSG00000204382,CTpedia;CTexploreR_CT;daSilva2017,no data,no data,no data,False,False,no data,0.8806,0.8808,0.987,0.987,ENST00000518075,protein_coding,True,True,True,False,False,53.1,False
+XAGE1B,,,cancer-testis antigen,ENSG00000204382,CTpedia;CTexploreR_CT;daSilva2017,no data,no data,no data,False,False,no data,0.8806,0.8808,0.987,0.987,ENST00000518075,protein_coding,True,True,True,False,True,53.1,False
 XAGE3,,,cancer-testis antigen,ENSG00000171402,CTpedia,True,False,Supported,False,False,placenta,0.9804,0.9804,0.9922,0.9922,ENST00000346279,protein_coding,True,True,True,True,True,368.3,False
 XAGE5,,,cancer-testis antigen,ENSG00000171405,CTpedia;CTexploreR_CT;daSilva2017,no data,no data,no data,True,False,no data,1.0,1.0,1.0,1.0,ENST00000375501,protein_coding,True,True,True,True,True,1.1,True
 GAGE2A,,,cancer-testis antigen,ENSG00000189064,CTpedia;CTexploreR_CT;daSilva2017;daSilva2017_protein,True,False,Supported,True,False,testis,0.9893,0.9893,1.0,1.0,ENST00000362097,protein_coding,True,True,True,True,True,92.6,False

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -123,6 +123,15 @@ def test_cta_filtered_and_evidence():
     excluded_names = gsc.CTA_excluded_gene_names()
 
     assert expressed_names
+    assert "XAGE1B" in expressed_names
+
+    bundled_evidence = gsc._bundled_cta_evidence()
+    bundled_filtered = bundled_evidence["filtered"].astype(str).str.lower() == "true"
+    bundled_expressed = bundled_filtered & ~(
+        bundled_evidence["never_expressed"].astype(str).str.lower() == "true"
+    )
+    assert "XAGE1B" in set(bundled_evidence.loc[bundled_expressed, "Symbol"])
+
     assert filtered_names
     assert all_names
     assert expressed_names < filtered_names  # expressed is strict subset of filtered


### PR DESCRIPTION
## Summary
- Mark XAGE1B as filtered in the bundled CTA fallback table so pirlygenes exposes the same 258 expressed CTA genes even without tsarina installed.
- Add regression coverage for both the public CTA API and the bundled fallback path.
- Bump the package version to 5.1.2.

## Verification
- `./test.sh tests/test_load_dataset_and_gene_sets.py` attempted, but the script uses `/opt/homebrew/bin/pytest`, which lacks xdist and exits before tests run.
- `./lint.sh` passed via the wrapper.
- `python -m pytest -n 0 --cov=pirlygenes/ --cov-report=term-missing tests` passed: 142 passed.