### PR TITLE
Bump 5.8.1: decouple data-bundle version from package version

### DIFF
--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -250,7 +250,7 @@ def _format_bytes(n: int) -> str:
 
 def cmd_data_status(_args: argparse.Namespace) -> int:
     snap = data_bundle.status()
-    sys.stdout.write(f"pirlygenes data bundle for v{snap['version']}\n")
+    sys.stdout.write(f"pirlygenes data bundle for v{snap['data_version']}\n")
     sys.stdout.write(f"  cache dir   : {snap['cache_dir']}\n")
     sys.stdout.write(f"  release URL : {snap['release_url']}\n")
     sys.stdout.write(f"  all local?  : {snap['all_local']}\n")

--- a/pirlygenes/data_bundle.py
+++ b/pirlygenes/data_bundle.py
@@ -54,13 +54,15 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
-from .version import __version__
+from .version import DATA_VERSION
 
 
 GITHUB_REPO = "pirl-unc/pirlygenes"
-TARBALL_FILENAME = f"pirlygenes-data-v{__version__}.tar.gz"
+# Pinned to DATA_VERSION (not __version__) so code-only package releases
+# reuse the last uploaded bundle — see version.py.
+TARBALL_FILENAME = f"pirlygenes-data-v{DATA_VERSION}.tar.gz"
 RELEASE_URL = (
-    f"https://github.com/{GITHUB_REPO}/releases/download/v{__version__}/"
+    f"https://github.com/{GITHUB_REPO}/releases/download/v{DATA_VERSION}/"
     f"{TARBALL_FILENAME}"
 )
 
@@ -91,7 +93,7 @@ def cache_dir() -> Path:
     override = os.environ.get("PIRLYGENES_BUNDLED_DATA")
     if override:
         return Path(override).expanduser()
-    return cache_root() / f"v{__version__}"
+    return cache_root() / f"v{DATA_VERSION}"
 
 
 def is_local() -> bool:
@@ -120,8 +122,8 @@ def fetch(*, verbose: bool = True) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     if verbose:
         sys.stderr.write(
-            f"pirlygenes: downloading data bundle for v{__version__} "
-            "(~340 MB, one-time)\n"
+            f"pirlygenes: downloading data bundle for v{DATA_VERSION} "
+            "(~350 MB, one-time)\n"
             f"  from {RELEASE_URL}\n"
             f"  to   {root}\n"
         )
@@ -187,7 +189,7 @@ def status() -> dict:
             "size_bytes": size_bytes,
         }
     return {
-        "version": __version__,
+        "data_version": DATA_VERSION,
         "cache_dir": str(root),
         "release_url": RELEASE_URL,
         "items": items,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.8.0"
+__version__ = "5.8.1"
+
+# Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
+# this ONLY when the reference data changes — it pins the bundle filename,
+# GitHub-release tag, and on-disk cache. Decoupling it from __version__
+# means a code-only release (bug/build-time fix) reuses the last uploaded
+# bundle instead of forcing a redundant ~350 MB re-upload. Must always
+# point at an existing `pirlygenes-data-v<DATA_VERSION>.tar.gz` release asset.
+DATA_VERSION = "5.8.0"
 
 version_string = f"v{__version__}"
 

--- a/tests/test_stats_and_data.py
+++ b/tests/test_stats_and_data.py
@@ -278,17 +278,17 @@ def test_data_bundle_prune_lists_and_deletes_stale_dirs(tmp_path, monkeypatch):
     # Build a fake cache root with two stale version dirs + the
     # current-version dir.
     monkeypatch.setenv(
-        "PIRLYGENES_BUNDLED_DATA", str(tmp_path / f"v{data_bundle.__version__}"),
+        "PIRLYGENES_BUNDLED_DATA", str(tmp_path / f"v{data_bundle.DATA_VERSION}"),
     )
-    for v in ["v5.0.0", "v5.1.0", f"v{data_bundle.__version__}"]:
+    for v in ["v5.0.0", "v5.1.0", f"v{data_bundle.DATA_VERSION}"]:
         d = tmp_path / v
         d.mkdir()
         (d / "marker.csv").write_text("x")
 
     versions = data_bundle.list_cache_versions()
     by_v = {e["version"]: e for e in versions}
-    assert {"v5.0.0", "v5.1.0", f"v{data_bundle.__version__}"} <= set(by_v)
-    assert by_v[f"v{data_bundle.__version__}"]["is_current"] is True
+    assert {"v5.0.0", "v5.1.0", f"v{data_bundle.DATA_VERSION}"} <= set(by_v)
+    assert by_v[f"v{data_bundle.DATA_VERSION}"]["is_current"] is True
     assert by_v["v5.0.0"]["is_current"] is False
 
     # Dry-run: returns candidates but leaves disk alone
@@ -301,7 +301,7 @@ def test_data_bundle_prune_lists_and_deletes_stale_dirs(tmp_path, monkeypatch):
     data_bundle.prune_cache(keep_current=True, dry_run=False)
     assert not (tmp_path / "v5.0.0").exists()
     assert not (tmp_path / "v5.1.0").exists()
-    assert (tmp_path / f"v{data_bundle.__version__}").exists()
+    assert (tmp_path / f"v{data_bundle.DATA_VERSION}").exists()
 
 
 def test_upsert_to_shard_allow_unset_for_legacy_backfill(tmp_path):


### PR DESCRIPTION
Code-only (NCBI build-time mirror + DATA_VERSION decoupling). Reuses the v5.8.0 data bundle — no re-upload.