### PR TITLE
CTA coverage plots + cohort×gene-set patient-coverage CLI

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -601,10 +601,8 @@ def _cta_vs_tmb(mat, cohorts, ensg_to_sym, threshold):
     SWEET_TMB, SWEET_COV = 3.0, 50.0
     ax.fill_between([x_lo, SWEET_TMB], SWEET_COV, 100, color="#ffd166",
                     alpha=0.18, zorder=0)
-    ax.text(x_lo * 1.08, 98.5,
-            "antigen-rich / mutation-poor\n(CTA-therapy sweet spot:\n"
-            "≥50% coverage, ≤3 mut/Mb)",
-            fontsize=7, va="top", ha="left", color="#9c6f00", style="italic")
+    ax.text(x_lo * 1.08, 98.5, "antigen-rich / mutation-poor",
+            fontsize=8, va="top", ha="left", color="#9c6f00", style="italic")
 
     ax.scatter(xs, ys, s=34, c=[_LINEAGE_COLORS[g] for g in groups],
                alpha=0.9, edgecolor="white", linewidth=0.4, zorder=3)

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -53,6 +53,17 @@ GLIOMA_MAP = CACHE / "derived" / "tcga_glioma_case_to_project.csv"
 OUT = Path(__file__).resolve().parent / "outputs"
 THRESHOLDS = [25, 50, 100, 200]
 
+# Honest display labels for cohorts whose registry code is misleading about the
+# actual sample composition. The bare "SARC" cohort here is the TCGA
+# "leiomyosarcoma" slice (n=100, ~90% leiomyosarcoma by GDC histology), NOT the
+# multi-histology TCGA-SARC umbrella its code implies — so label it as such
+# until the sarcoma taxonomy rebuild makes this canonical in the registry.
+_DISPLAY_CODE = {"SARC": "TCGA-LMS"}
+
+
+def _display_code(code: str) -> str:
+    return _DISPLAY_CODE.get(code, code)
+
 
 def _glioma_split_cohorts() -> list[TreehouseCohort]:
     """GBM/LGG cohorts from the cached TCGA glioma case->project map."""
@@ -256,14 +267,20 @@ def main():
     counts = counts.sort_values(["cancer_code", "n_gt25"], ascending=[True, False])
     counts.to_csv(OUT / "cta_patient_counts.csv", index=False)
 
-    print("[5/6] plots", flush=True)
+    print("[5/9] plots", flush=True)
     _plots(mat, cohorts, counts, ensg_to_sym, args.threshold, args.cohort)
 
-    print("[6/7] per-cohort coverage curves (one PNG each)", flush=True)
+    print("[6/9] per-cohort coverage curves (one PNG each)", flush=True)
     _coverage_every_cohort(mat, cohorts, ensg_to_sym, args.threshold)
 
-    print("[7/7] peak-coverage bar charts (parent/child + top-CTA colored)", flush=True)
+    print("[7/9] peak-coverage bar charts (parent/child + top-CTA colored)", flush=True)
     _peak_coverage_bars(mat, cohorts, ensg_to_sym, args.threshold)
+
+    print("[8/9] stacked coverage bar (per-CTA marginal contribution)", flush=True)
+    _stacked_coverage_bars(mat, cohorts, ensg_to_sym, args.threshold)
+
+    print("[9/9] CTA coverage vs cohort TMB", flush=True)
+    _cta_vs_tmb(mat, cohorts, ensg_to_sym, args.threshold)
     print(f"done -> {OUT}", flush=True)
 
 
@@ -296,6 +313,40 @@ def _shade(rgb, k):
     r, g, b = rgb[:3]
     h, l, s = colorsys.rgb_to_hls(r, g, b)
     return colorsys.hls_to_rgb(h, min(1.0, max(0.0, l + k)), s)
+
+
+# Distinct base hues, one per antigen family; members shaded within the hue.
+_FAMILY_PALETTE = [
+    "#e6194B", "#3cb44b", "#4363d8", "#f58231", "#911eb4", "#42d4f4",
+    "#f032e6", "#bfef45", "#469990", "#9A6324", "#800000", "#808000",
+    "#000075", "#e6beff", "#aaffc3", "#ffd8b1", "#a9a9a9", "#fabed4",
+]
+
+
+def _family_color_map(ctas_ordered):
+    """Map an ordered list of CTA symbols to colors: one base hue per antigen
+    family (ordered by first appearance), members shaded within the family hue.
+
+    Returns (cta_color, fam_order, fam_base, members) so callers can both color
+    bars and build a family-grouped legend."""
+    import matplotlib.colors as mcolors
+
+    ctas = list(dict.fromkeys(ctas_ordered))
+    fam_of = {c: _cta_family(c) for c in ctas}
+    fam_order = list(dict.fromkeys(fam_of[c] for c in ctas))
+    fam_base = {f: _FAMILY_PALETTE[i % len(_FAMILY_PALETTE)]
+                for i, f in enumerate(fam_order)}
+    members = {}
+    for c in ctas:
+        members.setdefault(fam_of[c], []).append(c)
+    cta_color = {}
+    for f, ms in members.items():
+        base = mcolors.to_rgb(fam_base[f])
+        ks = ([0.0] if len(ms) == 1
+              else [(-0.18 + 0.36 * j / (len(ms) - 1)) for j in range(len(ms))])
+        for c, k in zip(ms, ks):
+            cta_color[c] = _shade(base, k)
+    return cta_color, fam_order, fam_base, members
 
 
 def _parent_map():
@@ -333,7 +384,7 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
             "is_derived": code in parent_of, "top_cta": top_cta,
         })
     df = pd.DataFrame(rows).sort_values("peak", ascending=True)  # ascending -> top at top after barh
-    labels = [f"{c}  (n={n})" for c, n in zip(df["code"], df["n"])]
+    labels = [f"{_display_code(c)}  (n={n})" for c, n in zip(df["code"], df["n"])]
     h = max(6, len(df) * 0.26)
 
     # ---- (a) parent vs derived ----
@@ -359,28 +410,10 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
     plt.close(fig)
 
     # ---- (b) colored by top CTA, grouped by antigen family ----
-    # distinct base hue per family; members shaded within the family hue.
-    distinct = [
-        "#e6194B", "#3cb44b", "#4363d8", "#f58231", "#911eb4", "#42d4f4",
-        "#f032e6", "#bfef45", "#469990", "#9A6324", "#800000", "#808000",
-        "#000075", "#e6beff", "#aaffc3", "#ffd8b1", "#a9a9a9", "#fabed4",
-    ]
-    ctas = list(dict.fromkeys(df.sort_values("peak", ascending=False)["top_cta"]))
-    fam_of = {c: _cta_family(c) for c in ctas}
-    # families ordered by first (highest-coverage) appearance
-    fam_order = list(dict.fromkeys(fam_of[c] for c in ctas))
-    fam_base = {f: distinct[i % len(distinct)] for i, f in enumerate(fam_order)}
-    members = {}
-    for c in ctas:
-        members.setdefault(fam_of[c], []).append(c)
-    import matplotlib.colors as mcolors
-    cta_color = {}
-    for f, ms in members.items():
-        base = mcolors.to_rgb(fam_base[f])
-        ks = ([0.0] if len(ms) == 1
-              else [(-0.18 + 0.36 * j / (len(ms) - 1)) for j in range(len(ms))])
-        for c, k in zip(ms, ks):
-            cta_color[c] = _shade(base, k)
+    # distinct base hue per family; members shaded within the family hue,
+    # ordered by first (highest-coverage) appearance.
+    cta_color, fam_order, fam_base, members = _family_color_map(
+        df.sort_values("peak", ascending=False)["top_cta"])
 
     fig, ax = plt.subplots(figsize=(12, h))
     ax.barh(range(len(df)), df["peak"], color=[cta_color[c] for c in df["top_cta"]])
@@ -409,6 +442,213 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
           "-> 2 bar charts", flush=True)
 
 
+def _stacked_coverage_bars(mat, cohorts, ensg_to_sym, threshold,
+                           max_label_segments=8, min_label_pct=3.0):
+    """Horizontal STACKED bar per cohort: the greedy plateau split into each
+    CTA's marginal NEW-patient contribution. Because the contributions are
+    co-occurrence-aware (a patient already covered by an earlier CTA isn't
+    re-counted), the segments sum to the plateau and the bar never exceeds
+    100%. Segments are colored by antigen family (consistent across cohorts);
+    the widest segments are labelled with the CTA symbol in small font.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Patch
+
+    # Per cohort: ordered (cta_symbol, marginal_pct) contributions.
+    rows = []
+    for code in cohorts:
+        order, cum, n = greedy_coverage(mat, cohorts[code], threshold)
+        if not cum:
+            continue
+        segs, prev = [], 0.0
+        for i, idx in enumerate(order):
+            sym = ensg_to_sym.get(mat.index[idx], mat.index[idx])
+            marg = (cum[i] - prev) * 100
+            prev = cum[i]
+            if marg > 0:
+                segs.append((sym, marg))
+        rows.append({"code": code, "n": n, "peak": cum[-1] * 100, "segs": segs})
+    rows.sort(key=lambda r: r["peak"])  # ascending -> broadest at top after barh
+
+    # Global CTA color map: order CTAs by total marginal contribution so the
+    # most prominent antigens get the most distinct family hues.
+    from collections import Counter
+    tot = Counter()
+    for r in rows:
+        for sym, marg in r["segs"]:
+            tot[sym] += marg
+    cta_color, fam_order, fam_base, _members = _family_color_map(
+        [c for c, _ in tot.most_common()])
+
+    labels = [f"{_display_code(r['code'])}  (n={r['n']})" for r in rows]
+    hgt = max(6, len(rows) * 0.28)
+    fig, ax = plt.subplots(figsize=(13, hgt))
+    for y, r in enumerate(rows):
+        left = 0.0
+        for j, (sym, marg) in enumerate(r["segs"]):
+            ax.barh(y, marg, left=left, color=cta_color.get(sym, "#cccccc"),
+                    edgecolor="white", linewidth=0.3)
+            # label the widest leading segments; always try the dominant one
+            if (marg >= min_label_pct and j < max_label_segments) or j == 0:
+                if marg >= 1.5:
+                    ax.text(left + marg / 2, y, sym, va="center", ha="center",
+                            fontsize=4.5, clip_on=True)
+            left += marg
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels(labels, fontsize=7)
+    ax.set_xlabel(f"% of patients with ≥1 CTA > {threshold} TPM "
+                  "(stacked by each CTA's marginal new-patient share, greedy order)")
+    ax.set_xlim(0, 100)
+    ax.grid(axis="x", alpha=0.3)
+    handles = [Patch(color=fam_base[f], label=f) for f in fam_order]
+    ax.legend(handles=handles, loc="lower right", fontsize=6,
+              title="antigen family", ncol=2, handlelength=1.1,
+              labelspacing=0.25, columnspacing=1.0)
+    ax.set_title(f"CTA coverage by cancer type, split into each CTA's marginal "
+                 f"new-patient contribution (> {threshold} TPM, "
+                 f"Treehouse 25.01 PolyA)", fontsize=11)
+    fig.tight_layout()
+    fig.savefig(OUT / f"cta_stacked_coverage_t{threshold}.png", dpi=150)
+    plt.close(fig)
+    print(f"      {len(rows)} cohorts -> stacked coverage bar", flush=True)
+
+
+# Cohorts whose registry code is the wrong TMB key for their actual samples.
+# The bare "SARC" cohort is the TCGA leiomyosarcoma slice, so look up SARC_LMS.
+_TMB_CODE = {"SARC": "SARC_LMS"}
+
+# Coarse tissue-lineage groups for coloring the CTA-vs-TMB scatter, collapsed
+# from the registry `family` column so the legend stays readable.
+_LINEAGE_COLORS = {
+    "sarcoma": "#e85d04", "pediatric": "#d00000", "carcinoma": "#1d4e89",
+    "melanoma": "#6a040f", "neuroendocrine": "#2a9d8f", "heme": "#9d4edd",
+    "CNS": "#3a86ff", "germ cell": "#ffb703", "endocrine": "#588157",
+    "other": "#9a9a9a",
+}
+
+
+def _registry_family_map():
+    from pirlygenes.load_dataset import get_data
+    df = get_data("cancer-type-registry")
+    return {str(r.code): str(r.family) for r in df.itertuples()}
+
+
+def _lineage_group(family: str) -> str:
+    f = (family or "").lower()
+    if f.startswith("pediatric"):
+        return "pediatric"
+    if f == "sarcoma":
+        return "sarcoma"
+    if f == "melanoma":
+        return "melanoma"
+    if f == "net" or "neuroendocrine" in f:
+        return "neuroendocrine"
+    if f.startswith("heme"):
+        return "heme"
+    if f == "cns":
+        return "CNS"
+    if f == "germ-cell":
+        return "germ cell"
+    if f == "endocrine":
+        return "endocrine"
+    if f.startswith("carcinoma"):
+        return "carcinoma"
+    return "other"
+
+
+def _cta_vs_tmb(mat, cohorts, ensg_to_sym, threshold):
+    """Scatter: each cancer type's CTA coverage plateau (% of patients with ≥1
+    CTA over threshold) vs its published median TMB (mut/Mb, log x). Tumors with
+    high CTA coverage but low TMB are the interesting quadrant for CTA-directed
+    therapy (antigen present without relying on a high neoantigen load). Cohorts
+    with no curated TMB value are dropped and counted in the caption."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    tmb_map = gsc.cancer_tmb()  # {code: median_tmb}, codes w/o a value omitted
+    pts, missing = [], []
+    for code in cohorts:
+        order, cum, n = greedy_coverage(mat, cohorts[code], threshold)
+        if not cum:
+            continue
+        tmb = tmb_map.get(_TMB_CODE.get(code, code))
+        if tmb is None:
+            missing.append(code)
+            continue
+        pts.append((code, n, cum[-1] * 100, tmb))
+    if not pts:
+        print("      no cohorts with both coverage and TMB; skip", flush=True)
+        return
+
+    xs = [p[3] for p in pts]
+    ys = [p[2] for p in pts]
+    fam_map = _registry_family_map()
+    groups = [_lineage_group(fam_map.get(code, "")) for code, *_ in pts]
+
+    from matplotlib.lines import Line2D
+    fig, ax = plt.subplots(figsize=(12, 7.5))
+    ax.set_xscale("log")
+    x_lo, x_hi = min(xs) * 0.7, max(xs) * 1.5
+    ax.set_xlim(x_lo, x_hi)
+    ax.set_ylim(0, 100)
+
+    # Shade the "antigen-rich / mutation-poor" sweet spot: high CTA coverage
+    # (>=50%) at low TMB (<=3 mut/Mb), where CTA-directed therapy is attractive
+    # precisely because the low neoantigen load makes checkpoint blockade weak.
+    SWEET_TMB, SWEET_COV = 3.0, 50.0
+    ax.fill_between([x_lo, SWEET_TMB], SWEET_COV, 100, color="#ffd166",
+                    alpha=0.18, zorder=0)
+    ax.text(x_lo * 1.08, 98.5,
+            "antigen-rich / mutation-poor\n(CTA-therapy sweet spot:\n"
+            "≥50% coverage, ≤3 mut/Mb)",
+            fontsize=7, va="top", ha="left", color="#9c6f00", style="italic")
+
+    ax.scatter(xs, ys, s=34, c=[_LINEAGE_COLORS[g] for g in groups],
+               alpha=0.9, edgecolor="white", linewidth=0.4, zorder=3)
+    ax.set_xlabel("median tumor mutational burden (mut/Mb, log scale)")
+    ax.set_ylabel(f"% of patients with ≥1 CTA > {threshold} TPM "
+                  "(coverage plateau)")
+    ax.grid(alpha=0.3, which="both")
+
+    # Repel labels so they don't overlap (thin leader lines back to points).
+    texts = [ax.text(tmb, cov, _display_code(code), fontsize=6)
+             for code, n, cov, tmb in pts]
+    try:
+        from adjustText import adjust_text
+        adjust_text(texts, x=list(xs), y=list(ys), ax=ax,
+                    arrowprops=dict(arrowstyle="-", color="0.6", lw=0.4))
+    except ImportError:  # fallback: small fixed offset (may overlap)
+        for t, (code, n, cov, tmb) in zip(texts, pts):
+            t.set_fontsize(5)
+            t.set_position((tmb * 1.02, cov + 0.6))
+
+    # Lineage legend (only groups present), placed outside the axes.
+    present = [g for g in _LINEAGE_COLORS if g in set(groups)]
+    handles = [Line2D([0], [0], marker="o", linestyle="", markersize=6,
+                      markerfacecolor=_LINEAGE_COLORS[g], markeredgecolor="white",
+                      label=g) for g in present]
+    ax.legend(handles=handles, loc="center left", bbox_to_anchor=(1.01, 0.5),
+              fontsize=7, title="lineage", frameon=False)
+
+    sub = ""
+    if len(pts) >= 3:
+        r = np.corrcoef(np.log10(xs), ys)[0, 1]
+        sub = f"; Pearson r(log TMB, coverage)={r:.2f}"
+    ax.set_title(f"CTA coverage vs TMB by cancer type "
+                 f"(> {threshold} TPM, n={len(pts)} cohorts{sub})", fontsize=10)
+    ax.text(0.99, 0.01,
+            f"{len(missing)} cohort(s) dropped (no curated TMB)",
+            transform=ax.transAxes, fontsize=6, color="gray", ha="right")
+    fig.tight_layout()
+    fig.savefig(OUT / f"cta_coverage_vs_tmb_t{threshold}.png", dpi=150)
+    plt.close(fig)
+    print(f"      {len(pts)} cohorts plotted, {len(missing)} dropped (no TMB)",
+          flush=True)
+
+
 def _coverage_every_cohort(mat, cohorts, ensg_to_sym, threshold):
     """One annotated greedy co-occurrence-aware coverage PNG per cancer type,
     into outputs/cta_coverage/, plus a small-multiples overview sorted by how
@@ -434,9 +674,10 @@ def _coverage_every_cohort(mat, cohorts, ensg_to_sym, threshold):
             ax.annotate(nm, (x, c * 100), fontsize=6, rotation=45,
                         textcoords="offset points", xytext=(2, 4))
         ax.set_xlabel("# CTAs added (greedy, co-occurrence-aware)")
-        ax.set_ylabel(f"% of {code} patients with ≥1 CTA > {threshold} TPM")
-        ax.set_title(f"{code}: cumulative distinct-patient coverage "
-                     f"(> {threshold} TPM, n={n}); plateau "
+        ax.set_ylabel(f"% of {_display_code(code)} patients with ≥1 CTA "
+                      f"> {threshold} TPM")
+        ax.set_title(f"{_display_code(code)}: cumulative distinct-patient "
+                     f"coverage (> {threshold} TPM, n={n}); plateau "
                      f"{cum[-1]*100:.0f}%", fontsize=10)
         ax.set_xlim(0, min(30, len(cum) + 1))
         ax.set_ylim(0, 100)
@@ -452,12 +693,16 @@ def _coverage_every_cohort(mat, cohorts, ensg_to_sym, threshold):
     fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 2.5, nrow * 1.9),
                              sharex=True, sharey=True)
     axes = axes.ravel()
-    for ax, (code, n, cum, _names) in zip(axes, summary):
-        ax.plot(range(1, len(cum) + 1), [c * 100 for c in cum],
-                color="#b5179e", lw=1.2)
-        ax.fill_between(range(1, len(cum) + 1), [c * 100 for c in cum],
-                        alpha=0.15, color="#b5179e")
-        ax.set_title(f"{code} (n={n}) {cum[-1]*100:.0f}%", fontsize=7)
+    for ax, (code, n, cum, names) in zip(axes, summary):
+        xs = range(1, len(cum) + 1)
+        ax.plot(xs, [c * 100 for c in cum], color="#b5179e", lw=1.2)
+        ax.fill_between(xs, [c * 100 for c in cum], alpha=0.15, color="#b5179e")
+        # name the first few CTAs so each panel is readable on its own
+        for x, (nm, c) in enumerate(zip(names[:3], cum[:3]), start=1):
+            ax.annotate(nm, (x, c * 100), fontsize=4, rotation=45,
+                        textcoords="offset points", xytext=(1, 2))
+        ax.set_title(f"{_display_code(code)} (n={n}) {cum[-1]*100:.0f}%",
+                     fontsize=7)
         ax.set_xlim(0, 25)
         ax.set_ylim(0, 100)
         ax.tick_params(labelsize=5)
@@ -494,7 +739,8 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
                                     max(8, len(top_ctas) * 0.26)))
     im = ax.imshow(piv.to_numpy(), aspect="auto", cmap="magma")
     ax.set_xticks(range(len(piv.columns)))
-    ax.set_xticklabels(piv.columns, rotation=90, fontsize=6)
+    ax.set_xticklabels([_display_code(c) for c in piv.columns],
+                       rotation=90, fontsize=6)
     ax.set_yticks(range(len(piv.index)))
     ax.set_yticklabels(piv.index, fontsize=6)
     ax.set_title(f"# patients with CTA > {threshold} TPM "
@@ -511,7 +757,8 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
                                     max(8, len(top_ctas) * 0.26)))
     im = ax.imshow(pivp.to_numpy(), aspect="auto", cmap="viridis")
     ax.set_xticks(range(len(pivp.columns)))
-    ax.set_xticklabels(pivp.columns, rotation=90, fontsize=6)
+    ax.set_xticklabels([_display_code(c) for c in pivp.columns],
+                       rotation=90, fontsize=6)
     ax.set_yticks(range(len(pivp.index)))
     ax.set_yticklabels(pivp.index, fontsize=6)
     ax.set_title(f"% of cohort with CTA > {threshold} TPM "
@@ -528,9 +775,9 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
         fig, ax = plt.subplots(figsize=(10, max(4, len(fc) * 0.28)))
         ax.barh(fc["Symbol"], fc[pcol], color="#b5179e")
         ax.invert_yaxis()
-        ax.set_xlabel(f"% of {focus} patients > {threshold} TPM")
+        ax.set_xlabel(f"% of {_display_code(focus)} patients > {threshold} TPM")
         n = int(fc["n_samples"].iloc[0])
-        ax.set_title(f"{focus}: CTA expression breadth "
+        ax.set_title(f"{_display_code(focus)}: CTA expression breadth "
                      f"(> {threshold} TPM, n={n})", fontsize=10)
         for y, (p, k) in enumerate(zip(fc[pcol], fc[tcol])):
             ax.text(p, y, f" {k}", va="center", fontsize=6)
@@ -538,22 +785,27 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
         fig.savefig(OUT / f"cta_pct_bar_{focus}_t{threshold}.png", dpi=150)
         plt.close(fig)
 
-    # ---- (4) co-occurrence-aware coverage curves ----
-    fig, ax = plt.subplots(figsize=(8, 5.5))
-    for code in [focus, "SKCM", "LUAD", "BRCA", "OS"]:
-        if code not in cohorts:
-            continue
+    # ---- (4) co-occurrence-aware coverage curves (top cohorts by plateau) ----
+    curves = []
+    for code in cohorts:
         order, cum, n = greedy_coverage(mat, cohorts[code], threshold)
-        if not cum:
-            continue
+        if cum:
+            curves.append((code, n, cum))
+    curves.sort(key=lambda t: t[2][-1], reverse=True)
+    keep = curves[:12]
+    if focus in {c for c, _, _ in curves} and focus not in {c for c, _, _ in keep}:
+        keep += [t for t in curves if t[0] == focus]
+    fig, ax = plt.subplots(figsize=(9, 6))
+    for code, n, cum in keep:
         ax.plot(range(1, len(cum) + 1), [c * 100 for c in cum],
-                marker="o", ms=2, lw=1, label=f"{code} (n={n})")
+                marker="o", ms=2, lw=1, label=f"{_display_code(code)} (n={n})")
     ax.set_xlabel("# CTAs in panel (greedy, co-occurrence-aware)")
     ax.set_ylabel(f"% of patients with >=1 CTA > {threshold} TPM")
     ax.set_title(f"CTA panel coverage: distinct patients picked up "
-                 f"(> {threshold} TPM)", fontsize=10)
+                 f"(> {threshold} TPM; top {len(keep)} cohorts by plateau)",
+                 fontsize=10)
     ax.set_xlim(0, 30)
-    ax.legend(fontsize=8)
+    ax.legend(fontsize=7, ncol=2)
     ax.grid(alpha=0.3)
     fig.tight_layout()
     fig.savefig(OUT / f"cta_coverage_curves_t{threshold}.png", dpi=150)
@@ -570,9 +822,9 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
             ax.annotate(nm, (x, c * 100), fontsize=6, rotation=45,
                         textcoords="offset points", xytext=(2, 4))
         ax.set_xlabel("# CTAs added (greedy order)")
-        ax.set_ylabel(f"% of {focus} patients covered")
-        ax.set_title(f"{focus}: cumulative patient coverage as CTAs are added "
-                     f"(> {threshold} TPM, n={n})", fontsize=10)
+        ax.set_ylabel(f"% of {_display_code(focus)} patients covered")
+        ax.set_title(f"{_display_code(focus)}: cumulative patient coverage as "
+                     f"CTAs are added (> {threshold} TPM, n={n})", fontsize=10)
         ax.set_xlim(0, min(30, len(cum) + 1))
         ax.grid(alpha=0.3)
         fig.tight_layout()

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -303,7 +303,10 @@ def _cta_family(symbol: str) -> str:
         if s.startswith(p):
             return _FAMILY_LABEL.get(p, p)
     stem = re.sub(r"[0-9].*$", "", s)
-    return stem or s
+    # Guard against degenerate stems: symbols like C12orf42 / H2BC1 / ZC3H11B
+    # strip to "C"/"H"/"ZC", which are not real antigen families. Below a 3-char
+    # stem, treat the CTA as its own (singleton) family instead of a fake group.
+    return stem if len(stem) >= 3 else s
 
 
 def _shade(rgb, k):

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -278,10 +278,54 @@ def _build_parser() -> argparse.ArgumentParser:
 
     plot_parser = subparsers.add_parser(
         "plot",
-        help="Cohort-level plots (NotImplemented; see plan milestone 7).",
+        help="Cohort-level plots over the reference data.",
+        description=(
+            "Cohort-level plots over the packaged reference data.\n\n"
+            "actions:\n"
+            "  patient-coverage   per-cohort patient coverage of a gene set\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    plot_parser.add_argument(
-        "target", help="What to plot (e.g. a gene symbol or panel name)."
+    plot_sub = plot_parser.add_subparsers(
+        dest="plot_action", metavar="<action>", title="actions",
+    )
+    pc = plot_sub.add_parser(
+        "patient-coverage",
+        help="Per-cohort patient coverage of a gene set (counts CSV + plots).",
+        description=(
+            "For each cancer cohort with cached per-sample data, count how many\n"
+            "patients express each gene of a panel above TPM thresholds, and\n"
+            "compute greedy co-occurrence-aware coverage. Writes a counts CSV +\n"
+            "a stacked coverage bar + a coverage-curve small-multiples."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  pirlygenes plot patient-coverage --gene-set cta\n"
+            "  pirlygenes plot patient-coverage --gene-set lineage:PRAD --cohort PRAD\n"
+            "  pirlygenes plot patient-coverage --gene-set ./my_symbols.csv\n"
+        ),
+    )
+    pc.add_argument(
+        "--gene-set", required=True,
+        help=("panel to score: cta | surfaceome | mito | housekeeping | "
+              "therapy:<type> | lineage:<code> | a path to a CSV of symbols/ENSG ids"),
+    )
+    pc.add_argument(
+        "--source", default="treehouse-polya-25-01",
+        help="expression source id with cached per-sample data (default: %(default)s)",
+    )
+    pc.add_argument(
+        "--threshold", type=int, default=25,
+        help="TPM cutoff for the coverage plots (default: %(default)s)",
+    )
+    pc.add_argument(
+        "--cohort", action="append", default=None, metavar="CODE",
+        help="restrict to specific cancer-type code(s); repeatable (default: all)",
+    )
+    pc.add_argument(
+        "--out", default="coverage_out",
+        help="output directory for the CSV + PNGs (default: %(default)s)",
     )
 
     for name in sorted(_ANALYSIS_SUBCOMMANDS):
@@ -622,11 +666,37 @@ def cmd_build(args: argparse.Namespace) -> int:
     return int(result.returncode)
 
 
-def cmd_plot(_args: argparse.Namespace) -> int:
-    sys.stderr.write(
-        _NOT_IMPLEMENTED_MESSAGE.format(subcommand="plot", milestone=7) + "\n"
+def cmd_plot_patient_coverage(args: argparse.Namespace) -> int:
+    from . import coverage
+
+    try:
+        result = coverage.render(
+            args.gene_set, source_id=args.source, codes=args.cohort,
+            threshold=args.threshold, out_dir=args.out,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+    if result["n_cohorts"] == 0:
+        sys.stderr.write(
+            f"no cohorts with cached per-sample data for source "
+            f"'{args.source}' (and gene set '{result['label']}'). "
+            f"Run `pirlygenes downloads fetch {args.source}` / "
+            f"`pirlygenes build {args.source}` first.\n"
+        )
+        return 2
+    sys.stdout.write(
+        f"{result['label']}: {result['n_cohorts']} cohorts "
+        f"(> {args.threshold} TPM)\n"
     )
-    return 2
+    for kind, path in result["paths"].items():
+        sys.stdout.write(f"  {kind}: {path}\n")
+    return 0
+
+
+_PLOT_DISPATCH = {
+    "patient-coverage": cmd_plot_patient_coverage,
+}
 
 
 def cmd_analysis_moved(_args: argparse.Namespace) -> int:
@@ -686,9 +756,15 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         return handler(args)
 
+    if subcommand == "plot":
+        handler = _PLOT_DISPATCH.get(args.plot_action)
+        if handler is None:
+            sys.stderr.write("usage: pirlygenes plot {patient-coverage}\n")
+            return 2
+        return handler(args)
+
     dispatch = {
         "build": cmd_build,
-        "plot": cmd_plot,
     }
     handler = dispatch.get(subcommand)
     if handler is None:

--- a/pirlygenes/cohorts.py
+++ b/pirlygenes/cohorts.py
@@ -1,0 +1,106 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-sample cohort registry: which expression cohorts a build *source*
+materialises, and how each registry cancer-type code maps to its on-disk
+per-sample-TPM parquet stem.
+
+The builders (:mod:`pirlygenes.builders.treehouse`) write one per-sample TPM
+matrix per cohort to ``<source-cache>/derived/<stem>_per_sample_tpm.parquet``.
+Most cohorts use their own code as the stem; the TCGA-via-Treehouse cohorts use
+``tcga_<lower(code)>``; the molecular / histology sub-cohorts use mixed-case
+codes that don't round-trip from a lowercased stem (e.g. ``BRCA_LumA`` ->
+``tcga_brca_luma``), so that mapping is enumerated explicitly here rather than
+inferred. This is the package-level home for cohort definitions that previously
+lived only in ``scripts/sweep_treehouse_*`` — the cohort-level CLI
+(``pirlygenes plot``) and notebooks read per-sample data through it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import downloads
+
+
+@dataclass(frozen=True)
+class Cohort:
+    """One materialised per-sample cohort within a build source."""
+
+    code: str        # registry cancer-type code (e.g. "GBM", "BRCA_LumA")
+    stem: str        # per-sample parquet stem (filename minus _per_sample_tpm.parquet)
+    source_id: str   # expression source id (downloads registry)
+
+
+# --- treehouse-polya-25-01 -------------------------------------------------
+# Pediatric / sarcoma / rare cohorts: parquet stem == cancer code.
+_TH_DIRECT = [
+    "ATRT", "EWS", "HEPB", "MBL", "NPC", "NUTM", "OS",
+    "RMS_ARMS", "RMS_ERMS", "RMS_PRMS", "RMS_SSRMS",
+    "SARC_ANGIO", "SARC_ASPS", "SARC_DSRCT", "SARC_EHE", "SARC_EPITH",
+    "SARC_GIST", "SARC_IFS", "SARC_IMT", "SARC_LGFMS", "SARC_LMS",
+    "SARC_LPS_UNSPEC", "SARC_MPNST", "SARC_MYXFIB", "SARC_SYN", "SARC_UPS",
+]
+# TCGA-via-Treehouse direct projects: stem == "tcga_<lower(code)>".
+_TH_TCGA = [
+    "ACC", "BLCA", "BRCA", "CESC", "CHOL", "COAD", "DLBC", "ESCA", "GBM",
+    "HNSC", "KICH", "KIRC", "KIRP", "LAML", "LGG", "LIHC", "LUAD", "LUSC",
+    "MESO", "OV", "PAAD", "PCPG", "PRAD", "READ", "SARC", "SKCM", "STAD",
+    "TGCT", "THCA", "THYM", "UCEC", "UCS", "UVM",
+]
+# Molecular / histology sub-cohorts (mixed-case codes -> explicit stems).
+_TH_DERIVED = {
+    "BRCA_Basal": "tcga_brca_basal", "BRCA_HER2": "tcga_brca_her2",
+    "BRCA_LumA": "tcga_brca_luma", "BRCA_LumB": "tcga_brca_lumb",
+    "BRCA_Normal": "tcga_brca_normal",
+    "HNSC_HPV_neg": "tcga_hnsc_hpv_neg", "HNSC_HPV_pos": "tcga_hnsc_hpv_pos",
+    "LUAD_EGFR": "tcga_luad_egfr", "LUAD_KRAS": "tcga_luad_kras",
+    "LUAD_STK11": "tcga_luad_stk11",
+    "SARC_DDLPS": "tcga_sarc_ddlps", "SARC_PLEOLPS": "tcga_sarc_pleolps",
+    "SARC_WDLPS": "tcga_sarc_wdlps",
+}
+
+
+def _treehouse_polya_25_01() -> dict[str, Cohort]:
+    src = "treehouse-polya-25-01"
+    out: dict[str, Cohort] = {}
+    for code in _TH_DIRECT:
+        out[code] = Cohort(code, code, src)
+    for code in _TH_TCGA:
+        out[code] = Cohort(code, f"tcga_{code.lower()}", src)
+    for code, stem in _TH_DERIVED.items():
+        out[code] = Cohort(code, stem, src)
+    return out
+
+
+_REGISTRY: dict[str, dict[str, Cohort]] = {
+    "treehouse-polya-25-01": _treehouse_polya_25_01(),
+}
+
+
+def cohorts_for_source(source_id: str) -> dict[str, Cohort]:
+    """All registered cohorts for ``source_id`` ({code: Cohort}); empty if the
+    source has no per-sample cohort registry."""
+    return dict(_REGISTRY.get(source_id, {}))
+
+
+def parquet_path(cohort: Cohort):
+    """Path to a cohort's per-sample TPM parquet (may not exist on disk)."""
+    return (downloads.source_cache_dir(cohort.source_id) / "derived"
+            / f"{cohort.stem}_per_sample_tpm.parquet")
+
+
+def available_cohorts(source_id: str) -> dict[str, Cohort]:
+    """Registered cohorts whose per-sample parquet is actually present in the
+    local cache (i.e. usable right now without a build/download)."""
+    return {code: c for code, c in cohorts_for_source(source_id).items()
+            if parquet_path(c).exists()}

--- a/pirlygenes/coverage.py
+++ b/pirlygenes/coverage.py
@@ -1,0 +1,336 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cohort-level *patient* coverage of a gene set.
+
+The packaged cohort summaries store per-cohort percentiles only, so they can't
+answer "how many *patients* in this cohort express gene X above 50 TPM" or
+"as I add genes to a panel, how many *new* patients do I pick up". Those are
+cohort-level questions that need the per-sample matrices the builders cache
+(``<source>/derived/<stem>_per_sample_tpm.parquet``, linear TPM). This module
+reads those, restricted to a named gene set, and computes:
+
+  * per (cohort × gene × threshold) patient counts and percentages, and
+  * greedy co-occurrence-aware coverage — as genes are added in the order that
+    maximises *new* distinct patients over threshold, the cumulative fraction
+    of patients with >=1 panel gene over threshold (a patient expressing
+    several panel genes is counted once).
+
+It is the engine behind ``pirlygenes plot patient-coverage`` and generalises
+the CTA-specific analysis in ``analyses/cta_patient_counts.py`` to any panel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from . import cohorts as _cohorts
+from . import gene_sets_cancer as gsc
+
+DEFAULT_SOURCE = "treehouse-polya-25-01"
+DEFAULT_THRESHOLDS = (25, 50, 100, 200)
+
+# --- gene-set resolution ---------------------------------------------------
+
+# Tokens that map to an ENSG accessor in gene_sets_cancer. A cohort matrix row
+# is "in the panel" if its Ensembl_Gene_ID is in ``ensgs`` OR its Symbol is in
+# ``symbols`` — so panels keyed by either identifier resolve uniformly.
+def resolve_gene_set(name: str):
+    """Resolve a ``--gene-set`` token to ``(label, ensgs, symbols)``.
+
+    Supported tokens::
+
+        cta | surfaceome | mito | housekeeping
+        therapy:<type>     e.g. therapy:adc, therapy:car-t, therapy:radioligand
+        lineage:<code>     per-cancer-type lineage panel (e.g. lineage:PRAD)
+        <path>             a CSV/TXT with Symbol and/or Ensembl_Gene_ID column(s),
+                           or a single first column of symbols / ENSG ids
+    """
+    token = str(name).strip()
+    low = token.lower()
+    if low == "cta":
+        return "CTA", set(gsc.CTA_gene_ids()), set()
+    if low in ("surfaceome", "cancer-surfaceome"):
+        return "cancer-surfaceome", set(gsc.cancer_surfaceome_gene_ids()), set()
+    if low in ("mito", "mitochondrial"):
+        return "mitochondrial", set(gsc.mitochondrial_gene_ids()), set()
+    if low == "housekeeping":
+        return "housekeeping", set(gsc.housekeeping_gene_ids()), set()
+    if low.startswith("therapy:"):
+        t = token.split(":", 1)[1]
+        return f"therapy:{t}", set(gsc.therapy_target_gene_ids(t)), set()
+    if low.startswith("lineage:"):
+        code = gsc.resolve_cancer_type(token.split(":", 1)[1])
+        df = gsc.lineage_genes_df(code)
+        ensgs = set(df["Ensembl_Gene_ID"].dropna().astype(str).str.split(".").str[0])
+        syms = (set(df["Symbol"].dropna().astype(str).str.upper())
+                if "Symbol" in df.columns else set())
+        return f"lineage:{code}", ensgs, syms
+    p = Path(token).expanduser()
+    if p.exists():
+        return _gene_set_from_file(p)
+    raise ValueError(
+        f"Unknown --gene-set {name!r}. Use one of: cta, surfaceome, mito, "
+        "housekeeping, therapy:<type>, lineage:<code>, or a path to a CSV of "
+        "symbols/ENSG ids."
+    )
+
+
+def _gene_set_from_file(path: Path):
+    raw = pd.read_csv(path)
+    cols = {c.lower(): c for c in raw.columns}
+    ensgs, symbols = set(), set()
+    if "ensembl_gene_id" in cols:
+        ensgs |= set(raw[cols["ensembl_gene_id"]].dropna().astype(str)
+                     .str.split(".").str[0])
+    if "symbol" in cols:
+        symbols |= set(raw[cols["symbol"]].dropna().astype(str).str.upper())
+    if not ensgs and not symbols:  # bare first column: classify each token
+        for v in raw[raw.columns[0]].dropna().astype(str):
+            v = v.strip()
+            (ensgs.add(v.split(".")[0]) if v.upper().startswith("ENSG")
+             else symbols.add(v.upper()))
+    return path.name, ensgs, symbols
+
+
+# --- per-sample access + counting ------------------------------------------
+
+def cohort_matrix(cohort, ensgs=None, symbols=None) -> pd.DataFrame:
+    """Per-sample TPM matrix for ``cohort``, restricted to the panel rows.
+
+    Returns a Symbol-indexed, sample-columned DataFrame (linear TPM)."""
+    path = _cohorts.parquet_path(cohort)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"no per-sample parquet for {cohort.code} at {path} — run "
+            f"`pirlygenes build {cohort.source_id}` or `downloads fetch` first")
+    df = pd.read_parquet(path)
+    ensgs, symbols = ensgs or set(), {s.upper() for s in (symbols or set())}
+    mask = pd.Series(False, index=df.index)
+    if ensgs:
+        mask |= df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0].isin(ensgs)
+    if symbols:
+        mask |= df["Symbol"].astype(str).str.upper().isin(symbols)
+    sub = df.loc[mask]
+    sample_cols = [c for c in sub.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    return sub.set_index("Symbol")[sample_cols]
+
+
+def greedy_coverage(mat: pd.DataFrame, threshold: float):
+    """Greedily order genes by marginal NEW patients (>threshold).
+
+    Returns ``(ordered_row_positions, cumulative_fraction, n_samples)``."""
+    arr = mat.to_numpy()
+    n = arr.shape[1]
+    if n == 0 or arr.shape[0] == 0:
+        return [], [], n
+    hit = arr > threshold
+    covered = np.zeros(n, dtype=bool)
+    order, cum, remaining = [], [], set(range(arr.shape[0]))
+    while remaining:
+        best, best_gain = None, 0
+        for i in remaining:
+            gain = int((hit[i] & ~covered).sum())
+            if gain > best_gain:
+                best, best_gain = i, gain
+        if best is None or best_gain <= 0:
+            break
+        covered |= hit[best]
+        order.append(best)
+        cum.append(covered.sum() / n)
+        remaining.discard(best)
+    return order, cum, n
+
+
+def patient_coverage(gene_set: str, source_id: str = DEFAULT_SOURCE,
+                     codes=None, thresholds=DEFAULT_THRESHOLDS) -> pd.DataFrame:
+    """Long table: for every (cohort × gene) the number and % of patients with
+    TPM above each threshold. Only genes with at least one hit are kept.
+
+    ``codes`` optionally restricts to specific cancer types (resolved through
+    :func:`gene_sets_cancer.resolve_cancer_type`); default is every cohort with
+    a cached per-sample matrix for ``source_id``.
+    """
+    _label, ensgs, symbols = resolve_gene_set(gene_set)
+    avail = _cohorts.available_cohorts(source_id)
+    if codes:
+        want = {gsc.resolve_cancer_type(c) for c in codes}
+        avail = {k: v for k, v in avail.items() if k in want}
+    rows = []
+    for code, cohort in avail.items():
+        mat = cohort_matrix(cohort, ensgs, symbols)
+        n = mat.shape[1]
+        if n == 0:
+            continue
+        for sym, vals in zip(mat.index, mat.to_numpy()):
+            rec = {"cancer_code": code, "n_samples": n, "Symbol": sym}
+            any_hit = False
+            for t in thresholds:
+                k = int((vals > t).sum())
+                rec[f"n_gt{t}"] = k
+                rec[f"pct_gt{t}"] = round(100 * k / n, 2)
+                any_hit = any_hit or k > 0
+            if any_hit:
+                rows.append(rec)
+    cols = (["cancer_code", "n_samples", "Symbol"]
+            + [f"{p}_gt{t}" for t in thresholds for p in ("n", "pct")])
+    return pd.DataFrame(rows, columns=cols)
+
+
+# --- rendering (CLI) -------------------------------------------------------
+
+_PALETTE = [
+    "#e6194B", "#3cb44b", "#4363d8", "#f58231", "#911eb4", "#42d4f4",
+    "#f032e6", "#bfef45", "#469990", "#9A6324", "#800000", "#808000",
+    "#000075", "#e6beff", "#aaffc3", "#ffd8b1", "#a9a9a9", "#fabed4",
+]
+
+
+def _slug(label: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in label.lower()).strip("_")
+
+
+def render(gene_set: str, source_id: str = DEFAULT_SOURCE, codes=None,
+           threshold: int = 25, thresholds=DEFAULT_THRESHOLDS,
+           out_dir="coverage_out") -> dict:
+    """Compute patient coverage for ``gene_set`` and write a counts CSV plus two
+    figures (a per-CTA-style stacked coverage bar and a coverage-curve
+    small-multiples) into ``out_dir``. Returns a dict of written paths + the
+    counts DataFrame. ``threshold`` is the TPM cutoff used for the two plots;
+    ``thresholds`` are the cutoffs tabulated in the CSV.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    label, ensgs, symbols = resolve_gene_set(gene_set)
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    slug = _slug(label)
+
+    counts = patient_coverage(gene_set, source_id, codes, thresholds)
+    csv_path = out / f"{slug}_patient_counts.csv"
+    counts.sort_values(["cancer_code", f"n_gt{threshold}"],
+                       ascending=[True, False]).to_csv(csv_path, index=False)
+
+    # Per-cohort greedy coverage (reuse the loaded matrices once).
+    avail = _cohorts.available_cohorts(source_id)
+    if codes:
+        want = {gsc.resolve_cancer_type(c) for c in codes}
+        avail = {k: v for k, v in avail.items() if k in want}
+    per = []  # (code, n, cum, gene_names_in_greedy_order)
+    for code, cohort in avail.items():
+        mat = cohort_matrix(cohort, ensgs, symbols)
+        order, cum, n = greedy_coverage(mat, threshold)
+        if cum:
+            per.append((code, n, cum, [mat.index[i] for i in order]))
+    per.sort(key=lambda t: t[2][-1])  # ascending plateau -> broadest at top
+
+    paths = {"counts_csv": str(csv_path)}
+    if per:
+        paths["stacked_bar"] = str(_stacked_bar(
+            per, label, threshold, out / f"{slug}_stacked_coverage_t{threshold}.png",
+            plt))
+        paths["coverage_curves"] = str(_coverage_curves(
+            per, label, threshold,
+            out / f"{slug}_coverage_curves_t{threshold}.png", plt))
+    return {"paths": paths, "counts": counts, "label": label,
+            "n_cohorts": len(per)}
+
+
+def _gene_color_map(genes_ordered):
+    seen, colors = [], {}
+    for g in genes_ordered:
+        if g not in colors:
+            colors[g] = _PALETTE[len(seen) % len(_PALETTE)]
+            seen.append(g)
+    return colors
+
+
+def _stacked_bar(per, label, threshold, path, plt):
+    """Horizontal stacked bar: each cohort's greedy plateau split into each
+    gene's marginal new-patient contribution (segments sum to the plateau)."""
+    from collections import Counter
+    tot = Counter()
+    for _code, _n, cum, names in per:
+        prev = 0.0
+        for nm, c in zip(names, cum):
+            tot[nm] += (c - prev) * 100
+            prev = c
+    color = _gene_color_map([g for g, _ in tot.most_common()])
+
+    fig, ax = plt.subplots(figsize=(13, max(6, len(per) * 0.28)))
+    labels = []
+    for y, (code, n, cum, names) in enumerate(per):
+        labels.append(f"{code}  (n={n})")
+        left, prev = 0.0, 0.0
+        for j, (nm, c) in enumerate(zip(names, cum)):
+            marg = (c - prev) * 100
+            prev = c
+            if marg <= 0:
+                continue
+            ax.barh(y, marg, left=left, color=color.get(nm, "#cccccc"),
+                    edgecolor="white", linewidth=0.3)
+            if marg >= 3.0 or j == 0:
+                if marg >= 1.5:
+                    ax.text(left + marg / 2, y, nm, va="center", ha="center",
+                            fontsize=4.5, clip_on=True)
+            left += marg
+    ax.set_yticks(range(len(per)))
+    ax.set_yticklabels(labels, fontsize=7)
+    ax.set_xlim(0, 100)
+    ax.set_xlabel(f"% of patients with ≥1 {label} gene > {threshold} TPM "
+                  "(stacked by each gene's marginal new-patient share, greedy)")
+    ax.grid(axis="x", alpha=0.3)
+    ax.set_title(f"{label} coverage by cancer type, split by gene "
+                 f"(> {threshold} TPM, {len(per)} cohorts)", fontsize=11)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return path
+
+
+def _coverage_curves(per, label, threshold, path, plt):
+    """Small-multiples of each cohort's greedy coverage curve (sorted by
+    plateau, broadest first)."""
+    ordered = sorted(per, key=lambda t: t[2][-1], reverse=True)
+    ncol = 6
+    nrow = (len(ordered) + ncol - 1) // ncol
+    fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 2.5, nrow * 1.9),
+                             sharex=True, sharey=True, squeeze=False)
+    axes = axes.ravel()
+    for ax, (code, n, cum, names) in zip(axes, ordered):
+        xs = range(1, len(cum) + 1)
+        ax.plot(xs, [c * 100 for c in cum], color="#b5179e", lw=1.2)
+        ax.fill_between(xs, [c * 100 for c in cum], alpha=0.15, color="#b5179e")
+        for x, (nm, c) in enumerate(zip(names[:3], cum[:3]), start=1):
+            ax.annotate(nm, (x, c * 100), fontsize=4, rotation=45,
+                        textcoords="offset points", xytext=(1, 2))
+        ax.set_title(f"{code} (n={n}) {cum[-1]*100:.0f}%", fontsize=7)
+        ax.set_xlim(0, 25)
+        ax.set_ylim(0, 100)
+        ax.tick_params(labelsize=5)
+        ax.grid(alpha=0.25)
+    for ax in axes[len(ordered):]:
+        ax.axis("off")
+    fig.suptitle(f"{label} panel coverage by cancer type — distinct patients "
+                 f"with ≥1 gene > {threshold} TPM (sorted by plateau)",
+                 fontsize=11)
+    fig.supxlabel("# genes added (greedy)", fontsize=8)
+    fig.supylabel("% patients covered", fontsize=8)
+    fig.tight_layout(rect=(0.01, 0.01, 1, 0.97))
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return path

--- a/pirlygenes/data/cancer-tmb.csv
+++ b/pirlygenes/data/cancer-tmb.csv
@@ -1,0 +1,71 @@
+cancer_code,median_tmb_mut_mb,source,pmid_doi,confidence,notes
+ACC,1.0,Chalmers 2017,PMID:28420421,low,Adrenocortical; panel-based; low. Metastatic ACC higher.
+BLCA,7.1,Lawrence 2013,PMID:23770567,high,WES median; APOBEC-driven long tail.
+BRCA,1.2,Lawrence 2013,PMID:23770567,high,WES median; higher in basal/HER2; MSI rare.
+CESC,5.0,Lawrence 2013,PMID:23770567,medium,Cervical squamous; APOBEC + HPV; wide range.
+CHOL,2.0,Chalmers 2017,PMID:28420421,medium,Cholangiocarcinoma; panel ~1.8-2.4.
+COAD,3.1,Lawrence 2013,PMID:23770567,high,Colon MSS median; MSI-H/POLE subset >40.
+DLBC,3.3,Lawrence 2013,PMID:23770567,high,DLBCL WES median.
+ESCA,4.0,Lawrence 2013,PMID:23770567,medium,ESCC vs EAC differ; range wide.
+GBM,2.2,Lawrence 2013,PMID:23770567,high,WES median; post-temozolomide/MMR-deficient subset hypermutates.
+HNSC,3.9,Lawrence 2013,PMID:23770567,high,WES median; HPV+ vs HPV- differ slightly.
+KICH,0.7,Chalmers 2017,PMID:28420421,low,Kidney chromophobe; very low; among lowest renal subtypes.
+KIRC,1.9,Lawrence 2013,PMID:23770567,high,Kidney clear cell WES median.
+KIRP,1.3,Chalmers 2017,PMID:28420421,low,Kidney papillary; panel approx ~1-1.5.
+LAML,0.4,Lawrence 2013,PMID:23770567,high,AML WES median; among lowest of all cancers.
+LGG,1.0,Lawrence 2013,PMID:23770567,medium,IDH-mutant low; temozolomide recurrences hypermutate.
+LIHC,4.0,Chalmers 2017,PMID:28420421,medium,Liver HCC; panel/WES ~3-4.
+LUAD,8.1,Lawrence 2013,PMID:23770567,high,Lung adeno WES median; smoking-dependent (never-smokers far lower).
+LUSC,9.9,Lawrence 2013,PMID:23770567,high,Lung squamous WES median; smoking signature.
+MESO,1.8,Chalmers 2017,PMID:28420421,medium,Mesothelioma; low; panel ~1.1-2.
+OV,1.7,Lawrence 2013,PMID:23770567,high,Ovarian serous WES median; HRD/SCNA-driven not SNV.
+PAAD,2.1,Chalmers 2017,PMID:28420421,medium,Pancreatic adeno panel median ~2.0-2.4; MSI rare.
+PCPG,0.5,Chalmers 2017,PMID:28420421,low,Pheo/paraganglioma; very low; among lowest.
+PRAD,0.7,Lawrence 2013,PMID:23770567,high,Prostate adeno WES median; CDK12/MMR subset higher.
+READ,3.1,Lawrence 2013,PMID:23770567,medium,Treated as colorectal; MSI-H subset much higher.
+SKCM,12.9,Lawrence 2013,PMID:23770567,high,Cutaneous melanoma WES median; UV signature; highest common solid tumor.
+STAD,5.0,Chalmers 2017,PMID:28420421,medium,Stomach intestinal type; EBV+ / MSI-H subsets much higher.
+TGCT,0.5,Chalmers 2017,PMID:28420421,low,Testicular germ cell; very low SNV TMB; aneuploidy-driven.
+THCA,0.4,Chalmers 2017,PMID:28420421,high,Thyroid papillary; among lowest; single-driver BRAF/RAS.
+THYM,0.5,Chalmers 2017,PMID:28420421,low,Thymoma; very low; among lowest in TCGA.
+UCEC,2.5,Lawrence 2013,PMID:23770567,high,Endometrioid median; POLE-ultramutated and MSI-H subsets very high.
+UCS,2.5,Chalmers 2017,PMID:28420421,low,Uterine carcinosarcoma; approx; small cohorts.
+UVM,0.34,Wu 2019,DOI:10.21037/atm.2019.09.49,high,Uveal melanoma; lowest median across TCGA; GNAQ/GNA11-driven no UV.
+SARC_LMS,2.2,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Leiomyosarcoma; complex-karyotype STS; low SNV TMB.
+SARC_DDLPS,1.5,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Dedifferentiated liposarcoma; MDM2/CDK4 amplicon-driven; low TMB.
+SARC_UPS,2.2,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Undifferentiated pleomorphic sarcoma; among higher STS TMB.
+SARC_MYXFIB,2.2,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Myxofibrosarcoma ~2 mut/Mb.
+SARC_SYN,1.7,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Synovial sarcoma; lowest STS TMB; SS18-SSX fusion-driven simple karyotype.
+SARC_MPNST,2.5,Chalmers 2017,PMID:28420421,low,MPNST; panel ~2.5.
+OS,1.2,Grobner 2018,PMID:29489754,medium,Osteosarcoma pediatric WGS ~1.2; high SV/chromothripsis burden.
+EWS,0.6,Grobner 2018,PMID:29489754,high,Ewing sarcoma ~0.6; EWSR1-FLI1 fusion-driven; very few SNVs.
+RMS_ERMS,0.8,Grobner 2018,PMID:29489754,low,Embryonal RMS; low pediatric TMB; RAS-pathway; subtype median approximate.
+RMS_ARMS,0.4,Grobner 2018,PMID:29489754,low,Alveolar RMS; PAX3/7-FOXO1 fusion-driven; very low SNV burden; approximate.
+CHON,0.9,Meijer 2025,PMC11949235,low,Chondrosarcoma; low TMB; IDH1/2-driven.
+CHOR,0.53,Chordoma WGS,PMC11172617,medium,Chordoma skull-base WGS; brachyury-driven; rare MMR cases hypermutate.
+NBL,0.6,Grobner 2018,PMID:29489754,high,Neuroblastoma ~0.6; relapse higher.
+WILMS,0.2,Grobner 2018,PMID:29489754,low,Wilms tumor; very low pediatric TMB; per-entity median approximate.
+RT,0.1,Lawrence 2013,PMID:23770567,medium,Rhabdoid tumor ~0.1; SMARCB1-driven near-silent genome.
+ATRT,0.2,Grobner 2018,PMID:29489754,medium,AT/RT; lowest-mutation pediatric brain tumor; SMARCB1/SMARCA4-driven.
+MBL,0.3,Lawrence 2013,PMID:23770567,high,Medulloblastoma ~0.3; rare germline-MMR/POLE hypermutant cases.
+RB,0.085,Retinoblastoma WGS,PMC7918943,medium,Retinoblastoma ~0.085 substitutions/Mb; RB1-loss driven near-silent.
+HEPB,0.02,Grobner 2018,PMID:29489754,medium,Hepatoblastoma; lowest pediatric TMB; CTNNB1-driven.
+MM,1.6,Lawrence 2013,PMID:23770567,high,Multiple myeloma WES median ~1.6; increases at relapse.
+CLL,0.6,Lawrence 2013,PMID:23770567,high,CLL WES median ~0.6; low.
+MCL,1.0,Bea 2013,PMID:23770587,medium,Mantle cell lymphoma WES ~1; approximate per-Mb.
+FL,,,,none,Follicular lymphoma; AID/SHM-driven; no clean published per-Mb median.
+HL,2.0,Wienand 2019,PMID:30108156,low,Hodgkin; panel TMB inflated vs WES; approximate.
+BL,2.0,Love 2012,PMID:23143597,medium,Burkitt; AID/MYC-driven moderate burden; ~2 approximate WES.
+B_ALL,0.3,Grobner 2018,PMID:29489754,low,B-ALL; very low pediatric TMB; CMMRD/relapse cases far higher.
+T_ALL,0.5,Grobner 2018,PMID:29489754,low,T-ALL; low; slightly higher than B-ALL; approximate.
+MDS,0.3,Walter 2013,PMC3897298,medium,MDS ~9 somatic mutations/exome; rises with IPSS risk.
+MPN,,,,none,Myeloproliferative neoplasm; driver-defined (JAK2/CALR/MPL); no published per-Mb median.
+CML,,,,none,Chronic myeloid leukemia; BCR-ABL1-defined; very few additional mutations in chronic phase.
+CTCL,3.0,Park 2021,PMID:33574607,low,CTCL/mycosis fungoides; UV-signature; stage-dependent; advanced much higher.
+PANNET,1.9,Backman 2021,PMID:34326338,medium,Pancreatic NET well-diff median ~1.9 (vs NEC ~5.0); low.
+SCLC,8.6,George 2015,PMID:26168399,high,Small cell lung; high ~8.6; smoking signature.
+MEC,5.3,Knepper 2019,PMID:30482774,medium,Merkel cell carcinoma median ~5.3; bimodal MCPyV-neg(UV) high vs MCPyV-pos low.
+MTC,,,,none,Medullary thyroid; single-driver RET/RAS; no clean published per-Mb median.
+ADCC,0.31,Ho 2013,PMID:23685749,high,Adenoid cystic carcinoma ~0.31; MYB-NFIB fusion-driven; very low.
+NPC,0.95,Nasopharyngeal WES,PMC9498130,medium,Nasopharyngeal carcinoma median ~0.95-1.0; EBV-driven low SNV burden.
+NUTM,,,,none,NUT carcinoma; BRD4-NUT fusion-driven near-silent; no well-cited per-Mb median.

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -2064,6 +2064,36 @@ def disease_state_rules_df():
     return get_data("disease-state-rules")
 
 
+def cancer_tmb_df():
+    """Return the curated ``cancer-tmb.csv`` reference: median tumor
+    mutational burden (mut/Mb) per cancer-type code, with a per-row
+    published source/PMID and a confidence flag.
+
+    Cohorts with no defensible published per-Mb median are present with a
+    blank ``median_tmb_mut_mb`` (and a ``confidence`` of ``none``) so the
+    gap is explicit rather than silently absent. Values mix WES-anchored
+    medians (Lawrence 2013) with panel-based medians (Chalmers 2017) and
+    disease-specific studies; see the ``source``/``notes`` columns — panel
+    and WES TMB are not strictly comparable in the low-TMB range."""
+    return get_data("cancer-tmb")
+
+
+def cancer_tmb(cancer_type=None):
+    """Median TMB (mut/Mb) for one cancer type, or the whole
+    ``{code: median_tmb}`` map (codes with no published value omitted).
+
+    ``cancer_type`` is resolved through :func:`resolve_cancer_type`, so
+    aliases and display names work; returns ``None`` if the type has no
+    curated TMB value."""
+    df = cancer_tmb_df()
+    vals = df.dropna(subset=["median_tmb_mut_mb"])
+    mapping = dict(zip(vals["cancer_code"].astype(str),
+                       vals["median_tmb_mut_mb"].astype(float)))
+    if cancer_type is None:
+        return mapping
+    return mapping.get(resolve_cancer_type(cancer_type))
+
+
 # Per-cohort median tumor-cell purity from TCGA (Aran et al., Nat Commun 2015).
 # Used by trufflepig's purity-confidence reasoning; published here as reference
 # data so consumers don't have to depend on the analysis package just to look

--- a/tests/test_cancer_tmb.py
+++ b/tests/test_cancer_tmb.py
@@ -1,0 +1,77 @@
+"""Tests for the curated per-cancer-type median-TMB reference (cancer-tmb.csv)."""
+
+import math
+
+import pandas as pd
+
+from pirlygenes.gene_sets_cancer import cancer_tmb, cancer_tmb_df, resolve_cancer_type
+
+_EXPECTED_COLS = [
+    "cancer_code",
+    "median_tmb_mut_mb",
+    "source",
+    "pmid_doi",
+    "confidence",
+    "notes",
+]
+
+
+def test_schema_and_unique_codes():
+    df = cancer_tmb_df()
+    assert list(df.columns) == _EXPECTED_COLS
+    codes = df["cancer_code"].astype(str)
+    assert codes.is_unique
+    # Every code must be a real registry code.
+    for code in codes:
+        assert resolve_cancer_type(code) is not None
+
+
+def test_values_positive_and_plausible():
+    df = cancer_tmb_df()
+    vals = df.dropna(subset=["median_tmb_mut_mb"])["median_tmb_mut_mb"].astype(float)
+    assert (vals > 0).all()
+    # Median TMB by type should sit in a sane range (mut/Mb); melanoma is the
+    # high end (~13), pheo/retinoblastoma the low end (<0.1).
+    assert vals.max() < 50
+    assert vals.min() >= 0.01
+
+
+def test_every_value_is_cited():
+    """A non-blank TMB value must carry a source + PMID/DOI; a blank value must
+    be explicitly flagged confidence=none (an honest gap, not a silent absence)."""
+    df = cancer_tmb_df()
+    for row in df.itertuples():
+        has_value = isinstance(row.median_tmb_mut_mb, float) and not math.isnan(
+            row.median_tmb_mut_mb
+        )
+        if has_value:
+            assert isinstance(row.source, str) and row.source.strip()
+            assert isinstance(row.pmid_doi, str) and row.pmid_doi.strip()
+            assert row.confidence in {"high", "medium", "low"}
+        else:
+            assert row.confidence == "none"
+
+
+def test_accessor_map_omits_blanks():
+    mapping = cancer_tmb()
+    assert isinstance(mapping, dict)
+    # Blank-value codes (no published median) are absent from the map.
+    assert "MPN" not in mapping
+    assert "CML" not in mapping
+    # Well-established values are present.
+    assert "SKCM" in mapping and "PRAD" in mapping
+
+
+def test_accessor_resolves_aliases():
+    # melanoma -> SKCM (high TMB), prostate -> PRAD (low TMB)
+    assert cancer_tmb("melanoma") == cancer_tmb("SKCM")
+    assert cancer_tmb("melanoma") > cancer_tmb("prostate")
+    # A code with no curated value returns None rather than raising.
+    assert cancer_tmb("MPN") is None
+
+
+def test_skcm_is_highest_among_common_types():
+    mapping = cancer_tmb()
+    assert mapping["SKCM"] == max(
+        mapping[c] for c in ("SKCM", "LUAD", "LUSC", "BLCA", "BRCA", "PRAD")
+    )

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,122 @@
+"""Tests for pirlygenes.coverage (cohort-level patient coverage of a gene set).
+
+Uses a synthetic per-sample matrix written to a tmp cache — never real
+patient/clinical data."""
+
+import pandas as pd
+import pytest
+
+from pirlygenes import cohorts, coverage
+from pirlygenes.cli import main as cli_main
+
+
+# A 3-gene × 4-sample synthetic cohort with hand-chosen TPM so coverage is
+# deterministic at threshold 25:
+#   GENEA > 25 in s1, s2          (covers 2/4)
+#   GENEB > 25 in s2, s3          (adds s3 -> 3/4)
+#   GENEC > 25 in s1              (adds nothing new)
+# greedy plateau = 3/4 = 75%.
+_SYNTH = pd.DataFrame(
+    {
+        "Ensembl_Gene_ID": ["ENSG00000001", "ENSG00000002", "ENSG00000003"],
+        "Symbol": ["GENEA", "GENEB", "GENEC"],
+        "s1": [100.0, 1.0, 80.0],
+        "s2": [60.0, 90.0, 2.0],
+        "s3": [3.0, 40.0, 1.0],
+        "s4": [0.0, 0.0, 0.0],
+    }
+)
+
+
+@pytest.fixture
+def synth_source(tmp_path, monkeypatch):
+    """Register a synthetic cohort 'SYNTH' backed by a tmp-dir parquet."""
+    derived = tmp_path / "derived"
+    derived.mkdir()
+    _SYNTH.to_parquet(derived / "SYNTH_per_sample_tpm.parquet", index=False)
+
+    monkeypatch.setattr(coverage._cohorts.downloads, "source_cache_dir",
+                        lambda source_id, **k: tmp_path)
+    monkeypatch.setitem(
+        cohorts._REGISTRY, "synth",
+        {"SYNTH": cohorts.Cohort("SYNTH", "SYNTH", "synth")},
+    )
+    return tmp_path
+
+
+def _symbol_csv(tmp_path):
+    p = tmp_path / "panel.csv"
+    p.write_text("Symbol\nGENEA\nGENEB\nGENEC\n")
+    return p
+
+
+# --- resolve_gene_set ------------------------------------------------------
+
+def test_resolve_named_panels():
+    label, ensgs, symbols = coverage.resolve_gene_set("cta")
+    assert label == "CTA" and len(ensgs) > 50 and not symbols
+
+    label, ensgs, symbols = coverage.resolve_gene_set("lineage:PRAD")
+    assert label == "lineage:PRAD"
+    assert ensgs or symbols  # lineage panel has ENSG and/or symbols
+
+
+def test_resolve_csv_path(tmp_path):
+    label, ensgs, symbols = coverage.resolve_gene_set(str(_symbol_csv(tmp_path)))
+    assert symbols == {"GENEA", "GENEB", "GENEC"}
+
+
+def test_resolve_unknown_raises():
+    with pytest.raises(ValueError):
+        coverage.resolve_gene_set("definitely-not-a-panel")
+
+
+# --- matrix + greedy + counts ----------------------------------------------
+
+def test_cohort_matrix_filters_to_panel(synth_source):
+    cohort = cohorts.cohorts_for_source("synth")["SYNTH"]
+    mat = coverage.cohort_matrix(cohort, symbols={"GENEA", "GENEB"})
+    assert set(mat.index) == {"GENEA", "GENEB"}
+    assert mat.shape == (2, 4)
+
+
+def test_greedy_coverage_plateau(synth_source):
+    cohort = cohorts.cohorts_for_source("synth")["SYNTH"]
+    mat = coverage.cohort_matrix(cohort, symbols={"GENEA", "GENEB", "GENEC"})
+    order, cum, n = coverage.greedy_coverage(mat, threshold=25)
+    assert n == 4
+    assert cum[-1] == pytest.approx(0.75)  # 3 of 4 patients
+    assert mat.index[order[0]] == "GENEA"  # most-covering gene first
+
+
+def test_patient_coverage_counts(synth_source, tmp_path):
+    df = coverage.patient_coverage(str(_symbol_csv(tmp_path)), source_id="synth",
+                                   thresholds=(25,))
+    a = df[df.Symbol == "GENEA"].iloc[0]
+    assert a.n_samples == 4 and a.n_gt25 == 2 and a.pct_gt25 == 50.0
+    # GENEC is >25 in one sample, so it is retained (any_hit), not dropped.
+    assert "GENEC" in set(df.Symbol)
+
+
+# --- CLI dispatch ----------------------------------------------------------
+
+def test_cli_patient_coverage(synth_source, tmp_path):
+    out = tmp_path / "out"
+    rc = cli_main([
+        "plot", "patient-coverage", "--gene-set", str(_symbol_csv(tmp_path)),
+        "--source", "synth", "--threshold", "25", "--out", str(out),
+    ])
+    assert rc == 0
+    assert (out / "panel_csv_patient_counts.csv").exists()
+    assert (out / "panel_csv_stacked_coverage_t25.png").exists()
+
+
+def test_cli_bad_gene_set_returns_2(tmp_path):
+    rc = cli_main([
+        "plot", "patient-coverage", "--gene-set", "nope", "--out", str(tmp_path),
+    ])
+    assert rc == 2
+
+
+def test_cli_plot_no_action_returns_2():
+    assert cli_main(["plot"]) == 2

--- a/tests/test_downloads_and_cli.py
+++ b/tests/test_downloads_and_cli.py
@@ -2,8 +2,9 @@
 
 Covers the foundation shipped in the expression-data refresh project
 (see docs/expression-data-refresh-plan.md). Heavy behavior (build,
-fetch, plot) is scaffolded only — those subcommands return a clear
-NotImplemented pointer and are not exercised here.
+fetch) is scaffolded only — those subcommands return a clear
+NotImplemented pointer and are not exercised here. `plot
+patient-coverage` is implemented and covered in test_coverage.py.
 """
 
 from __future__ import annotations
@@ -147,11 +148,12 @@ def test_cli_build_ambiguous_cancer_code_lists_candidates():
     pass
 
 
-def test_cli_plot_scaffolded_but_not_implemented():
-    rc, _, err = _run_cli(["plot", "FATE1"])
+def test_cli_plot_requires_an_action():
+    # `plot` is now implemented (patient-coverage); with no action it prints a
+    # usage line naming the available action and exits non-zero.
+    rc, _, err = _run_cli(["plot"])
     assert rc == 2
-    assert "not implemented" in err
-    assert "milestone 7" in err
+    assert "patient-coverage" in err
 
 
 def test_cli_analyze_redirects_to_trufflepig():


### PR DESCRIPTION
Phase A + B of the CTA-coverage work (Phase C — sarcoma taxonomy rebuild — is a separate follow-up).

## Phase A — coverage plots (`analyses/cta_patient_counts.py`)
- **Stacked-by-CTA bar** (`cta_stacked_coverage_t<t>.png`): each cohort's greedy coverage plateau split into every CTA's **marginal new-patient share** (co-occurrence-aware → segments sum to the plateau, ≤100%), family-colored, small-font segment labels.
- **Labelled coverage figures**: CTA names annotated on the "CTA panel coverage" small-multiples; the multi-cohort curve expanded from 5 hardcoded cohorts to the top-12 by plateau.
- **CTA-vs-TMB scatter** (`cta_coverage_vs_tmb_t<t>.png`): coverage plateau vs median TMB (log x), points colored by tissue lineage, the antigen-rich/mutation-poor quadrant shaded + labelled, labels de-overlapped via `adjustText` (graceful no-dep fallback).
- **`cancer-tmb.csv`** (new curated reference): median TMB (mut/Mb) per cancer type, one published source + PMID/DOI + confidence per row (Lawrence 2013 WES / Chalmers 2017 panel / disease-specific); gaps left blank (MPN/CML/FL/MTC/NUTM). New `cancer_tmb()` / `cancer_tmb_df()` accessors.
- **Honest labels**: the bare TCGA `SARC` cohort is empirically leiomyosarcoma (n=100; GDC histology ~90% LMS), rendered as `TCGA-LMS` in these plots pending the Phase C registry rebuild.

## Phase B — `pirlygenes plot patient-coverage --gene-set <…>`
Promotes the CTA-specific patient-counting/coverage logic to a reusable cohort-level CLI command for any panel.
- **`pirlygenes/coverage.py`**: `resolve_gene_set` (`cta` | `surfaceome` | `mito` | `housekeeping` | `therapy:<type>` | `lineage:<code>` | a CSV of symbols/ENSG ids), per-sample parquet access (linear TPM, not the 5.8 GB TSV), `greedy_coverage`, `patient_coverage` (long counts), and `render()` → counts CSV + stacked bar + coverage small-multiples.
- **`pirlygenes/cohorts.py`**: code→parquet-stem registry for `treehouse-polya-25-01`, hoisted from `scripts/sweep_treehouse_*`.
- **`pirlygenes/cli.py`**: real `plot` subparser with a `patient-coverage` action + dispatch (replaces the NotImplemented stub).

## Tests
`tests/test_cancer_tmb.py` + `tests/test_coverage.py` (synthetic per-sample parquet + monkeypatched cache — no clinical data); updated the one CLI test that asserted the old stub. Full suite green (368 passed).