### PR TITLE
Fusion reference table + sarcoma-lineage membership (Phase C foundation)

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -601,10 +601,8 @@ def _cta_vs_tmb(mat, cohorts, ensg_to_sym, threshold):
     SWEET_TMB, SWEET_COV = 3.0, 50.0
     ax.fill_between([x_lo, SWEET_TMB], SWEET_COV, 100, color="#ffd166",
                     alpha=0.18, zorder=0)
-    ax.text(x_lo * 1.08, 98.5,
-            "antigen-rich / mutation-poor\n(CTA-therapy sweet spot:\n"
-            "≥50% coverage, ≤3 mut/Mb)",
-            fontsize=7, va="top", ha="left", color="#9c6f00", style="italic")
+    ax.text(x_lo * 1.08, 98.5, "antigen-rich / mutation-poor",
+            fontsize=8, va="top", ha="left", color="#9c6f00", style="italic")
 
     ax.scatter(xs, ys, s=34, c=[_LINEAGE_COLORS[g] for g in groups],
                alpha=0.9, edgecolor="white", linewidth=0.4, zorder=3)

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -53,6 +53,17 @@ GLIOMA_MAP = CACHE / "derived" / "tcga_glioma_case_to_project.csv"
 OUT = Path(__file__).resolve().parent / "outputs"
 THRESHOLDS = [25, 50, 100, 200]
 
+# Honest display labels for cohorts whose registry code is misleading about the
+# actual sample composition. The bare "SARC" cohort here is the TCGA
+# "leiomyosarcoma" slice (n=100, ~90% leiomyosarcoma by GDC histology), NOT the
+# multi-histology TCGA-SARC umbrella its code implies — so label it as such
+# until the sarcoma taxonomy rebuild makes this canonical in the registry.
+_DISPLAY_CODE = {"SARC": "TCGA-LMS"}
+
+
+def _display_code(code: str) -> str:
+    return _DISPLAY_CODE.get(code, code)
+
 
 def _glioma_split_cohorts() -> list[TreehouseCohort]:
     """GBM/LGG cohorts from the cached TCGA glioma case->project map."""
@@ -256,14 +267,20 @@ def main():
     counts = counts.sort_values(["cancer_code", "n_gt25"], ascending=[True, False])
     counts.to_csv(OUT / "cta_patient_counts.csv", index=False)
 
-    print("[5/6] plots", flush=True)
+    print("[5/9] plots", flush=True)
     _plots(mat, cohorts, counts, ensg_to_sym, args.threshold, args.cohort)
 
-    print("[6/7] per-cohort coverage curves (one PNG each)", flush=True)
+    print("[6/9] per-cohort coverage curves (one PNG each)", flush=True)
     _coverage_every_cohort(mat, cohorts, ensg_to_sym, args.threshold)
 
-    print("[7/7] peak-coverage bar charts (parent/child + top-CTA colored)", flush=True)
+    print("[7/9] peak-coverage bar charts (parent/child + top-CTA colored)", flush=True)
     _peak_coverage_bars(mat, cohorts, ensg_to_sym, args.threshold)
+
+    print("[8/9] stacked coverage bar (per-CTA marginal contribution)", flush=True)
+    _stacked_coverage_bars(mat, cohorts, ensg_to_sym, args.threshold)
+
+    print("[9/9] CTA coverage vs cohort TMB", flush=True)
+    _cta_vs_tmb(mat, cohorts, ensg_to_sym, args.threshold)
     print(f"done -> {OUT}", flush=True)
 
 
@@ -296,6 +313,40 @@ def _shade(rgb, k):
     r, g, b = rgb[:3]
     h, l, s = colorsys.rgb_to_hls(r, g, b)
     return colorsys.hls_to_rgb(h, min(1.0, max(0.0, l + k)), s)
+
+
+# Distinct base hues, one per antigen family; members shaded within the hue.
+_FAMILY_PALETTE = [
+    "#e6194B", "#3cb44b", "#4363d8", "#f58231", "#911eb4", "#42d4f4",
+    "#f032e6", "#bfef45", "#469990", "#9A6324", "#800000", "#808000",
+    "#000075", "#e6beff", "#aaffc3", "#ffd8b1", "#a9a9a9", "#fabed4",
+]
+
+
+def _family_color_map(ctas_ordered):
+    """Map an ordered list of CTA symbols to colors: one base hue per antigen
+    family (ordered by first appearance), members shaded within the family hue.
+
+    Returns (cta_color, fam_order, fam_base, members) so callers can both color
+    bars and build a family-grouped legend."""
+    import matplotlib.colors as mcolors
+
+    ctas = list(dict.fromkeys(ctas_ordered))
+    fam_of = {c: _cta_family(c) for c in ctas}
+    fam_order = list(dict.fromkeys(fam_of[c] for c in ctas))
+    fam_base = {f: _FAMILY_PALETTE[i % len(_FAMILY_PALETTE)]
+                for i, f in enumerate(fam_order)}
+    members = {}
+    for c in ctas:
+        members.setdefault(fam_of[c], []).append(c)
+    cta_color = {}
+    for f, ms in members.items():
+        base = mcolors.to_rgb(fam_base[f])
+        ks = ([0.0] if len(ms) == 1
+              else [(-0.18 + 0.36 * j / (len(ms) - 1)) for j in range(len(ms))])
+        for c, k in zip(ms, ks):
+            cta_color[c] = _shade(base, k)
+    return cta_color, fam_order, fam_base, members
 
 
 def _parent_map():
@@ -333,7 +384,7 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
             "is_derived": code in parent_of, "top_cta": top_cta,
         })
     df = pd.DataFrame(rows).sort_values("peak", ascending=True)  # ascending -> top at top after barh
-    labels = [f"{c}  (n={n})" for c, n in zip(df["code"], df["n"])]
+    labels = [f"{_display_code(c)}  (n={n})" for c, n in zip(df["code"], df["n"])]
     h = max(6, len(df) * 0.26)
 
     # ---- (a) parent vs derived ----
@@ -359,28 +410,10 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
     plt.close(fig)
 
     # ---- (b) colored by top CTA, grouped by antigen family ----
-    # distinct base hue per family; members shaded within the family hue.
-    distinct = [
-        "#e6194B", "#3cb44b", "#4363d8", "#f58231", "#911eb4", "#42d4f4",
-        "#f032e6", "#bfef45", "#469990", "#9A6324", "#800000", "#808000",
-        "#000075", "#e6beff", "#aaffc3", "#ffd8b1", "#a9a9a9", "#fabed4",
-    ]
-    ctas = list(dict.fromkeys(df.sort_values("peak", ascending=False)["top_cta"]))
-    fam_of = {c: _cta_family(c) for c in ctas}
-    # families ordered by first (highest-coverage) appearance
-    fam_order = list(dict.fromkeys(fam_of[c] for c in ctas))
-    fam_base = {f: distinct[i % len(distinct)] for i, f in enumerate(fam_order)}
-    members = {}
-    for c in ctas:
-        members.setdefault(fam_of[c], []).append(c)
-    import matplotlib.colors as mcolors
-    cta_color = {}
-    for f, ms in members.items():
-        base = mcolors.to_rgb(fam_base[f])
-        ks = ([0.0] if len(ms) == 1
-              else [(-0.18 + 0.36 * j / (len(ms) - 1)) for j in range(len(ms))])
-        for c, k in zip(ms, ks):
-            cta_color[c] = _shade(base, k)
+    # distinct base hue per family; members shaded within the family hue,
+    # ordered by first (highest-coverage) appearance.
+    cta_color, fam_order, fam_base, members = _family_color_map(
+        df.sort_values("peak", ascending=False)["top_cta"])
 
     fig, ax = plt.subplots(figsize=(12, h))
     ax.barh(range(len(df)), df["peak"], color=[cta_color[c] for c in df["top_cta"]])
@@ -409,6 +442,213 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
           "-> 2 bar charts", flush=True)
 
 
+def _stacked_coverage_bars(mat, cohorts, ensg_to_sym, threshold,
+                           max_label_segments=8, min_label_pct=3.0):
+    """Horizontal STACKED bar per cohort: the greedy plateau split into each
+    CTA's marginal NEW-patient contribution. Because the contributions are
+    co-occurrence-aware (a patient already covered by an earlier CTA isn't
+    re-counted), the segments sum to the plateau and the bar never exceeds
+    100%. Segments are colored by antigen family (consistent across cohorts);
+    the widest segments are labelled with the CTA symbol in small font.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Patch
+
+    # Per cohort: ordered (cta_symbol, marginal_pct) contributions.
+    rows = []
+    for code in cohorts:
+        order, cum, n = greedy_coverage(mat, cohorts[code], threshold)
+        if not cum:
+            continue
+        segs, prev = [], 0.0
+        for i, idx in enumerate(order):
+            sym = ensg_to_sym.get(mat.index[idx], mat.index[idx])
+            marg = (cum[i] - prev) * 100
+            prev = cum[i]
+            if marg > 0:
+                segs.append((sym, marg))
+        rows.append({"code": code, "n": n, "peak": cum[-1] * 100, "segs": segs})
+    rows.sort(key=lambda r: r["peak"])  # ascending -> broadest at top after barh
+
+    # Global CTA color map: order CTAs by total marginal contribution so the
+    # most prominent antigens get the most distinct family hues.
+    from collections import Counter
+    tot = Counter()
+    for r in rows:
+        for sym, marg in r["segs"]:
+            tot[sym] += marg
+    cta_color, fam_order, fam_base, _members = _family_color_map(
+        [c for c, _ in tot.most_common()])
+
+    labels = [f"{_display_code(r['code'])}  (n={r['n']})" for r in rows]
+    hgt = max(6, len(rows) * 0.28)
+    fig, ax = plt.subplots(figsize=(13, hgt))
+    for y, r in enumerate(rows):
+        left = 0.0
+        for j, (sym, marg) in enumerate(r["segs"]):
+            ax.barh(y, marg, left=left, color=cta_color.get(sym, "#cccccc"),
+                    edgecolor="white", linewidth=0.3)
+            # label the widest leading segments; always try the dominant one
+            if (marg >= min_label_pct and j < max_label_segments) or j == 0:
+                if marg >= 1.5:
+                    ax.text(left + marg / 2, y, sym, va="center", ha="center",
+                            fontsize=4.5, clip_on=True)
+            left += marg
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels(labels, fontsize=7)
+    ax.set_xlabel(f"% of patients with ≥1 CTA > {threshold} TPM "
+                  "(stacked by each CTA's marginal new-patient share, greedy order)")
+    ax.set_xlim(0, 100)
+    ax.grid(axis="x", alpha=0.3)
+    handles = [Patch(color=fam_base[f], label=f) for f in fam_order]
+    ax.legend(handles=handles, loc="lower right", fontsize=6,
+              title="antigen family", ncol=2, handlelength=1.1,
+              labelspacing=0.25, columnspacing=1.0)
+    ax.set_title(f"CTA coverage by cancer type, split into each CTA's marginal "
+                 f"new-patient contribution (> {threshold} TPM, "
+                 f"Treehouse 25.01 PolyA)", fontsize=11)
+    fig.tight_layout()
+    fig.savefig(OUT / f"cta_stacked_coverage_t{threshold}.png", dpi=150)
+    plt.close(fig)
+    print(f"      {len(rows)} cohorts -> stacked coverage bar", flush=True)
+
+
+# Cohorts whose registry code is the wrong TMB key for their actual samples.
+# The bare "SARC" cohort is the TCGA leiomyosarcoma slice, so look up SARC_LMS.
+_TMB_CODE = {"SARC": "SARC_LMS"}
+
+# Coarse tissue-lineage groups for coloring the CTA-vs-TMB scatter, collapsed
+# from the registry `family` column so the legend stays readable.
+_LINEAGE_COLORS = {
+    "sarcoma": "#e85d04", "pediatric": "#d00000", "carcinoma": "#1d4e89",
+    "melanoma": "#6a040f", "neuroendocrine": "#2a9d8f", "heme": "#9d4edd",
+    "CNS": "#3a86ff", "germ cell": "#ffb703", "endocrine": "#588157",
+    "other": "#9a9a9a",
+}
+
+
+def _registry_family_map():
+    from pirlygenes.load_dataset import get_data
+    df = get_data("cancer-type-registry")
+    return {str(r.code): str(r.family) for r in df.itertuples()}
+
+
+def _lineage_group(family: str) -> str:
+    f = (family or "").lower()
+    if f.startswith("pediatric"):
+        return "pediatric"
+    if f == "sarcoma":
+        return "sarcoma"
+    if f == "melanoma":
+        return "melanoma"
+    if f == "net" or "neuroendocrine" in f:
+        return "neuroendocrine"
+    if f.startswith("heme"):
+        return "heme"
+    if f == "cns":
+        return "CNS"
+    if f == "germ-cell":
+        return "germ cell"
+    if f == "endocrine":
+        return "endocrine"
+    if f.startswith("carcinoma"):
+        return "carcinoma"
+    return "other"
+
+
+def _cta_vs_tmb(mat, cohorts, ensg_to_sym, threshold):
+    """Scatter: each cancer type's CTA coverage plateau (% of patients with ≥1
+    CTA over threshold) vs its published median TMB (mut/Mb, log x). Tumors with
+    high CTA coverage but low TMB are the interesting quadrant for CTA-directed
+    therapy (antigen present without relying on a high neoantigen load). Cohorts
+    with no curated TMB value are dropped and counted in the caption."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    tmb_map = gsc.cancer_tmb()  # {code: median_tmb}, codes w/o a value omitted
+    pts, missing = [], []
+    for code in cohorts:
+        order, cum, n = greedy_coverage(mat, cohorts[code], threshold)
+        if not cum:
+            continue
+        tmb = tmb_map.get(_TMB_CODE.get(code, code))
+        if tmb is None:
+            missing.append(code)
+            continue
+        pts.append((code, n, cum[-1] * 100, tmb))
+    if not pts:
+        print("      no cohorts with both coverage and TMB; skip", flush=True)
+        return
+
+    xs = [p[3] for p in pts]
+    ys = [p[2] for p in pts]
+    fam_map = _registry_family_map()
+    groups = [_lineage_group(fam_map.get(code, "")) for code, *_ in pts]
+
+    from matplotlib.lines import Line2D
+    fig, ax = plt.subplots(figsize=(12, 7.5))
+    ax.set_xscale("log")
+    x_lo, x_hi = min(xs) * 0.7, max(xs) * 1.5
+    ax.set_xlim(x_lo, x_hi)
+    ax.set_ylim(0, 100)
+
+    # Shade the "antigen-rich / mutation-poor" sweet spot: high CTA coverage
+    # (>=50%) at low TMB (<=3 mut/Mb), where CTA-directed therapy is attractive
+    # precisely because the low neoantigen load makes checkpoint blockade weak.
+    SWEET_TMB, SWEET_COV = 3.0, 50.0
+    ax.fill_between([x_lo, SWEET_TMB], SWEET_COV, 100, color="#ffd166",
+                    alpha=0.18, zorder=0)
+    ax.text(x_lo * 1.08, 98.5,
+            "antigen-rich / mutation-poor\n(CTA-therapy sweet spot:\n"
+            "≥50% coverage, ≤3 mut/Mb)",
+            fontsize=7, va="top", ha="left", color="#9c6f00", style="italic")
+
+    ax.scatter(xs, ys, s=34, c=[_LINEAGE_COLORS[g] for g in groups],
+               alpha=0.9, edgecolor="white", linewidth=0.4, zorder=3)
+    ax.set_xlabel("median tumor mutational burden (mut/Mb, log scale)")
+    ax.set_ylabel(f"% of patients with ≥1 CTA > {threshold} TPM "
+                  "(coverage plateau)")
+    ax.grid(alpha=0.3, which="both")
+
+    # Repel labels so they don't overlap (thin leader lines back to points).
+    texts = [ax.text(tmb, cov, _display_code(code), fontsize=6)
+             for code, n, cov, tmb in pts]
+    try:
+        from adjustText import adjust_text
+        adjust_text(texts, x=list(xs), y=list(ys), ax=ax,
+                    arrowprops=dict(arrowstyle="-", color="0.6", lw=0.4))
+    except ImportError:  # fallback: small fixed offset (may overlap)
+        for t, (code, n, cov, tmb) in zip(texts, pts):
+            t.set_fontsize(5)
+            t.set_position((tmb * 1.02, cov + 0.6))
+
+    # Lineage legend (only groups present), placed outside the axes.
+    present = [g for g in _LINEAGE_COLORS if g in set(groups)]
+    handles = [Line2D([0], [0], marker="o", linestyle="", markersize=6,
+                      markerfacecolor=_LINEAGE_COLORS[g], markeredgecolor="white",
+                      label=g) for g in present]
+    ax.legend(handles=handles, loc="center left", bbox_to_anchor=(1.01, 0.5),
+              fontsize=7, title="lineage", frameon=False)
+
+    sub = ""
+    if len(pts) >= 3:
+        r = np.corrcoef(np.log10(xs), ys)[0, 1]
+        sub = f"; Pearson r(log TMB, coverage)={r:.2f}"
+    ax.set_title(f"CTA coverage vs TMB by cancer type "
+                 f"(> {threshold} TPM, n={len(pts)} cohorts{sub})", fontsize=10)
+    ax.text(0.99, 0.01,
+            f"{len(missing)} cohort(s) dropped (no curated TMB)",
+            transform=ax.transAxes, fontsize=6, color="gray", ha="right")
+    fig.tight_layout()
+    fig.savefig(OUT / f"cta_coverage_vs_tmb_t{threshold}.png", dpi=150)
+    plt.close(fig)
+    print(f"      {len(pts)} cohorts plotted, {len(missing)} dropped (no TMB)",
+          flush=True)
+
+
 def _coverage_every_cohort(mat, cohorts, ensg_to_sym, threshold):
     """One annotated greedy co-occurrence-aware coverage PNG per cancer type,
     into outputs/cta_coverage/, plus a small-multiples overview sorted by how
@@ -434,9 +674,10 @@ def _coverage_every_cohort(mat, cohorts, ensg_to_sym, threshold):
             ax.annotate(nm, (x, c * 100), fontsize=6, rotation=45,
                         textcoords="offset points", xytext=(2, 4))
         ax.set_xlabel("# CTAs added (greedy, co-occurrence-aware)")
-        ax.set_ylabel(f"% of {code} patients with ≥1 CTA > {threshold} TPM")
-        ax.set_title(f"{code}: cumulative distinct-patient coverage "
-                     f"(> {threshold} TPM, n={n}); plateau "
+        ax.set_ylabel(f"% of {_display_code(code)} patients with ≥1 CTA "
+                      f"> {threshold} TPM")
+        ax.set_title(f"{_display_code(code)}: cumulative distinct-patient "
+                     f"coverage (> {threshold} TPM, n={n}); plateau "
                      f"{cum[-1]*100:.0f}%", fontsize=10)
         ax.set_xlim(0, min(30, len(cum) + 1))
         ax.set_ylim(0, 100)
@@ -452,12 +693,16 @@ def _coverage_every_cohort(mat, cohorts, ensg_to_sym, threshold):
     fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 2.5, nrow * 1.9),
                              sharex=True, sharey=True)
     axes = axes.ravel()
-    for ax, (code, n, cum, _names) in zip(axes, summary):
-        ax.plot(range(1, len(cum) + 1), [c * 100 for c in cum],
-                color="#b5179e", lw=1.2)
-        ax.fill_between(range(1, len(cum) + 1), [c * 100 for c in cum],
-                        alpha=0.15, color="#b5179e")
-        ax.set_title(f"{code} (n={n}) {cum[-1]*100:.0f}%", fontsize=7)
+    for ax, (code, n, cum, names) in zip(axes, summary):
+        xs = range(1, len(cum) + 1)
+        ax.plot(xs, [c * 100 for c in cum], color="#b5179e", lw=1.2)
+        ax.fill_between(xs, [c * 100 for c in cum], alpha=0.15, color="#b5179e")
+        # name the first few CTAs so each panel is readable on its own
+        for x, (nm, c) in enumerate(zip(names[:3], cum[:3]), start=1):
+            ax.annotate(nm, (x, c * 100), fontsize=4, rotation=45,
+                        textcoords="offset points", xytext=(1, 2))
+        ax.set_title(f"{_display_code(code)} (n={n}) {cum[-1]*100:.0f}%",
+                     fontsize=7)
         ax.set_xlim(0, 25)
         ax.set_ylim(0, 100)
         ax.tick_params(labelsize=5)
@@ -494,7 +739,8 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
                                     max(8, len(top_ctas) * 0.26)))
     im = ax.imshow(piv.to_numpy(), aspect="auto", cmap="magma")
     ax.set_xticks(range(len(piv.columns)))
-    ax.set_xticklabels(piv.columns, rotation=90, fontsize=6)
+    ax.set_xticklabels([_display_code(c) for c in piv.columns],
+                       rotation=90, fontsize=6)
     ax.set_yticks(range(len(piv.index)))
     ax.set_yticklabels(piv.index, fontsize=6)
     ax.set_title(f"# patients with CTA > {threshold} TPM "
@@ -511,7 +757,8 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
                                     max(8, len(top_ctas) * 0.26)))
     im = ax.imshow(pivp.to_numpy(), aspect="auto", cmap="viridis")
     ax.set_xticks(range(len(pivp.columns)))
-    ax.set_xticklabels(pivp.columns, rotation=90, fontsize=6)
+    ax.set_xticklabels([_display_code(c) for c in pivp.columns],
+                       rotation=90, fontsize=6)
     ax.set_yticks(range(len(pivp.index)))
     ax.set_yticklabels(pivp.index, fontsize=6)
     ax.set_title(f"% of cohort with CTA > {threshold} TPM "
@@ -528,9 +775,9 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
         fig, ax = plt.subplots(figsize=(10, max(4, len(fc) * 0.28)))
         ax.barh(fc["Symbol"], fc[pcol], color="#b5179e")
         ax.invert_yaxis()
-        ax.set_xlabel(f"% of {focus} patients > {threshold} TPM")
+        ax.set_xlabel(f"% of {_display_code(focus)} patients > {threshold} TPM")
         n = int(fc["n_samples"].iloc[0])
-        ax.set_title(f"{focus}: CTA expression breadth "
+        ax.set_title(f"{_display_code(focus)}: CTA expression breadth "
                      f"(> {threshold} TPM, n={n})", fontsize=10)
         for y, (p, k) in enumerate(zip(fc[pcol], fc[tcol])):
             ax.text(p, y, f" {k}", va="center", fontsize=6)
@@ -538,22 +785,27 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
         fig.savefig(OUT / f"cta_pct_bar_{focus}_t{threshold}.png", dpi=150)
         plt.close(fig)
 
-    # ---- (4) co-occurrence-aware coverage curves ----
-    fig, ax = plt.subplots(figsize=(8, 5.5))
-    for code in [focus, "SKCM", "LUAD", "BRCA", "OS"]:
-        if code not in cohorts:
-            continue
+    # ---- (4) co-occurrence-aware coverage curves (top cohorts by plateau) ----
+    curves = []
+    for code in cohorts:
         order, cum, n = greedy_coverage(mat, cohorts[code], threshold)
-        if not cum:
-            continue
+        if cum:
+            curves.append((code, n, cum))
+    curves.sort(key=lambda t: t[2][-1], reverse=True)
+    keep = curves[:12]
+    if focus in {c for c, _, _ in curves} and focus not in {c for c, _, _ in keep}:
+        keep += [t for t in curves if t[0] == focus]
+    fig, ax = plt.subplots(figsize=(9, 6))
+    for code, n, cum in keep:
         ax.plot(range(1, len(cum) + 1), [c * 100 for c in cum],
-                marker="o", ms=2, lw=1, label=f"{code} (n={n})")
+                marker="o", ms=2, lw=1, label=f"{_display_code(code)} (n={n})")
     ax.set_xlabel("# CTAs in panel (greedy, co-occurrence-aware)")
     ax.set_ylabel(f"% of patients with >=1 CTA > {threshold} TPM")
     ax.set_title(f"CTA panel coverage: distinct patients picked up "
-                 f"(> {threshold} TPM)", fontsize=10)
+                 f"(> {threshold} TPM; top {len(keep)} cohorts by plateau)",
+                 fontsize=10)
     ax.set_xlim(0, 30)
-    ax.legend(fontsize=8)
+    ax.legend(fontsize=7, ncol=2)
     ax.grid(alpha=0.3)
     fig.tight_layout()
     fig.savefig(OUT / f"cta_coverage_curves_t{threshold}.png", dpi=150)
@@ -570,9 +822,9 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
             ax.annotate(nm, (x, c * 100), fontsize=6, rotation=45,
                         textcoords="offset points", xytext=(2, 4))
         ax.set_xlabel("# CTAs added (greedy order)")
-        ax.set_ylabel(f"% of {focus} patients covered")
-        ax.set_title(f"{focus}: cumulative patient coverage as CTAs are added "
-                     f"(> {threshold} TPM, n={n})", fontsize=10)
+        ax.set_ylabel(f"% of {_display_code(focus)} patients covered")
+        ax.set_title(f"{_display_code(focus)}: cumulative patient coverage as "
+                     f"CTAs are added (> {threshold} TPM, n={n})", fontsize=10)
         ax.set_xlim(0, min(30, len(cum) + 1))
         ax.grid(alpha=0.3)
         fig.tight_layout()

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -303,7 +303,10 @@ def _cta_family(symbol: str) -> str:
         if s.startswith(p):
             return _FAMILY_LABEL.get(p, p)
     stem = re.sub(r"[0-9].*$", "", s)
-    return stem or s
+    # Guard against degenerate stems: symbols like C12orf42 / H2BC1 / ZC3H11B
+    # strip to "C"/"H"/"ZC", which are not real antigen families. Below a 3-char
+    # stem, treat the CTA as its own (singleton) family instead of a fake group.
+    return stem if len(stem) >= 3 else s
 
 
 def _shade(rgb, k):

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -180,6 +180,37 @@ def extract_cta_matrix(symbols: dict[str, str]) -> pd.DataFrame:
     return out
 
 
+# Extra per-sample cohorts pulled from other cached per-cohort parquets (linear
+# TPM) so coverage isn't confined to a single compendium. The set expands as
+# more sources gain materialized per-sample data (see issue #275).
+_EXTRA_PARQUET_COHORTS = [
+    ("treehouse-ribod-25-01", "CHOR"),
+    ("treehouse-ribod-25-01", "RB"),
+]
+
+
+def _add_parquet_cohorts(mat, cohorts, ctas):
+    """Merge extra per-sample cohorts (from cached per-cohort parquets) into the
+    CTA matrix + cohort buckets, aligned to the existing CTA index."""
+    cache = Path.home() / ".cache" / "pirlygenes" / "expression"
+    added = []
+    for source_id, code in _EXTRA_PARQUET_COHORTS:
+        p = cache / source_id / "derived" / f"{code}_per_sample_tpm.parquet"
+        if not p.exists():
+            continue
+        df = pd.read_parquet(p)
+        df = df[df["Ensembl_Gene_ID"].astype(str).isin(set(ctas))]
+        sample_cols = [c for c in df.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+        sub = df.set_index("Ensembl_Gene_ID")[sample_cols].reindex(mat.index).fillna(0.0)
+        sub.columns = [f"{code}::{c}" for c in sub.columns]  # avoid id collisions
+        mat = pd.concat([mat, sub], axis=1)
+        cohorts[code] = list(sub.columns)
+        added.append(f"{code}(n={len(sample_cols)})")
+    if added:
+        print(f"      + extra per-sample cohorts: {', '.join(added)}", flush=True)
+    return mat, cohorts
+
+
 def per_cohort_counts(mat, cohorts, ensg_to_sym):
     """Long table: CTA × cohort × threshold -> n patients, pct."""
     rows = []
@@ -260,7 +291,9 @@ def main():
 
     print("[3/5] extract CTA per-sample TPM matrix (awk slice + log2 inverse)", flush=True)
     mat = extract_cta_matrix(ensg_to_sym)
-    print(f"      matrix {mat.shape[0]} CTAs × {mat.shape[1]} samples", flush=True)
+    mat, cohorts = _add_parquet_cohorts(mat, cohorts, ctas)
+    print(f"      matrix {mat.shape[0]} CTAs × {mat.shape[1]} samples, "
+          f"{len(cohorts)} cohorts", flush=True)
 
     print("[4/5] per (CTA × cohort) threshold counts -> CSV", flush=True)
     counts = per_cohort_counts(mat, cohorts, ensg_to_sym)
@@ -403,7 +436,7 @@ def _peak_coverage_bars(mat, cohorts, ensg_to_sym, threshold):
         Patch(color="#e85d04", label="sub-divided (derived) cohort"),
     ], loc="lower right", fontsize=9)
     ax.set_title(f"CTA coverage ceiling by cancer type "
-                 f"(> {threshold} TPM, Treehouse 25.01 PolyA)", fontsize=11)
+                 f"(> {threshold} TPM)", fontsize=11)
     ax.grid(axis="x", alpha=0.3)
     fig.tight_layout()
     fig.savefig(OUT / f"cta_peak_coverage_by_parent_child_t{threshold}.png", dpi=150)
@@ -507,8 +540,9 @@ def _stacked_coverage_bars(mat, cohorts, ensg_to_sym, threshold,
               title="antigen family", ncol=2, handlelength=1.1,
               labelspacing=0.25, columnspacing=1.0)
     ax.set_title(f"CTA coverage by cancer type, split into each CTA's marginal "
-                 f"new-patient contribution (> {threshold} TPM, "
-                 f"Treehouse 25.01 PolyA)", fontsize=11)
+                 f"new-patient contribution (> {threshold} TPM)", fontsize=11)
+    fig.text(0.99, 0.005, f"{len(rows)} per-sample cohorts (others summary-only)",
+             ha="right", fontsize=6, color="gray")
     fig.tight_layout()
     fig.savefig(OUT / f"cta_stacked_coverage_t{threshold}.png", dpi=150)
     plt.close(fig)
@@ -520,9 +554,10 @@ def _stacked_coverage_bars(mat, cohorts, ensg_to_sym, threshold,
 _TMB_CODE = {"SARC": "SARC_LMS"}
 
 # Coarse tissue-lineage groups for coloring the CTA-vs-TMB scatter, collapsed
-# from the registry `family` column so the legend stays readable.
+# from the registry `family` column (lineage-only after the Phase-C refactor;
+# age is a separate `pediatric` flag, so pediatric sarcomas color as sarcoma).
 _LINEAGE_COLORS = {
-    "sarcoma": "#e85d04", "pediatric": "#d00000", "carcinoma": "#1d4e89",
+    "sarcoma": "#e85d04", "embryonal": "#d00000", "carcinoma": "#1d4e89",
     "melanoma": "#6a040f", "neuroendocrine": "#2a9d8f", "heme": "#9d4edd",
     "CNS": "#3a86ff", "germ cell": "#ffb703", "endocrine": "#588157",
     "other": "#9a9a9a",
@@ -537,13 +572,13 @@ def _registry_family_map():
 
 def _lineage_group(family: str) -> str:
     f = (family or "").lower()
-    if f.startswith("pediatric"):
-        return "pediatric"
     if f == "sarcoma":
         return "sarcoma"
+    if f == "embryonal":
+        return "embryonal"
     if f == "melanoma":
         return "melanoma"
-    if f == "net" or "neuroendocrine" in f:
+    if "neuroendocrine" in f:
         return "neuroendocrine"
     if f.startswith("heme"):
         return "heme"
@@ -553,7 +588,7 @@ def _lineage_group(family: str) -> str:
         return "germ cell"
     if f == "endocrine":
         return "endocrine"
-    if f.startswith("carcinoma"):
+    if f.startswith("carcinoma"):  # incl carcinoma-other
         return "carcinoma"
     return "other"
 
@@ -637,8 +672,10 @@ def _cta_vs_tmb(mat, cohorts, ensg_to_sym, threshold):
         sub = f"; Pearson r(log TMB, coverage)={r:.2f}"
     ax.set_title(f"CTA coverage vs TMB by cancer type "
                  f"(> {threshold} TPM, n={len(pts)} cohorts{sub})", fontsize=10)
+    n_registry = len(_registry_family_map())
     ax.text(0.99, 0.01,
-            f"{len(missing)} cohort(s) dropped (no curated TMB)",
+            f"{len(pts)} per-sample cohorts shown (of {n_registry} registry "
+            f"types; others summary-only); {len(missing)} dropped (no curated TMB)",
             transform=ax.transAxes, fontsize=6, color="gray", ha="right")
     fig.tight_layout()
     fig.savefig(OUT / f"cta_coverage_vs_tmb_t{threshold}.png", dpi=150)
@@ -742,7 +779,7 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
     ax.set_yticks(range(len(piv.index)))
     ax.set_yticklabels(piv.index, fontsize=6)
     ax.set_title(f"# patients with CTA > {threshold} TPM "
-                 f"(top 40 CTAs × cohorts, Treehouse 25.01 PolyA)", fontsize=9)
+                 f"(top 40 CTAs × cohorts)", fontsize=9)
     fig.colorbar(im, ax=ax, shrink=0.5, label="patients")
     fig.tight_layout()
     fig.savefig(OUT / f"cta_patient_count_heatmap_t{threshold}.png", dpi=150)

--- a/docs/cancer-type-ontology-audit.md
+++ b/docs/cancer-type-ontology-audit.md
@@ -1,0 +1,113 @@
+# Cancer-type registry ontology audit (Phase C)
+
+Audit of `pirlygenes/data/cancer-type-registry.csv` (130 codes) against the
+**WHO Classification of Tumours, 5th edition** series, and the resulting
+restructure plan. Grounded in the WHO volumes (cited by volume; no fabricated
+page-level citations):
+
+- Soft Tissue and Bone Tumours (5th ed., 2020)
+- Central Nervous System Tumours (5th ed., 2021)
+- Thoracic Tumours (5th ed., 2021)
+- Endocrine and Neuroendocrine Tumours (5th ed., 2022)
+- Haematolymphoid Tumours (5th ed., 2022)
+- Digestive System (2019), Urinary & Male Genital (2022), Female Genital (2020),
+  Breast (2019), Head & Neck (2022), Skin (2023), **Paediatric Tumours (2023)**
+
+## Core finding — `family` conflates two orthogonal axes
+
+The single `family` column mixes **developmental age** (`pediatric-*`) with
+**tissue/lineage**. WHO classifies by **lineage/organ-system, age-independent**;
+the dedicated *Paediatric Tumours* volume cross-cuts the lineage volumes rather
+than replacing them. The conflation actively fragments real lineages:
+
+- **Sarcomas split across 3 families by age:** `sarcoma` (35) vs `pediatric-bone`
+  (OS, EWS) vs `pediatric-soft` (RMS_ERMS/ARMS/SSRMS) — even though `RMS_PRMS`,
+  `CHON`, `GCTB` already sit in `sarcoma`. WHO *Soft Tissue and Bone Tumours*
+  places osteosarcoma, Ewing, all rhabdomyosarcomas, chondrosarcoma, GCTB in one
+  lineage regardless of patient age. This is why the CTA-vs-TMB plot colored
+  OS/EWS/RMS as "pediatric" instead of "sarcoma," fragmenting the cluster.
+- **Neuroendocrine scattered:** `net` (11, and it mixes well-diff NET with
+  poorly-diff NEC), while PCPG/MTC sit in `endocrine` and NBL in `pediatric-net`.
+  WHO *Endocrine & Neuroendocrine Tumours* treats NENs as a cross-organ family
+  and explicitly separates **NET (well-differentiated, G1–G3)** from **NEC
+  (poorly-differentiated, small-/large-cell)**.
+
+## Resolution — `family` = lineage only; add an orthogonal `pediatric` flag
+
+### Family reassignments
+| Codes | From | To | WHO basis |
+|---|---|---|---|
+| OS, EWS, RMS_ERMS/ARMS/SSRMS (→`SARC_*`) | pediatric-bone, pediatric-soft | **sarcoma** | Soft Tissue & Bone 2020 |
+| ATRT, MBL(+WNT/SHH/G3/G4) | pediatric-cns | **cns** | CNS 2021 (embryonal CNS tumours) |
+| NBL(+MYCN subtypes) | pediatric-net | **neuroendocrine** | Endocrine & NE 2022 (peripheral neuroblastic, neural-crest) |
+| WILMS, HEPB, RB, RT | pediatric-embryonal/eye/liver | **embryonal** | Paediatric 2023 (nephroblastoma, hepatoblastoma, retinoblastoma, rhabdoid = embryonal/blastemal) |
+| (rename) `net` family | net | **neuroendocrine** | Endocrine & NE 2022 |
+
+Retire the `pediatric-bone`, `pediatric-soft`, `pediatric-cns`,
+`pediatric-embryonal`, `pediatric-eye`, `pediatric-liver`, `pediatric-net`
+families. Add a boolean **`pediatric`** column set on the codes that were under
+them (OS/EWS/RMS, ATRT/MBL, WILMS/HEPB/RB/RT, NBL) — age as a flag, not a family.
+
+Note (judgment call): `embryonal` is treated as a *lineage* descriptor
+(blastemal/embryonal neoplasms), not an age bucket; ATRT (intracranial rhabdoid)
+goes to `cns`, RT (extracranial rhabdoid) to `embryonal`. PCPG/MTC stay in
+`endocrine` (neural-crest endocrine) and additionally carry a neuroendocrine tag.
+
+### Code renames (one-separator + family conventions; every old code keeps a backward-compat alias in CANCER_TYPE_ALIASES so trufflepig/external callers don't break)
+
+**Sarcoma — `SARC_` prefix everywhere:**
+OS→SARC_OS, EWS→SARC_EWS, CHON→SARC_CHON, CHOR→SARC_CHOR, GCTB→SARC_GCTB,
+RMS_ERMS→SARC_RMS_ERMS, RMS_ARMS→SARC_RMS_ARMS, RMS_PRMS→SARC_RMS_PRMS,
+RMS_SSRMS→SARC_RMS_SSRMS, ESS_LG→SARC_ESS_LG, ESS_HG→SARC_ESS_HG,
+SARC_LPS_UNSPEC→SARC_LPSunspec.
+
+**Neuroendocrine — keep famous codes (`SCLC`, `PANNET`), `NET_`/`NEC_` for the rest:**
+MID_NET→NET_MIDGUT, REC_NET→NET_RECTAL, LUNG_NET_LC→NET_LUNG,
+LUNG_NET_LCNEC→NEC_LUNG_LC, MEC→NEC_MERKEL. (`NET_`/`NEC_` prefix encodes the
+well-diff vs poorly-diff distinction; `SCLC` is NEC, `PANNET` is NET — recorded
+via family + a `differentiation` note rather than renaming the famous codes.)
+
+**One-separator normalization (collapse a split single concept token):**
+HNSC_HPV_pos→HNSC_HPVpos, HNSC_HPV_neg→HNSC_HPVneg,
+NBL_MYCN_amp→NBL_MYCNamp, NBL_MYCN_nonamp→NBL_MYCNnonamp,
+LAML_ELN_Fav→LAML_ELNFav, LAML_ELN_Int→LAML_ELNInt, LAML_ELN_Adv→LAML_ELNAdv.
+(Genuine hierarchy levels like `SARC_RMS_ERMS` keep their separators.)
+
+### `rare` is another non-lineage bucket (dissolve it)
+Like `pediatric-*` grouped by age, `family=rare` groups by *frequency*: it holds
+`NUTM` (a carcinoma) and `CHOR` (a notochordal/axial bone tumour) — no shared
+lineage. Resolution:
+- `CHOR` → **sarcoma** (`SARC_CHOR`); WHO Soft Tissue & Bone classifies chordoma
+  among notochordal tumours. (Already in `sarcoma_lineage_codes`.)
+- `NUTM` → **carcinoma**; WHO files NUT carcinoma in Thoracic + Head & Neck as a
+  midline poorly-differentiated carcinoma. No organ-specific carcinoma family
+  fits, so place it in a new `carcinoma-other` (organ-less / undifferentiated
+  carcinomas) lineage family. Retire `rare`.
+
+Note: `UCS` (uterine carcinosarcoma) is a metaplastic **carcinoma** (stays
+`carcinoma-gu`) — the only category it shares with NUT carcinoma is "carcinoma"
+(both poorly-differentiated, lineage-obscured); they are not co-located because
+they have no shared organ/lineage.
+
+## Minor / accepted as-is
+- `UCS` (carcinosarcoma) in `carcinoma-gu` — WHO views it as metaplastic
+  carcinoma (epithelial); acceptable.
+- `MESO` `carcinoma-mesothelial` — mesothelioma is its own WHO mesothelial
+  category; label slightly imprecise but clear. (Could rename family `mesothelial`.)
+- `carcinoma-gu` lumps urinary + male + female genital (WHO separates) —
+  acceptable coarsening for now.
+
+## Execution status / sequencing
+1. This audit doc (the spec). ✅
+2. Registry restructure: code renames + family reassignments + `pediatric` flag +
+   backward-compat aliases + `differentiation` note for NET/NEC. Propagate renamed
+   codes across the curated CSVs (cancer-type-genes, drivers, key-genes, lineage,
+   surfaceome, therapy, tmb, fusions), `cohorts.py`, and tests.
+3. Sarcoma data rebuild: TCGA-SARC histology atoms + computed `SARC`/`TCGA_SARC`/
+   `SARC_<hist>` aggregates (build-time pooling of per-sample atoms).
+4. Plot fix: lineage coloring uses the corrected `family` (pediatric sarcomas now
+   color as sarcoma); regenerate CTA coverage bars + CTA-vs-TMB.
+5. DATA_VERSION bump + tarball; deploy on merge. trufflepig = separate coordinated PR.
+
+See also the curation issues filed upstream where tsarina owns the data
+(tsarina #77 aliases, #78 expression threshold, #79 missing CT genes).

--- a/pirlygenes/cli.py
+++ b/pirlygenes/cli.py
@@ -278,10 +278,54 @@ def _build_parser() -> argparse.ArgumentParser:
 
     plot_parser = subparsers.add_parser(
         "plot",
-        help="Cohort-level plots (NotImplemented; see plan milestone 7).",
+        help="Cohort-level plots over the reference data.",
+        description=(
+            "Cohort-level plots over the packaged reference data.\n\n"
+            "actions:\n"
+            "  patient-coverage   per-cohort patient coverage of a gene set\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    plot_parser.add_argument(
-        "target", help="What to plot (e.g. a gene symbol or panel name)."
+    plot_sub = plot_parser.add_subparsers(
+        dest="plot_action", metavar="<action>", title="actions",
+    )
+    pc = plot_sub.add_parser(
+        "patient-coverage",
+        help="Per-cohort patient coverage of a gene set (counts CSV + plots).",
+        description=(
+            "For each cancer cohort with cached per-sample data, count how many\n"
+            "patients express each gene of a panel above TPM thresholds, and\n"
+            "compute greedy co-occurrence-aware coverage. Writes a counts CSV +\n"
+            "a stacked coverage bar + a coverage-curve small-multiples."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  pirlygenes plot patient-coverage --gene-set cta\n"
+            "  pirlygenes plot patient-coverage --gene-set lineage:PRAD --cohort PRAD\n"
+            "  pirlygenes plot patient-coverage --gene-set ./my_symbols.csv\n"
+        ),
+    )
+    pc.add_argument(
+        "--gene-set", required=True,
+        help=("panel to score: cta | surfaceome | mito | housekeeping | "
+              "therapy:<type> | lineage:<code> | a path to a CSV of symbols/ENSG ids"),
+    )
+    pc.add_argument(
+        "--source", default="treehouse-polya-25-01",
+        help="expression source id with cached per-sample data (default: %(default)s)",
+    )
+    pc.add_argument(
+        "--threshold", type=int, default=25,
+        help="TPM cutoff for the coverage plots (default: %(default)s)",
+    )
+    pc.add_argument(
+        "--cohort", action="append", default=None, metavar="CODE",
+        help="restrict to specific cancer-type code(s); repeatable (default: all)",
+    )
+    pc.add_argument(
+        "--out", default="coverage_out",
+        help="output directory for the CSV + PNGs (default: %(default)s)",
     )
 
     for name in sorted(_ANALYSIS_SUBCOMMANDS):
@@ -622,11 +666,37 @@ def cmd_build(args: argparse.Namespace) -> int:
     return int(result.returncode)
 
 
-def cmd_plot(_args: argparse.Namespace) -> int:
-    sys.stderr.write(
-        _NOT_IMPLEMENTED_MESSAGE.format(subcommand="plot", milestone=7) + "\n"
+def cmd_plot_patient_coverage(args: argparse.Namespace) -> int:
+    from . import coverage
+
+    try:
+        result = coverage.render(
+            args.gene_set, source_id=args.source, codes=args.cohort,
+            threshold=args.threshold, out_dir=args.out,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+    if result["n_cohorts"] == 0:
+        sys.stderr.write(
+            f"no cohorts with cached per-sample data for source "
+            f"'{args.source}' (and gene set '{result['label']}'). "
+            f"Run `pirlygenes downloads fetch {args.source}` / "
+            f"`pirlygenes build {args.source}` first.\n"
+        )
+        return 2
+    sys.stdout.write(
+        f"{result['label']}: {result['n_cohorts']} cohorts "
+        f"(> {args.threshold} TPM)\n"
     )
-    return 2
+    for kind, path in result["paths"].items():
+        sys.stdout.write(f"  {kind}: {path}\n")
+    return 0
+
+
+_PLOT_DISPATCH = {
+    "patient-coverage": cmd_plot_patient_coverage,
+}
 
 
 def cmd_analysis_moved(_args: argparse.Namespace) -> int:
@@ -686,9 +756,15 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         return handler(args)
 
+    if subcommand == "plot":
+        handler = _PLOT_DISPATCH.get(args.plot_action)
+        if handler is None:
+            sys.stderr.write("usage: pirlygenes plot {patient-coverage}\n")
+            return 2
+        return handler(args)
+
     dispatch = {
         "build": cmd_build,
-        "plot": cmd_plot,
     }
     handler = dispatch.get(subcommand)
     if handler is None:

--- a/pirlygenes/cohorts.py
+++ b/pirlygenes/cohorts.py
@@ -1,0 +1,106 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-sample cohort registry: which expression cohorts a build *source*
+materialises, and how each registry cancer-type code maps to its on-disk
+per-sample-TPM parquet stem.
+
+The builders (:mod:`pirlygenes.builders.treehouse`) write one per-sample TPM
+matrix per cohort to ``<source-cache>/derived/<stem>_per_sample_tpm.parquet``.
+Most cohorts use their own code as the stem; the TCGA-via-Treehouse cohorts use
+``tcga_<lower(code)>``; the molecular / histology sub-cohorts use mixed-case
+codes that don't round-trip from a lowercased stem (e.g. ``BRCA_LumA`` ->
+``tcga_brca_luma``), so that mapping is enumerated explicitly here rather than
+inferred. This is the package-level home for cohort definitions that previously
+lived only in ``scripts/sweep_treehouse_*`` — the cohort-level CLI
+(``pirlygenes plot``) and notebooks read per-sample data through it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import downloads
+
+
+@dataclass(frozen=True)
+class Cohort:
+    """One materialised per-sample cohort within a build source."""
+
+    code: str        # registry cancer-type code (e.g. "GBM", "BRCA_LumA")
+    stem: str        # per-sample parquet stem (filename minus _per_sample_tpm.parquet)
+    source_id: str   # expression source id (downloads registry)
+
+
+# --- treehouse-polya-25-01 -------------------------------------------------
+# Pediatric / sarcoma / rare cohorts: parquet stem == cancer code.
+_TH_DIRECT = [
+    "ATRT", "EWS", "HEPB", "MBL", "NPC", "NUTM", "OS",
+    "RMS_ARMS", "RMS_ERMS", "RMS_PRMS", "RMS_SSRMS",
+    "SARC_ANGIO", "SARC_ASPS", "SARC_DSRCT", "SARC_EHE", "SARC_EPITH",
+    "SARC_GIST", "SARC_IFS", "SARC_IMT", "SARC_LGFMS", "SARC_LMS",
+    "SARC_LPS_UNSPEC", "SARC_MPNST", "SARC_MYXFIB", "SARC_SYN", "SARC_UPS",
+]
+# TCGA-via-Treehouse direct projects: stem == "tcga_<lower(code)>".
+_TH_TCGA = [
+    "ACC", "BLCA", "BRCA", "CESC", "CHOL", "COAD", "DLBC", "ESCA", "GBM",
+    "HNSC", "KICH", "KIRC", "KIRP", "LAML", "LGG", "LIHC", "LUAD", "LUSC",
+    "MESO", "OV", "PAAD", "PCPG", "PRAD", "READ", "SARC", "SKCM", "STAD",
+    "TGCT", "THCA", "THYM", "UCEC", "UCS", "UVM",
+]
+# Molecular / histology sub-cohorts (mixed-case codes -> explicit stems).
+_TH_DERIVED = {
+    "BRCA_Basal": "tcga_brca_basal", "BRCA_HER2": "tcga_brca_her2",
+    "BRCA_LumA": "tcga_brca_luma", "BRCA_LumB": "tcga_brca_lumb",
+    "BRCA_Normal": "tcga_brca_normal",
+    "HNSC_HPV_neg": "tcga_hnsc_hpv_neg", "HNSC_HPV_pos": "tcga_hnsc_hpv_pos",
+    "LUAD_EGFR": "tcga_luad_egfr", "LUAD_KRAS": "tcga_luad_kras",
+    "LUAD_STK11": "tcga_luad_stk11",
+    "SARC_DDLPS": "tcga_sarc_ddlps", "SARC_PLEOLPS": "tcga_sarc_pleolps",
+    "SARC_WDLPS": "tcga_sarc_wdlps",
+}
+
+
+def _treehouse_polya_25_01() -> dict[str, Cohort]:
+    src = "treehouse-polya-25-01"
+    out: dict[str, Cohort] = {}
+    for code in _TH_DIRECT:
+        out[code] = Cohort(code, code, src)
+    for code in _TH_TCGA:
+        out[code] = Cohort(code, f"tcga_{code.lower()}", src)
+    for code, stem in _TH_DERIVED.items():
+        out[code] = Cohort(code, stem, src)
+    return out
+
+
+_REGISTRY: dict[str, dict[str, Cohort]] = {
+    "treehouse-polya-25-01": _treehouse_polya_25_01(),
+}
+
+
+def cohorts_for_source(source_id: str) -> dict[str, Cohort]:
+    """All registered cohorts for ``source_id`` ({code: Cohort}); empty if the
+    source has no per-sample cohort registry."""
+    return dict(_REGISTRY.get(source_id, {}))
+
+
+def parquet_path(cohort: Cohort):
+    """Path to a cohort's per-sample TPM parquet (may not exist on disk)."""
+    return (downloads.source_cache_dir(cohort.source_id) / "derived"
+            / f"{cohort.stem}_per_sample_tpm.parquet")
+
+
+def available_cohorts(source_id: str) -> dict[str, Cohort]:
+    """Registered cohorts whose per-sample parquet is actually present in the
+    local cache (i.e. usable right now without a build/download)."""
+    return {code: c for code, c in cohorts_for_source(source_id).items()
+            if parquet_path(c).exists()}

--- a/pirlygenes/coverage.py
+++ b/pirlygenes/coverage.py
@@ -1,0 +1,336 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cohort-level *patient* coverage of a gene set.
+
+The packaged cohort summaries store per-cohort percentiles only, so they can't
+answer "how many *patients* in this cohort express gene X above 50 TPM" or
+"as I add genes to a panel, how many *new* patients do I pick up". Those are
+cohort-level questions that need the per-sample matrices the builders cache
+(``<source>/derived/<stem>_per_sample_tpm.parquet``, linear TPM). This module
+reads those, restricted to a named gene set, and computes:
+
+  * per (cohort × gene × threshold) patient counts and percentages, and
+  * greedy co-occurrence-aware coverage — as genes are added in the order that
+    maximises *new* distinct patients over threshold, the cumulative fraction
+    of patients with >=1 panel gene over threshold (a patient expressing
+    several panel genes is counted once).
+
+It is the engine behind ``pirlygenes plot patient-coverage`` and generalises
+the CTA-specific analysis in ``analyses/cta_patient_counts.py`` to any panel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from . import cohorts as _cohorts
+from . import gene_sets_cancer as gsc
+
+DEFAULT_SOURCE = "treehouse-polya-25-01"
+DEFAULT_THRESHOLDS = (25, 50, 100, 200)
+
+# --- gene-set resolution ---------------------------------------------------
+
+# Tokens that map to an ENSG accessor in gene_sets_cancer. A cohort matrix row
+# is "in the panel" if its Ensembl_Gene_ID is in ``ensgs`` OR its Symbol is in
+# ``symbols`` — so panels keyed by either identifier resolve uniformly.
+def resolve_gene_set(name: str):
+    """Resolve a ``--gene-set`` token to ``(label, ensgs, symbols)``.
+
+    Supported tokens::
+
+        cta | surfaceome | mito | housekeeping
+        therapy:<type>     e.g. therapy:adc, therapy:car-t, therapy:radioligand
+        lineage:<code>     per-cancer-type lineage panel (e.g. lineage:PRAD)
+        <path>             a CSV/TXT with Symbol and/or Ensembl_Gene_ID column(s),
+                           or a single first column of symbols / ENSG ids
+    """
+    token = str(name).strip()
+    low = token.lower()
+    if low == "cta":
+        return "CTA", set(gsc.CTA_gene_ids()), set()
+    if low in ("surfaceome", "cancer-surfaceome"):
+        return "cancer-surfaceome", set(gsc.cancer_surfaceome_gene_ids()), set()
+    if low in ("mito", "mitochondrial"):
+        return "mitochondrial", set(gsc.mitochondrial_gene_ids()), set()
+    if low == "housekeeping":
+        return "housekeeping", set(gsc.housekeeping_gene_ids()), set()
+    if low.startswith("therapy:"):
+        t = token.split(":", 1)[1]
+        return f"therapy:{t}", set(gsc.therapy_target_gene_ids(t)), set()
+    if low.startswith("lineage:"):
+        code = gsc.resolve_cancer_type(token.split(":", 1)[1])
+        df = gsc.lineage_genes_df(code)
+        ensgs = set(df["Ensembl_Gene_ID"].dropna().astype(str).str.split(".").str[0])
+        syms = (set(df["Symbol"].dropna().astype(str).str.upper())
+                if "Symbol" in df.columns else set())
+        return f"lineage:{code}", ensgs, syms
+    p = Path(token).expanduser()
+    if p.exists():
+        return _gene_set_from_file(p)
+    raise ValueError(
+        f"Unknown --gene-set {name!r}. Use one of: cta, surfaceome, mito, "
+        "housekeeping, therapy:<type>, lineage:<code>, or a path to a CSV of "
+        "symbols/ENSG ids."
+    )
+
+
+def _gene_set_from_file(path: Path):
+    raw = pd.read_csv(path)
+    cols = {c.lower(): c for c in raw.columns}
+    ensgs, symbols = set(), set()
+    if "ensembl_gene_id" in cols:
+        ensgs |= set(raw[cols["ensembl_gene_id"]].dropna().astype(str)
+                     .str.split(".").str[0])
+    if "symbol" in cols:
+        symbols |= set(raw[cols["symbol"]].dropna().astype(str).str.upper())
+    if not ensgs and not symbols:  # bare first column: classify each token
+        for v in raw[raw.columns[0]].dropna().astype(str):
+            v = v.strip()
+            (ensgs.add(v.split(".")[0]) if v.upper().startswith("ENSG")
+             else symbols.add(v.upper()))
+    return path.name, ensgs, symbols
+
+
+# --- per-sample access + counting ------------------------------------------
+
+def cohort_matrix(cohort, ensgs=None, symbols=None) -> pd.DataFrame:
+    """Per-sample TPM matrix for ``cohort``, restricted to the panel rows.
+
+    Returns a Symbol-indexed, sample-columned DataFrame (linear TPM)."""
+    path = _cohorts.parquet_path(cohort)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"no per-sample parquet for {cohort.code} at {path} — run "
+            f"`pirlygenes build {cohort.source_id}` or `downloads fetch` first")
+    df = pd.read_parquet(path)
+    ensgs, symbols = ensgs or set(), {s.upper() for s in (symbols or set())}
+    mask = pd.Series(False, index=df.index)
+    if ensgs:
+        mask |= df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0].isin(ensgs)
+    if symbols:
+        mask |= df["Symbol"].astype(str).str.upper().isin(symbols)
+    sub = df.loc[mask]
+    sample_cols = [c for c in sub.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    return sub.set_index("Symbol")[sample_cols]
+
+
+def greedy_coverage(mat: pd.DataFrame, threshold: float):
+    """Greedily order genes by marginal NEW patients (>threshold).
+
+    Returns ``(ordered_row_positions, cumulative_fraction, n_samples)``."""
+    arr = mat.to_numpy()
+    n = arr.shape[1]
+    if n == 0 or arr.shape[0] == 0:
+        return [], [], n
+    hit = arr > threshold
+    covered = np.zeros(n, dtype=bool)
+    order, cum, remaining = [], [], set(range(arr.shape[0]))
+    while remaining:
+        best, best_gain = None, 0
+        for i in remaining:
+            gain = int((hit[i] & ~covered).sum())
+            if gain > best_gain:
+                best, best_gain = i, gain
+        if best is None or best_gain <= 0:
+            break
+        covered |= hit[best]
+        order.append(best)
+        cum.append(covered.sum() / n)
+        remaining.discard(best)
+    return order, cum, n
+
+
+def patient_coverage(gene_set: str, source_id: str = DEFAULT_SOURCE,
+                     codes=None, thresholds=DEFAULT_THRESHOLDS) -> pd.DataFrame:
+    """Long table: for every (cohort × gene) the number and % of patients with
+    TPM above each threshold. Only genes with at least one hit are kept.
+
+    ``codes`` optionally restricts to specific cancer types (resolved through
+    :func:`gene_sets_cancer.resolve_cancer_type`); default is every cohort with
+    a cached per-sample matrix for ``source_id``.
+    """
+    _label, ensgs, symbols = resolve_gene_set(gene_set)
+    avail = _cohorts.available_cohorts(source_id)
+    if codes:
+        want = {gsc.resolve_cancer_type(c) for c in codes}
+        avail = {k: v for k, v in avail.items() if k in want}
+    rows = []
+    for code, cohort in avail.items():
+        mat = cohort_matrix(cohort, ensgs, symbols)
+        n = mat.shape[1]
+        if n == 0:
+            continue
+        for sym, vals in zip(mat.index, mat.to_numpy()):
+            rec = {"cancer_code": code, "n_samples": n, "Symbol": sym}
+            any_hit = False
+            for t in thresholds:
+                k = int((vals > t).sum())
+                rec[f"n_gt{t}"] = k
+                rec[f"pct_gt{t}"] = round(100 * k / n, 2)
+                any_hit = any_hit or k > 0
+            if any_hit:
+                rows.append(rec)
+    cols = (["cancer_code", "n_samples", "Symbol"]
+            + [f"{p}_gt{t}" for t in thresholds for p in ("n", "pct")])
+    return pd.DataFrame(rows, columns=cols)
+
+
+# --- rendering (CLI) -------------------------------------------------------
+
+_PALETTE = [
+    "#e6194B", "#3cb44b", "#4363d8", "#f58231", "#911eb4", "#42d4f4",
+    "#f032e6", "#bfef45", "#469990", "#9A6324", "#800000", "#808000",
+    "#000075", "#e6beff", "#aaffc3", "#ffd8b1", "#a9a9a9", "#fabed4",
+]
+
+
+def _slug(label: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in label.lower()).strip("_")
+
+
+def render(gene_set: str, source_id: str = DEFAULT_SOURCE, codes=None,
+           threshold: int = 25, thresholds=DEFAULT_THRESHOLDS,
+           out_dir="coverage_out") -> dict:
+    """Compute patient coverage for ``gene_set`` and write a counts CSV plus two
+    figures (a per-CTA-style stacked coverage bar and a coverage-curve
+    small-multiples) into ``out_dir``. Returns a dict of written paths + the
+    counts DataFrame. ``threshold`` is the TPM cutoff used for the two plots;
+    ``thresholds`` are the cutoffs tabulated in the CSV.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    label, ensgs, symbols = resolve_gene_set(gene_set)
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    slug = _slug(label)
+
+    counts = patient_coverage(gene_set, source_id, codes, thresholds)
+    csv_path = out / f"{slug}_patient_counts.csv"
+    counts.sort_values(["cancer_code", f"n_gt{threshold}"],
+                       ascending=[True, False]).to_csv(csv_path, index=False)
+
+    # Per-cohort greedy coverage (reuse the loaded matrices once).
+    avail = _cohorts.available_cohorts(source_id)
+    if codes:
+        want = {gsc.resolve_cancer_type(c) for c in codes}
+        avail = {k: v for k, v in avail.items() if k in want}
+    per = []  # (code, n, cum, gene_names_in_greedy_order)
+    for code, cohort in avail.items():
+        mat = cohort_matrix(cohort, ensgs, symbols)
+        order, cum, n = greedy_coverage(mat, threshold)
+        if cum:
+            per.append((code, n, cum, [mat.index[i] for i in order]))
+    per.sort(key=lambda t: t[2][-1])  # ascending plateau -> broadest at top
+
+    paths = {"counts_csv": str(csv_path)}
+    if per:
+        paths["stacked_bar"] = str(_stacked_bar(
+            per, label, threshold, out / f"{slug}_stacked_coverage_t{threshold}.png",
+            plt))
+        paths["coverage_curves"] = str(_coverage_curves(
+            per, label, threshold,
+            out / f"{slug}_coverage_curves_t{threshold}.png", plt))
+    return {"paths": paths, "counts": counts, "label": label,
+            "n_cohorts": len(per)}
+
+
+def _gene_color_map(genes_ordered):
+    seen, colors = [], {}
+    for g in genes_ordered:
+        if g not in colors:
+            colors[g] = _PALETTE[len(seen) % len(_PALETTE)]
+            seen.append(g)
+    return colors
+
+
+def _stacked_bar(per, label, threshold, path, plt):
+    """Horizontal stacked bar: each cohort's greedy plateau split into each
+    gene's marginal new-patient contribution (segments sum to the plateau)."""
+    from collections import Counter
+    tot = Counter()
+    for _code, _n, cum, names in per:
+        prev = 0.0
+        for nm, c in zip(names, cum):
+            tot[nm] += (c - prev) * 100
+            prev = c
+    color = _gene_color_map([g for g, _ in tot.most_common()])
+
+    fig, ax = plt.subplots(figsize=(13, max(6, len(per) * 0.28)))
+    labels = []
+    for y, (code, n, cum, names) in enumerate(per):
+        labels.append(f"{code}  (n={n})")
+        left, prev = 0.0, 0.0
+        for j, (nm, c) in enumerate(zip(names, cum)):
+            marg = (c - prev) * 100
+            prev = c
+            if marg <= 0:
+                continue
+            ax.barh(y, marg, left=left, color=color.get(nm, "#cccccc"),
+                    edgecolor="white", linewidth=0.3)
+            if marg >= 3.0 or j == 0:
+                if marg >= 1.5:
+                    ax.text(left + marg / 2, y, nm, va="center", ha="center",
+                            fontsize=4.5, clip_on=True)
+            left += marg
+    ax.set_yticks(range(len(per)))
+    ax.set_yticklabels(labels, fontsize=7)
+    ax.set_xlim(0, 100)
+    ax.set_xlabel(f"% of patients with ≥1 {label} gene > {threshold} TPM "
+                  "(stacked by each gene's marginal new-patient share, greedy)")
+    ax.grid(axis="x", alpha=0.3)
+    ax.set_title(f"{label} coverage by cancer type, split by gene "
+                 f"(> {threshold} TPM, {len(per)} cohorts)", fontsize=11)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return path
+
+
+def _coverage_curves(per, label, threshold, path, plt):
+    """Small-multiples of each cohort's greedy coverage curve (sorted by
+    plateau, broadest first)."""
+    ordered = sorted(per, key=lambda t: t[2][-1], reverse=True)
+    ncol = 6
+    nrow = (len(ordered) + ncol - 1) // ncol
+    fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 2.5, nrow * 1.9),
+                             sharex=True, sharey=True, squeeze=False)
+    axes = axes.ravel()
+    for ax, (code, n, cum, names) in zip(axes, ordered):
+        xs = range(1, len(cum) + 1)
+        ax.plot(xs, [c * 100 for c in cum], color="#b5179e", lw=1.2)
+        ax.fill_between(xs, [c * 100 for c in cum], alpha=0.15, color="#b5179e")
+        for x, (nm, c) in enumerate(zip(names[:3], cum[:3]), start=1):
+            ax.annotate(nm, (x, c * 100), fontsize=4, rotation=45,
+                        textcoords="offset points", xytext=(1, 2))
+        ax.set_title(f"{code} (n={n}) {cum[-1]*100:.0f}%", fontsize=7)
+        ax.set_xlim(0, 25)
+        ax.set_ylim(0, 100)
+        ax.tick_params(labelsize=5)
+        ax.grid(alpha=0.25)
+    for ax in axes[len(ordered):]:
+        ax.axis("off")
+    fig.suptitle(f"{label} panel coverage by cancer type — distinct patients "
+                 f"with ≥1 gene > {threshold} TPM (sorted by plateau)",
+                 fontsize=11)
+    fig.supxlabel("# genes added (greedy)", fontsize=8)
+    fig.supylabel("% patients covered", fontsize=8)
+    fig.tight_layout(rect=(0.01, 0.01, 1, 0.97))
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return path

--- a/pirlygenes/data/cancer-fusions.csv
+++ b/pirlygenes/data/cancer-fusions.csv
@@ -1,0 +1,171 @@
+cancer_code,fusion_family,gene_5prime,gene_5prime_family,gene_3prime,gene_3prime_family,frequency,is_defining,pathognomonic,rnaseq_detectable,mechanism,confidence,pmid,notes
+EWS,EWSR1-ETS,EWSR1,FET,FLI1,ETS,~85%,true,true,yes,fusion_transcript,high,PMID:1522903,Ewing sarcoma; t(11;22)(q24;q12); most common partner
+EWS,EWSR1-ETS,EWSR1,FET,ERG,ETS,~10%,true,true,yes,fusion_transcript,high,PMID:8162068,t(21;22)(q22;q12); second most common ETS partner
+EWS,EWSR1-ETS,EWSR1,FET,ETV1,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:7700648,rare ETS variant fusion
+EWS,EWSR1-ETS,EWSR1,FET,ETV4,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:9182765,rare ETS variant fusion (also called E1AF)
+EWS,EWSR1-ETS,EWSR1,FET,FEV,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:11050006,rare ETS variant fusion
+EWS,FUS-ETS,FUS,FET,ERG,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:8392442,FET-family alternative (FUS instead of EWSR1)
+SARC_SYN,SS18-SSX,SS18,,SSX1,SSX,~65%,true,true,yes,fusion_transcript,high,PMID:7951326,synovial sarcoma; t(X;18)(p11;q11); SSX1 more common in biphasic
+SARC_SYN,SS18-SSX,SS18,,SSX2,SSX,~35%,true,true,yes,fusion_transcript,high,PMID:7951326,SSX2 tends monophasic
+SARC_SYN,SS18-SSX,SS18,,SSX4,SSX,rare,true,true,yes,fusion_transcript,medium,PMID:7951326,rare third partner
+SARC_DSRCT,EWSR1-WT1,EWSR1,FET,WT1,zinc-finger TF,~95%,true,true,yes,fusion_transcript,high,PMID:7954420,desmoplastic small round cell tumor; t(11;22)(p13;q12)
+SARC_ASPS,ASPSCR1-TFE3,ASPSCR1,,TFE3,MiT/TFE,~95%,true,false,surrogate,fusion_transcript,high,PMID:11526541,alveolar soft part sarcoma; der(17)t(X;17); ASPL=ASPSCR1; TFE3 IHC surrogate
+SARC_CCS,EWSR1-ATF1,EWSR1,FET,ATF1,bZIP(CREB/ATF),~90%,true,true,yes,fusion_transcript,high,PMID:8504306,clear cell sarcoma (melanoma of soft parts); t(12;22)(q13;q12)
+SARC_CCS,EWSR1-CREB1,EWSR1,FET,CREB1,bZIP(CREB/ATF),minority,true,false,yes,fusion_transcript,medium,PMID:17464315,variant; also seen in GI clear cell sarcoma-like / angiomatoid FH
+SARC_IFS,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,~90%,true,false,yes,fusion_transcript,high,PMID:9590769,infantile fibrosarcoma; t(12;15)(p13;q25); TRK-inhibitor responsive
+SARC_EHE,WWTR1-CAMTA1,WWTR1,Hippo coactivator,CAMTA1,,~90%,true,true,yes,fusion_transcript,high,PMID:21885844,epithelioid hemangioendothelioma; t(1;3); WWTR1=TAZ; CAMTA1 IHC surrogate
+SARC_EHE,YAP1-TFE3,YAP1,Hippo coactivator,TFE3,MiT/TFE,minority,true,false,surrogate,fusion_transcript,high,PMID:23737213,distinct EHE subset; TFE3 IHC surrogate; YAP1-TFE3 variant
+SARC_LGFMS,FUS-CREB3L2,FUS,FET,CREB3L2,bZIP(CREB/ATF),~90%,true,true,yes,fusion_transcript,high,PMID:15334060,low-grade fibromyxoid sarcoma; t(7;16)(q33;p11)
+SARC_LGFMS,FUS-CREB3L1,FUS,FET,CREB3L1,bZIP(CREB/ATF),minority,true,true,yes,fusion_transcript,medium,PMID:15920748,variant translocation t(11;16)
+SARC_LGFMS,EWSR1-CREB3L1,EWSR1,FET,CREB3L1,bZIP(CREB/ATF),rare,true,true,yes,fusion_transcript,medium,PMID:17345601,rare FET-family variant
+SARC_EMC,EWSR1-NR4A3,EWSR1,FET,NR4A3,nuclear receptor,~60%,true,true,yes,fusion_transcript,high,PMID:9537325,extraskeletal myxoid chondrosarcoma; t(9;22)(q22;q12); NR4A3=CHN/TEC/NOR1
+SARC_EMC,TAF15-NR4A3,TAF15,FET,NR4A3,nuclear receptor,~30%,true,true,yes,fusion_transcript,high,PMID:10398438,TAF15=TAF2N/RBP56; t(9;17)
+SARC_EMC,TCF12-NR4A3,TCF12,bHLH,NR4A3,nuclear receptor,rare,true,true,yes,fusion_transcript,medium,PMID:12112524,rare variant; t(9;15)
+SARC_SFT,NAB2-STAT6,NAB2,,STAT6,STAT,~95%,true,true,surrogate,fusion_transcript,high,PMID:23313952,solitary fibrous tumor; intrachromosomal 12q13 inversion; nuclear STAT6 IHC surrogate; intronic breakpoints can miss in RNA
+SARC_IMT,TPM3-ALK,TPM3,tropomyosin,ALK,RTK,common,true,true,surrogate,fusion_transcript,high,PMID:10934142,inflammatory myofibroblastic tumor; ALK IHC surrogate; ALK-inhibitor responsive
+SARC_IMT,TPM4-ALK,TPM4,tropomyosin,ALK,RTK,minority,true,true,surrogate,fusion_transcript,medium,PMID:10934142,IMT ALK partner
+SARC_IMT,EML4-ALK,EML4,,ALK,RTK,minority,true,false,surrogate,fusion_transcript,medium,PMID:16951148,IMT ALK partner
+SARC_IMT,RANBP2-ALK,RANBP2,,ALK,RTK,minority,true,true,surrogate,fusion_transcript,medium,PMID:16462738,epithelioid inflammatory myofibroblastic sarcoma; aggressive variant
+SARC_IMT,CARS1-ROS1,CARS1,,ROS1,RTK,minority,true,true,surrogate,fusion_transcript,medium,PMID:25028501,ROS1-rearranged IMT subset (CARS=CARS1)
+SARC_IMT,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,rare,true,false,yes,fusion_transcript,medium,PMID:25028501,NTRK-rearranged IMT subset
+SARC_IMT,TFG-ROS1,TFG,,ROS1,RTK,rare,true,true,surrogate,fusion_transcript,low,,ROS1 partner reported in IMT
+SARC_DFSP,COL1A1-PDGFB,COL1A1,collagen,PDGFB,growth factor,~90%,true,true,surrogate,fusion_transcript,high,PMID:9192848,dermatofibrosarcoma protuberans; supernumerary ring chr from t(17;22); PDGFB overexpression; imatinib responsive
+SARC_MYXLPS,FUS-DDIT3,FUS,FET,DDIT3,bZIP(C/EBP),~90%,true,true,yes,fusion_transcript,high,PMID:8099842,myxoid/round cell liposarcoma; t(12;16)(q13;p11); DDIT3=CHOP
+SARC_MYXLPS,EWSR1-DDIT3,EWSR1,FET,DDIT3,bZIP(C/EBP),minority,true,true,yes,fusion_transcript,medium,PMID:8612988,variant t(12;22)
+SARC_PEC,SFPQ-TFE3,SFPQ,,TFE3,MiT/TFE,minority,false,false,surrogate,fusion_transcript,medium,PMID:25517172,PEComa TFE3-rearranged subset; SFPQ=PSF; TFE3 IHC surrogate; most PEComas are TSC1/2-driven not fusion
+SARC_PEC,DVL2-TFE3,DVL2,,TFE3,MiT/TFE,rare,false,false,surrogate,fusion_transcript,low,,rare PEComa TFE3 partner
+RMS_ARMS,PAX3-FOXO1,PAX3,PAX,FOXO1,FOX,~70%,true,true,yes,fusion_transcript,high,PMID:8275086,alveolar rhabdomyosarcoma; t(2;13)(q35;q14); worse prognosis than PAX7
+RMS_ARMS,PAX7-FOXO1,PAX7,PAX,FOXO1,FOX,~20%,true,true,yes,fusion_transcript,medium,PMID:8275086,"t(1;13)(p36;q14); younger, better outcome; FOXO1=FKHR; PMID is the shared PAX-FKHR discovery paper"
+RMS_SSRMS,VGLL2-NCOA2,VGLL2,vestigial-like,NCOA2,NR coactivator,subset,true,true,yes,fusion_transcript,medium,PMID:30664692,infantile spindle cell/sclerosing RMS; congenital subset
+RMS_SSRMS,TEAD1-NCOA2,TEAD1,TEAD,NCOA2,NR coactivator,subset,true,true,yes,fusion_transcript,low,PMID:30664692,alternative infantile spindle cell RMS fusion
+RMS_SSRMS,(none),,,,,,false,false,no,other,high,,"older child/adult sclerosing-spindle RMS driven by MYOD1 L122R point mutation, not a fusion"
+CHON,HEY1-NCOA2,HEY1,bHLH,NCOA2,NR coactivator,~80%,true,true,yes,fusion_transcript,high,PMID:22387997,mesenchymal chondrosarcoma; ins(8;8) or t(8;8)
+CHON,IRF2BP2-CDX1,IRF2BP2,,CDX1,homeobox,rare,false,false,yes,fusion_transcript,low,,rare mesenchymal chondrosarcoma variant
+CHON,(none),,,,,,false,false,no,other,high,,"conventional chondrosarcoma driven by IDH1/IDH2 mutation, not a fusion"
+ESS_LG,JAZF1-SUZ12,JAZF1,,SUZ12,PRC2/Polycomb,~50%,true,true,yes,fusion_transcript,high,PMID:11427703,low-grade endometrial stromal sarcoma; t(7;17); SUZ12=JJAZ1
+ESS_LG,JAZF1-PHF1,JAZF1,,PHF1,PRC2/Polycomb,minority,true,true,yes,fusion_transcript,medium,PMID:16331334,variant; PHF1 (6p21) recurrent partner
+ESS_LG,EPC1-PHF1,EPC1,PRC2/Polycomb,PHF1,PRC2/Polycomb,minority,true,true,yes,fusion_transcript,medium,PMID:16331334,PHF1-rearranged LG-ESS variant
+ESS_HG,YWHAE-NUTM2A,YWHAE,14-3-3,NUTM2A,NUT,common,true,true,yes,fusion_transcript,high,PMID:22456610,high-grade endometrial stromal sarcoma; t(10;17); NUTM2A/B=FAM22A/B; cyclin D1+
+ESS_HG,YWHAE-NUTM2B,YWHAE,14-3-3,NUTM2B,NUT,common,true,true,yes,fusion_transcript,high,PMID:22456610,paralogous 3' partner
+ESS_HG,ZC3H7B-BCOR,ZC3H7B,,BCOR,PRC2/Polycomb,subset,true,false,yes,fusion_transcript,medium,PMID:23344418,BCOR-rearranged HG-ESS subset; BCOR ITD-related morphology
+SARC_LMS,(none),,,,,,false,false,no,other,high,,"leiomyosarcoma: complex karyotype, TP53/RB1/PTEN loss; no recurrent fusion"
+SARC_UPS,(none),,,,,,false,false,no,other,high,,"undifferentiated pleomorphic sarcoma: complex genome, no defining fusion"
+SARC_MYXFIB,(none),,,,,,false,false,no,other,high,,"myxofibrosarcoma: complex karyotype, no recurrent fusion"
+SARC_DDLPS,(none),,,,,,false,false,no,other,high,,"dedifferentiated liposarcoma: 12q13-15 amplification (MDM2/CDK4), not a fusion"
+SARC_WDLPS,(none),,,,,,false,false,no,other,high,,"well-differentiated liposarcoma: MDM2/CDK4 amplification (ring/giant marker chr), not a fusion"
+SARC_PLEOLPS,(none),,,,,,false,false,no,other,high,,"pleomorphic liposarcoma: complex karyotype, TP53/RB1 loss; no defining fusion"
+SARC_GIST,(none),,,,,,false,false,no,other,high,,GIST: KIT or PDGFRA activating mutation (or SDH-deficient); not fusion-driven
+SARC_MPNST,(none),,,,,,false,false,no,other,high,,MPNST: NF1 loss + SUZ12/EED (PRC2) loss + CDKN2A; not fusion-driven
+SARC_EPITH,(none),,,,,,false,false,no,other,high,,"epithelioid sarcoma: SMARCB1/INI1 loss (deletion), not a fusion"
+SARC_KS,(none),,,,,,false,false,no,other,high,,"Kaposi sarcoma: HHV8/KSHV viral oncogenesis, not a chromosomal fusion"
+OS,(none),,,,,,false,false,no,other,high,,"osteosarcoma: complex/chaotic karyotype, chromothripsis, TP53/RB1; no recurrent fusion"
+RMS_ERMS,(none),,,,,,false,false,no,other,high,,"embryonal RMS: RAS-pathway mutations, 11p15 LOH; fusion-negative"
+CHOR,(none),,,,,,false,false,surrogate,other,high,,chordoma: TBXT(brachyury) duplication/overexpression drives; not a fusion (brachyury IHC)
+GCTB,(none),,,,,,false,false,surrogate,other,high,,giant cell tumor of bone: H3F3A (H3-3A) G34W point mutation; not a fusion
+LAML,RUNX1-RUNX1T1,RUNX1,CBF,RUNX1T1,CBF,common,true,true,yes,fusion_transcript,high,PMID:1907282,AML t(8;21)(q22;q22); core-binding factor; RUNX1T1=ETO/MTG8; favorable
+LAML,CBFB-MYH11,CBFB,CBF,MYH11,myosin,common,true,true,yes,fusion_transcript,high,PMID:8316832,AML inv(16)(p13q22)/t(16;16); CBF-AML; favorable
+LAML,KMT2A-MLLT3,KMT2A,KMT/HMTase,MLLT3,YEATS,subset,true,true,yes,fusion_transcript,high,PMID:1652368,AML t(9;11); KMT2A=MLL; MLLT3=AF9; promiscuous MLL partner
+LAML,KMT2A-MLLT10,KMT2A,KMT/HMTase,MLLT10,MLL partner,subset,true,false,yes,fusion_transcript,medium,PMID:8642287,t(10;11); MLLT10=AF10
+LAML,KMT2A-ELL,KMT2A,KMT/HMTase,ELL,,subset,true,true,yes,fusion_transcript,medium,PMID:8161785,t(11;19)(q23;p13.1)
+LAML,KMT2A-MLLT1,KMT2A,KMT/HMTase,MLLT1,YEATS,subset,true,true,yes,fusion_transcript,medium,PMID:1825142,t(11;19)(q23;p13.3); MLLT1=ENL
+LAML,DEK-NUP214,DEK,,NUP214,nucleoporin,rare,true,true,yes,fusion_transcript,high,PMID:1565502,t(6;9)(p23;q34); FLT3-ITD-associated; poor prognosis; NUP214=CAN
+LAML,NUP98-NSD1,NUP98,nucleoporin,NSD1,KMT/HMTase,rare,true,true,yes,fusion_transcript,medium,PMID:11532778,t(5;11); cryptic; pediatric AML; poor prognosis
+LAML,NUP98-KDM5A,NUP98,nucleoporin,KDM5A,,rare,true,true,yes,fusion_transcript,low,,t(11;12); KDM5A=JARID1A; acute megakaryoblastic
+LAML,RBM15-MKL1,RBM15,,MKL1,MRTF,rare,true,true,yes,fusion_transcript,medium,PMID:11753601,"t(1;22); infant acute megakaryoblastic leukemia; MKL1=MRTFA, RBM15=OTT"
+LAML_APL,PML-RARA,PML,TRIM/PML,RARA,nuclear receptor,~95%,true,true,yes,fusion_transcript,high,PMID:1652369,acute promyelocytic leukemia; t(15;17)(q24;q21); ATRA/ATO responsive
+LAML_APL,ZBTB16-RARA,ZBTB16,BTB-ZF TF,RARA,nuclear receptor,rare,true,true,yes,fusion_transcript,high,PMID:8302850,t(11;17); ZBTB16=PLZF; ATRA-resistant variant
+LAML_APL,NPM1-RARA,NPM1,nucleophosmin,RARA,nuclear receptor,rare,true,true,yes,fusion_transcript,medium,PMID:8642286,t(5;17) variant APL
+CML,BCR-ABL1,BCR,,ABL1,non-RTK kinase,~100%,true,false,yes,fusion_transcript,high,PMID:6304885,chronic myeloid leukemia; t(9;22) Philadelphia; p210 (e13a2/e14a2); TKI responsive
+B_ALL,BCR-ABL1,BCR,,ABL1,non-RTK kinase,~25%,true,false,yes,fusion_transcript,high,PMID:2825356,Ph+ B-ALL; adults more often; p190 (e1a2) typical; TKI responsive
+B_ALL,ETV6-RUNX1,ETV6,ETS,RUNX1,CBF,~25%,true,true,yes,fusion_transcript,high,PMID:7896484,"childhood B-ALL; t(12;21)(p13;q22) cryptic; ETV6=TEL, RUNX1=AML1; favorable"
+B_ALL,TCF3-PBX1,TCF3,bHLH(E-protein),PBX1,homeobox(TALE),~5%,true,true,yes,fusion_transcript,high,PMID:2196176,t(1;19)(q23;p13); TCF3=E2A; pre-B
+B_ALL,KMT2A-AFF1,KMT2A,KMT/HMTase,AFF1,AF4/LAF4,subset,true,true,yes,fusion_transcript,high,PMID:1606615,t(4;11)(q21;q23); infant B-ALL; AFF1=AF4; poor prognosis
+B_ALL,DUX4-IGH,IGH,Ig locus,DUX4,homeobox,subset,true,true,surrogate,ig_enhancer_hijack,medium,PMID:27776115,DUX4-rearranged B-ALL; IGH enhancer drives DUX4; ERG deregulation; favorable; orientation per IGH-enhancer juxtaposition
+B_ALL,P2RY8-CRLF2,P2RY8,,CRLF2,cytokine receptor,subset,true,true,surrogate,promoter_swap,medium,PMID:19838194,Ph-like; PAR1 deletion places CRLF2 under P2RY8 promoter; CRLF2 overexpression
+B_ALL,IGH-CRLF2,IGH,Ig locus,CRLF2,cytokine receptor,subset,true,true,surrogate,ig_enhancer_hijack,medium,PMID:19838194,Ph-like; IGH enhancer drives CRLF2; JAK pathway activation
+T_ALL,STIL-TAL1,STIL,,TAL1,bHLH,subset,true,true,surrogate,promoter_swap,high,PMID:8350619,T-ALL; SIL-TAL1 microdeletion 1p32 places TAL1 under STIL promoter; TAL1 overexpression
+T_ALL,TLX1-TRD,TRD,TCR locus,TLX1,homeobox,subset,true,true,surrogate,enhancer_hijack,medium,PMID:1671808,t(10;14)/t(7;10); TCR enhancer drives TLX1 (HOX11) overexpression
+T_ALL,TLX3-BCL11B,BCL11B,,TLX3,homeobox,subset,true,true,surrogate,enhancer_hijack,medium,PMID:11607818,t(5;14)(q35;q32); TLX3=HOX11L2 overexpression via BCL11B enhancer
+T_ALL,NUP214-ABL1,NUP214,nucleoporin,ABL1,non-RTK kinase,subset,true,true,yes,fusion_transcript,medium,PMID:15361874,episomal amplification 9q34; TKI-sensitive T-ALL
+T_ALL,KMT2A-MLLT10,KMT2A,KMT/HMTase,MLLT10,MLL partner,subset,true,false,yes,fusion_transcript,medium,PMID:8642287,t(10;11); MLLT10=AF10; early T-cell precursor associated
+MCL,CCND1-IGH,IGH,Ig locus,CCND1,cyclin,~95%,true,false,surrogate,ig_enhancer_hijack,high,,mantle cell lymphoma; t(11;14)(q13;q32); IGH enhancer drives cyclin D1; no chimeric transcript; cyclin D1 IHC surrogate; PMID unverified
+FL,BCL2-IGH,IGH,Ig locus,BCL2,BCL2/apoptosis,~85%,true,false,surrogate,ig_enhancer_hijack,high,PMID:3929080,follicular lymphoma; t(14;18)(q32;q21); IGH enhancer drives BCL2 anti-apoptotic overexpression
+BL,MYC-IGH,IGH,Ig locus,MYC,,~80%,true,false,surrogate,ig_enhancer_hijack,high,PMID:6262918,Burkitt lymphoma; t(8;14)(q24;q32); IGH enhancer drives MYC
+BL,MYC-IGK,IGK,Ig locus,MYC,,minority,true,true,surrogate,ig_enhancer_hijack,high,PMID:6939711,variant t(2;8); IGK light-chain enhancer drives MYC
+BL,MYC-IGL,IGL,Ig locus,MYC,,minority,true,true,surrogate,ig_enhancer_hijack,high,PMID:6939711,variant t(8;22); IGL light-chain enhancer drives MYC
+DLBC,BCL6-IGH,IGH,Ig locus,BCL6,BTB-ZF TF,subset,false,false,surrogate,ig_enhancer_hijack,medium,PMID:8284124,DLBCL; BCL6 (3q27) promiscuous rearrangements; many non-Ig partners; BCL6 overexpression
+DLBC,MYC-IGH,IGH,Ig locus,MYC,,subset,false,false,surrogate,ig_enhancer_hijack,medium,PMID:19204204,double-hit / HGBL with MYC + BCL2 (and/or BCL6) rearrangements; aggressive
+DLBC,BCL2-IGH,IGH,Ig locus,BCL2,BCL2/apoptosis,subset,false,false,surrogate,ig_enhancer_hijack,medium,PMID:19204204,double-hit partner lesion (GCB-DLBCL)
+MM,CCND1-IGH,IGH,Ig locus,CCND1,cyclin,~15-20%,true,false,surrogate,ig_enhancer_hijack,high,PMID:9596662,multiple myeloma; t(11;14); cyclin D1 overexpression; venetoclax-sensitive subset
+MM,NSD2-IGH,IGH,Ig locus,NSD2,KMT/HMTase,~15%,true,true,surrogate,ig_enhancer_hijack,high,PMID:9520447,t(4;14)(p16;q32); NSD2=WHSC1/MMSET + FGFR3 dysregulation; high-risk
+MM,FGFR3-IGH,IGH,Ig locus,FGFR3,RTK,~15%,true,true,surrogate,ig_enhancer_hijack,high,PMID:9520447,co-deregulated with NSD2 in t(4;14); FGFR3 overexpression
+MM,MAF-IGH,IGH,Ig locus,MAF,bZIP(MAF),~5%,true,true,surrogate,ig_enhancer_hijack,high,PMID:9989715,t(14;16)(q32;q23); c-MAF overexpression; high-risk
+MM,CCND3-IGH,IGH,Ig locus,CCND3,cyclin,rare,true,true,surrogate,ig_enhancer_hijack,medium,PMID:11290608,t(6;14)(p21;q32); cyclin D3 overexpression
+MM,MAFB-IGH,IGH,Ig locus,MAFB,bZIP(MAF),rare,true,true,surrogate,ig_enhancer_hijack,medium,PMID:11090077,t(14;20)(q32;q12); MAFB overexpression; high-risk
+CLL,(none),,,,,,false,false,no,other,high,,"CLL: del13q14, trisomy 12, del11q(ATM), del17p(TP53), IGHV mutation status; not fusion-driven"
+MDS,(none),,,,,,false,false,no,other,high,,"MDS: del5q/-7/del20q, SF3B1/TET2/ASXL1/TP53 mutations; not fusion-driven (rare exceptions)"
+MPN,(none),,,,,,false,false,no,other,high,,"MPN (PV/ET/PMF): JAK2 V617F, CALR, or MPL driver mutations; not fusion-driven"
+CTCL,(none),,,,,,false,false,no,other,high,,"cutaneous T-cell lymphoma (MF/Sezary): complex CNAs, no defining recurrent fusion"
+HCL,(none),,,,,,false,false,no,other,high,,hairy cell leukemia: BRAF V600E point mutation; not a fusion
+NUTM,BRD4-NUTM1,BRD4,BET,NUTM1,NUT,~70%,true,true,yes,fusion_transcript,high,PMID:12543779,NUT carcinoma; t(15;19); most common partner; BET-inhibitor target
+NUTM,BRD3-NUTM1,BRD3,BET,NUTM1,NUT,~15%,true,true,yes,fusion_transcript,high,PMID:19318580,second most common NUT carcinoma fusion
+NUTM,NSD3-NUTM1,NSD3,KMT/HMTase,NUTM1,NUT,~10%,true,true,yes,fusion_transcript,high,PMID:26057308,NSD3=WHSC1L1; NUT carcinoma variant
+NUTM,ZNF532-NUTM1,ZNF532,,NUTM1,NUT,rare,true,true,yes,fusion_transcript,medium,PMID:29162909,rare NUT carcinoma partner
+ADCC,MYB-NFIB,MYB,MYB,NFIB,NFI,~60%,true,true,yes,fusion_transcript,high,PMID:19841262,adenoid cystic carcinoma; t(6;9)(q22-23;p23-24)
+ADCC,MYBL1-NFIB,MYBL1,MYB,NFIB,NFI,subset,true,true,yes,fusion_transcript,high,PMID:26851182,MYBL1-NFIB alternative in MYB-negative ACC; same MYB-pathway activation
+ACINIC,HTN3-MSANTD3,HTN3,,MSANTD3,,subset,true,true,yes,fusion_transcript,medium,PMID:30664692,acinic cell carcinoma (salivary) recurrent fusion; t(4;11)
+ACINIC,(none),,,,,,false,false,surrogate,enhancer_hijack,medium,PMID:30664692,secretory acinic / mammary analogue overlap; many acinic cell carcinomas show NR4A3 enhancer hijack overexpression rather than a clean chimera
+THCA,CCDC6-RET,CCDC6,,RET,RTK,subset,false,false,yes,fusion_transcript,high,PMID:1690453,papillary thyroid carcinoma RET/PTC1; CCDC6=H4; RET-inhibitor target; radiation-associated
+THCA,NCOA4-RET,NCOA4,NR coactivator,RET,RTK,subset,false,false,yes,fusion_transcript,high,PMID:8183555,RET/PTC3; NCOA4=ELE1/ARA70; common in radiation-induced PTC
+THCA,PAX8-PPARG,PAX8,PAX,PPARG,nuclear receptor,subset,false,false,yes,fusion_transcript,high,PMID:10866930,follicular thyroid carcinoma (and follicular-variant PTC); t(2;3)(q13;p25)
+THCA,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:24613932,NTRK-rearranged PTC; TRK-inhibitor target
+THCA,STRN-ALK,STRN,,ALK,RTK,rare,false,false,surrogate,fusion_transcript,medium,PMID:24613932,ALK-rearranged thyroid carcinoma subset
+THCA,(none),,,,,,false,false,no,other,high,,"most PTC driven by BRAF V600E point mutation, not a fusion; fusions enrich in young/radiation cases"
+LUAD,EML4-ALK,EML4,,ALK,RTK,~4-5%,false,false,yes,fusion_transcript,high,PMID:17625570,NSCLC; inv(2)(p21p23); ALK-TKI responsive; variant 1/3 common; intronic breakpoints
+LUAD,CD74-ROS1,CD74,,ROS1,RTK,~1-2%,false,false,yes,fusion_transcript,high,PMID:22327623,ROS1-rearranged NSCLC; crizotinib/entrectinib target
+LUAD,EZR-ROS1,EZR,,ROS1,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:22327623,ROS1 partner in NSCLC
+LUAD,SLC34A2-ROS1,SLC34A2,SLC,ROS1,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:17625570,ROS1 partner in NSCLC
+LUAD,KIF5B-RET,KIF5B,,RET,RTK,~1-2%,false,false,yes,fusion_transcript,high,PMID:22327623,RET-rearranged NSCLC; selpercatinib/pralsetinib target
+LUAD,CCDC6-RET,CCDC6,,RET,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:22327623,RET partner in NSCLC
+LUAD,CD74-NRG1,CD74,,NRG1,growth factor,rare,false,false,yes,fusion_transcript,medium,PMID:24469108,NRG1-rearranged (often invasive mucinous adenocarcinoma); HER3 pathway; zenocutuzumab target
+LUAD,SLC3A2-NRG1,SLC3A2,SLC,NRG1,growth factor,rare,false,false,yes,fusion_transcript,low,,NRG1 partner
+LUAD,NTRK,,,NTRK1,RTK,rare,false,false,yes,fusion_transcript,medium,PMID:24162815,"NTRK1/3-rearranged NSCLC (rare); multiple 5' partners (e.g. MPRIP, TPM3, SQSTM1); TRK-inhibitor target"
+PRAD,TMPRSS2-ERG,TMPRSS2,,ERG,ETS,~50%,false,false,surrogate,promoter_swap,high,PMID:16254181,prostate cancer; androgen-driven TMPRSS2 promoter drives ERG; intrachromosomal del 21q22; ERG IHC surrogate
+PRAD,SLC45A3-ERG,SLC45A3,SLC,ERG,ETS,minority,false,false,surrogate,promoter_swap,medium,PMID:19015641,androgen-regulated SLC45A3 (prostein) promoter drives ERG
+PRAD,TMPRSS2-ETV1,TMPRSS2,,ETV1,ETS,minority,false,false,surrogate,promoter_swap,medium,PMID:16254181,ETV1 alternative ETS partner; ETV1 has additional 5' partners
+PRAD,TMPRSS2-ETV4,TMPRSS2,,ETV4,ETS,rare,false,false,surrogate,promoter_swap,medium,PMID:16518403,rarer ETS fusion
+PRAD,TMPRSS2-ETV5,TMPRSS2,,ETV5,ETS,rare,false,false,surrogate,promoter_swap,low,PMID:17486278,rarest ETS fusion
+GBM,FGFR3-TACC3,FGFR3,RTK,TACC3,TACC,~3%,false,false,yes,fusion_transcript,high,PMID:22837387,glioblastoma; tandem dup 4p16; FGFR-inhibitor target; tandem-dup can be missed by some callers
+GBM,(none),,,,,,false,false,no,other,high,,"most GBM driven by EGFR amp/EGFRvIII, +7/-10, CDKN2A loss, TERT promoter; not a defining fusion"
+LGG,KIAA1549-BRAF,KIAA1549,,BRAF,,~70%,true,true,yes,fusion_transcript,high,PMID:18974108,pilocytic astrocytoma; tandem dup 7q34; MAPK activation; MEK-inhibitor sensitive
+LGG,FGFR3-TACC3,FGFR3,RTK,TACC3,TACC,subset,false,false,yes,fusion_transcript,medium,PMID:22837387,subset of diffuse gliomas; FGFR target
+LGG,(none),,,,,,false,false,no,other,high,,diffuse adult LGG driven by IDH1/2 mutation +/- 1p19q codeletion or ATRX/TP53; not fusion-defined
+CHOL,FGFR2-BICC1,FGFR2,RTK,BICC1,,subset,false,false,yes,fusion_transcript,high,PMID:23558953,intrahepatic cholangiocarcinoma; FGFR2 fusions (~10-15% iCCA); FGFR-inhibitor (pemigatinib) target; promiscuous 3' partners
+CHOL,FGFR2-AHCYL1,FGFR2,RTK,AHCYL1,,subset,false,false,yes,fusion_transcript,medium,PMID:24122810,recurrent FGFR2 3' partner in iCCA
+MTC,(none),,,,,,false,false,no,other,high,,medullary thyroid carcinoma: RET germline/somatic POINT mutations (M918T etc.) or RAS; NOT a fusion
+MEC,(none),,,,,,false,false,no,other,high,,Merkel cell carcinoma: MCPyV clonal integration (virus-positive) or UV-mutation (virus-negative); not a chromosomal fusion
+SCLC,(none),,,,,,false,false,no,other,high,,"small cell lung cancer: near-universal TP53 + RB1 loss, MYC family amp; no recurrent fusion"
+PANNET,(none),,,,,,false,false,no,other,high,,"pancreatic neuroendocrine tumor: MEN1, DAXX/ATRX, mTOR-pathway mutations; not fusion-driven"
+MID_NET,(none),,,,,,false,false,no,other,high,,"midgut/small-bowel NET: CDKN1B mutation, chr18 LOH; not fusion-driven"
+LIHC,DNAJB1-PRKACA,DNAJB1,,PRKACA,non-RTK kinase,~100% of FLC,true,true,yes,fusion_transcript,high,PMID:24578576,"fibrolamellar HCC subtype; ~400kb deletion chr19 fuses DNAJB1 to PRKACA; defining for FLC (young, non-cirrhotic)"
+LIHC,(none),,,,,,false,false,no,other,high,,"conventional HCC: TERT promoter, CTNNB1, TP53; not fusion-driven"
+BRCA,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,~100% of secretory,true,false,yes,fusion_transcript,high,PMID:12244301,secretory carcinoma of breast (MASC analogue); t(12;15); rare subtype but defining; TRK-inhibitor target
+BRCA,(none),,,,,,false,false,no,other,high,,common breast cancer (luminal/HER2/basal): driven by ER/HER2/CN events; no defining fusion (secretory carcinoma excepted)
+RMS_ARMS,PAX-FOXO/alt,PAX3,PAX,NCOA1,NR coactivator,rare,true,true,yes,fusion_transcript,low,,PAX3 alternative 3' partner (NCOA1); fusion-positive ARMS variant
+RMS_ARMS,PAX-FOXO/alt,PAX3,PAX,NCOA2,NR coactivator,rare,true,true,yes,fusion_transcript,low,,PAX3 alternative 3' partner (NCOA2)
+RMS_ARMS,PAX-FOXO/alt,PAX3,PAX,FOXO4,FOX,rare,true,true,yes,fusion_transcript,low,,rare PAX3-FOXO4 (AFX) variant; still a PAX->FOX fusion
+RMS_SSRMS,FET-TFCP2,EWSR1,FET,TFCP2,CP2 TF,subset,true,true,yes,fusion_transcript,medium,PMID:30138265,"sclerosing/spindle-cell RMS, often intraosseous; FET-TFCP2"
+RMS_SSRMS,FET-TFCP2,FUS,FET,TFCP2,CP2 TF,minority,true,true,yes,fusion_transcript,low,,FUS alternative to EWSR1 in spindle/sclerosing RMS
+RMS_SSRMS,NCOA2-fusion,SRF,MADS-box TF,NCOA2,NR coactivator,rare,true,true,yes,fusion_transcript,low,,infantile spindle cell RMS variant (SRF-NCOA2)
+SARC_CIC,CIC-DUX4,CIC,HMG-box (capicua),DUX4,homeobox,~95%,true,true,surrogate,fusion_transcript,medium,,CIC-rearranged sarcoma; t(4;19)/t(10;19); DUX4 D4Z4 macrosatellite is hard to call by RNA-seq -> ETV4/PEA3 + WT1 overexpression surrogate
+SARC_CIC,CIC-FOXO4,CIC,HMG-box (capicua),FOXO4,FOX,minority,true,true,yes,fusion_transcript,low,,t(X;19) variant
+SARC_CIC,CIC-NUTM1,CIC,HMG-box (capicua),NUTM1,NUT,rare,true,true,yes,fusion_transcript,low,,rare CIC 3' partner
+SARC_BCOR,BCOR-CCNB3,BCOR,PRC2/Polycomb,CCNB3,cyclin,majority,true,true,yes,fusion_transcript,medium,,"BCOR-rearranged sarcoma; Xp11 paracentric inversion (cryptic by FISH, RNA-seq detectable)"
+SARC_BCOR,ZC3H7B-BCOR,ZC3H7B,,BCOR,PRC2/Polycomb,minority,true,false,yes,fusion_transcript,low,,also occurs in high-grade endometrial stromal sarcoma (not entity-specific)
+SARC_BCOR,BCOR-MAML3,BCOR,PRC2/Polycomb,MAML3,Mastermind,rare,true,true,yes,fusion_transcript,low,,variant BCOR fusion
+SARC_BCOR,(none-ITD),,,,,subset,true,false,no,other,medium,,"infantile primitive myxoid mesenchymal tumor / undifferentiated round cell: BCOR internal tandem duplication (ITD), not a fusion"
+SARC_MYOEP,EWSR1-POU5F1,EWSR1,FET,POU5F1,POU-homeobox,subset,true,true,yes,fusion_transcript,medium,,soft-tissue myoepithelial carcinoma; POU5F1=OCT4 pluripotency factor
+SARC_MYOEP,FUS-POU5F1,FUS,FET,POU5F1,POU-homeobox,minority,true,true,yes,fusion_transcript,low,,FET-family alternative (FUS)
+SARC_MYOEP,EWSR1-PBX1,EWSR1,FET,PBX1,homeobox(TALE),subset,true,true,yes,fusion_transcript,low,,myoepithelioma EWSR1 partner
+SARC_MYOEP,EWSR1-ZNF444,EWSR1,FET,ZNF444,,rare,true,true,yes,fusion_transcript,low,,rare myoepithelial partner
+SARC_SMARCA4,(none),,,,,,false,false,no,other,high,,"SMARCA4/BRG1 deficiency (deletion/truncating mutation), not a fusion"

--- a/pirlygenes/data/cancer-tmb.csv
+++ b/pirlygenes/data/cancer-tmb.csv
@@ -1,0 +1,71 @@
+cancer_code,median_tmb_mut_mb,source,pmid_doi,confidence,notes
+ACC,1.0,Chalmers 2017,PMID:28420421,low,Adrenocortical; panel-based; low. Metastatic ACC higher.
+BLCA,7.1,Lawrence 2013,PMID:23770567,high,WES median; APOBEC-driven long tail.
+BRCA,1.2,Lawrence 2013,PMID:23770567,high,WES median; higher in basal/HER2; MSI rare.
+CESC,5.0,Lawrence 2013,PMID:23770567,medium,Cervical squamous; APOBEC + HPV; wide range.
+CHOL,2.0,Chalmers 2017,PMID:28420421,medium,Cholangiocarcinoma; panel ~1.8-2.4.
+COAD,3.1,Lawrence 2013,PMID:23770567,high,Colon MSS median; MSI-H/POLE subset >40.
+DLBC,3.3,Lawrence 2013,PMID:23770567,high,DLBCL WES median.
+ESCA,4.0,Lawrence 2013,PMID:23770567,medium,ESCC vs EAC differ; range wide.
+GBM,2.2,Lawrence 2013,PMID:23770567,high,WES median; post-temozolomide/MMR-deficient subset hypermutates.
+HNSC,3.9,Lawrence 2013,PMID:23770567,high,WES median; HPV+ vs HPV- differ slightly.
+KICH,0.7,Chalmers 2017,PMID:28420421,low,Kidney chromophobe; very low; among lowest renal subtypes.
+KIRC,1.9,Lawrence 2013,PMID:23770567,high,Kidney clear cell WES median.
+KIRP,1.3,Chalmers 2017,PMID:28420421,low,Kidney papillary; panel approx ~1-1.5.
+LAML,0.4,Lawrence 2013,PMID:23770567,high,AML WES median; among lowest of all cancers.
+LGG,1.0,Lawrence 2013,PMID:23770567,medium,IDH-mutant low; temozolomide recurrences hypermutate.
+LIHC,4.0,Chalmers 2017,PMID:28420421,medium,Liver HCC; panel/WES ~3-4.
+LUAD,8.1,Lawrence 2013,PMID:23770567,high,Lung adeno WES median; smoking-dependent (never-smokers far lower).
+LUSC,9.9,Lawrence 2013,PMID:23770567,high,Lung squamous WES median; smoking signature.
+MESO,1.8,Chalmers 2017,PMID:28420421,medium,Mesothelioma; low; panel ~1.1-2.
+OV,1.7,Lawrence 2013,PMID:23770567,high,Ovarian serous WES median; HRD/SCNA-driven not SNV.
+PAAD,2.1,Chalmers 2017,PMID:28420421,medium,Pancreatic adeno panel median ~2.0-2.4; MSI rare.
+PCPG,0.5,Chalmers 2017,PMID:28420421,low,Pheo/paraganglioma; very low; among lowest.
+PRAD,0.7,Lawrence 2013,PMID:23770567,high,Prostate adeno WES median; CDK12/MMR subset higher.
+READ,3.1,Lawrence 2013,PMID:23770567,medium,Treated as colorectal; MSI-H subset much higher.
+SKCM,12.9,Lawrence 2013,PMID:23770567,high,Cutaneous melanoma WES median; UV signature; highest common solid tumor.
+STAD,5.0,Chalmers 2017,PMID:28420421,medium,Stomach intestinal type; EBV+ / MSI-H subsets much higher.
+TGCT,0.5,Chalmers 2017,PMID:28420421,low,Testicular germ cell; very low SNV TMB; aneuploidy-driven.
+THCA,0.4,Chalmers 2017,PMID:28420421,high,Thyroid papillary; among lowest; single-driver BRAF/RAS.
+THYM,0.5,Chalmers 2017,PMID:28420421,low,Thymoma; very low; among lowest in TCGA.
+UCEC,2.5,Lawrence 2013,PMID:23770567,high,Endometrioid median; POLE-ultramutated and MSI-H subsets very high.
+UCS,2.5,Chalmers 2017,PMID:28420421,low,Uterine carcinosarcoma; approx; small cohorts.
+UVM,0.34,Wu 2019,DOI:10.21037/atm.2019.09.49,high,Uveal melanoma; lowest median across TCGA; GNAQ/GNA11-driven no UV.
+SARC_LMS,2.2,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Leiomyosarcoma; complex-karyotype STS; low SNV TMB.
+SARC_DDLPS,1.5,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Dedifferentiated liposarcoma; MDM2/CDK4 amplicon-driven; low TMB.
+SARC_UPS,2.2,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Undifferentiated pleomorphic sarcoma; among higher STS TMB.
+SARC_MYXFIB,2.2,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Myxofibrosarcoma ~2 mut/Mb.
+SARC_SYN,1.7,TCGA-SARC 2017,DOI:10.1016/j.cell.2017.10.014,medium,Synovial sarcoma; lowest STS TMB; SS18-SSX fusion-driven simple karyotype.
+SARC_MPNST,2.5,Chalmers 2017,PMID:28420421,low,MPNST; panel ~2.5.
+OS,1.2,Grobner 2018,PMID:29489754,medium,Osteosarcoma pediatric WGS ~1.2; high SV/chromothripsis burden.
+EWS,0.6,Grobner 2018,PMID:29489754,high,Ewing sarcoma ~0.6; EWSR1-FLI1 fusion-driven; very few SNVs.
+RMS_ERMS,0.8,Grobner 2018,PMID:29489754,low,Embryonal RMS; low pediatric TMB; RAS-pathway; subtype median approximate.
+RMS_ARMS,0.4,Grobner 2018,PMID:29489754,low,Alveolar RMS; PAX3/7-FOXO1 fusion-driven; very low SNV burden; approximate.
+CHON,0.9,Meijer 2025,PMC11949235,low,Chondrosarcoma; low TMB; IDH1/2-driven.
+CHOR,0.53,Chordoma WGS,PMC11172617,medium,Chordoma skull-base WGS; brachyury-driven; rare MMR cases hypermutate.
+NBL,0.6,Grobner 2018,PMID:29489754,high,Neuroblastoma ~0.6; relapse higher.
+WILMS,0.2,Grobner 2018,PMID:29489754,low,Wilms tumor; very low pediatric TMB; per-entity median approximate.
+RT,0.1,Lawrence 2013,PMID:23770567,medium,Rhabdoid tumor ~0.1; SMARCB1-driven near-silent genome.
+ATRT,0.2,Grobner 2018,PMID:29489754,medium,AT/RT; lowest-mutation pediatric brain tumor; SMARCB1/SMARCA4-driven.
+MBL,0.3,Lawrence 2013,PMID:23770567,high,Medulloblastoma ~0.3; rare germline-MMR/POLE hypermutant cases.
+RB,0.085,Retinoblastoma WGS,PMC7918943,medium,Retinoblastoma ~0.085 substitutions/Mb; RB1-loss driven near-silent.
+HEPB,0.02,Grobner 2018,PMID:29489754,medium,Hepatoblastoma; lowest pediatric TMB; CTNNB1-driven.
+MM,1.6,Lawrence 2013,PMID:23770567,high,Multiple myeloma WES median ~1.6; increases at relapse.
+CLL,0.6,Lawrence 2013,PMID:23770567,high,CLL WES median ~0.6; low.
+MCL,1.0,Bea 2013,PMID:23770587,medium,Mantle cell lymphoma WES ~1; approximate per-Mb.
+FL,,,,none,Follicular lymphoma; AID/SHM-driven; no clean published per-Mb median.
+HL,2.0,Wienand 2019,PMID:30108156,low,Hodgkin; panel TMB inflated vs WES; approximate.
+BL,2.0,Love 2012,PMID:23143597,medium,Burkitt; AID/MYC-driven moderate burden; ~2 approximate WES.
+B_ALL,0.3,Grobner 2018,PMID:29489754,low,B-ALL; very low pediatric TMB; CMMRD/relapse cases far higher.
+T_ALL,0.5,Grobner 2018,PMID:29489754,low,T-ALL; low; slightly higher than B-ALL; approximate.
+MDS,0.3,Walter 2013,PMC3897298,medium,MDS ~9 somatic mutations/exome; rises with IPSS risk.
+MPN,,,,none,Myeloproliferative neoplasm; driver-defined (JAK2/CALR/MPL); no published per-Mb median.
+CML,,,,none,Chronic myeloid leukemia; BCR-ABL1-defined; very few additional mutations in chronic phase.
+CTCL,3.0,Park 2021,PMID:33574607,low,CTCL/mycosis fungoides; UV-signature; stage-dependent; advanced much higher.
+PANNET,1.9,Backman 2021,PMID:34326338,medium,Pancreatic NET well-diff median ~1.9 (vs NEC ~5.0); low.
+SCLC,8.6,George 2015,PMID:26168399,high,Small cell lung; high ~8.6; smoking signature.
+MEC,5.3,Knepper 2019,PMID:30482774,medium,Merkel cell carcinoma median ~5.3; bimodal MCPyV-neg(UV) high vs MCPyV-pos low.
+MTC,,,,none,Medullary thyroid; single-driver RET/RAS; no clean published per-Mb median.
+ADCC,0.31,Ho 2013,PMID:23685749,high,Adenoid cystic carcinoma ~0.31; MYB-NFIB fusion-driven; very low.
+NPC,0.95,Nasopharyngeal WES,PMC9498130,medium,Nasopharyngeal carcinoma median ~0.95-1.0; EBV-driven low SNV burden.
+NUTM,,,,none,NUT carcinoma; BRD4-NUT fusion-driven near-silent; no well-cited per-Mb median.

--- a/pirlygenes/data/cancer-type-registry.csv
+++ b/pirlygenes/data/cancer-type-registry.csv
@@ -1,131 +1,131 @@
-code,name,family,primary_tissue,primary_template,parent_code,subtype_key,expression_source,source_cohort,source_pmid,notes,mixture_cohort
-ACC,Adrenocortical Carcinoma,endocrine,adrenal_cortex,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False
-BLCA,Bladder Urothelial Carcinoma,carcinoma-gu,bladder,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False
-BRCA,Breast Invasive Carcinoma,carcinoma-breast,breast,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Umbrella — use PAM50 subtypes for subtype-aware inference,False
-BRCA_LumA,Luminal A,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,ER+/PR+ HER2-; endocrine-first,False
-BRCA_LumB,Luminal B,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,ER+ proliferative; endocrine + chemo,False
-BRCA_HER2,HER2-enriched,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,ERBB2-amp; HER2-directed therapy,False
-BRCA_Basal,Basal-like,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,TNBC proxy; chemo + sacituzumab,False
-BRCA_Normal,Normal-like,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,rare; low-confidence stratum,False
-CESC,Cervical Squamous / Adenocarcinoma,carcinoma-gu,cervix,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HPV-driven,False
-CHOL,Cholangiocarcinoma,carcinoma-gi,bile_duct,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Intrahepatic + extrahepatic + gallbladder lumped,False
-COAD,Colon Adenocarcinoma,carcinoma-gi,colon,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,CMS1-4 molecular subtypes + MSI-H axis,False
-DLBC,Diffuse Large B-cell Lymphoma,heme-bcell,lymph_node,heme_nodal,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,ABC vs GCB subtypes,False
-ESCA,Esophageal Carcinoma,carcinoma-gi,esophagus,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Adenocarcinoma + squamous lumped — biologically distinct,False
-GBM,Glioblastoma Multiforme,cns,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-wildtype per 2021 WHO; mes/classical/proneural subtypes,False
-HNSC,Head and Neck Squamous Cell Carcinoma,carcinoma-head-neck,pharynx,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HPV+ vs HPV- — two distinct diseases,False
-HNSC_HPV_pos,HPV+ HNSC,carcinoma-head-neck,oropharynx,solid_primary,HNSC,,TCGA/HPV,TREEHOUSE_POLYA_25_01_TCGA_HNSC_HPV,PMID:25631445,Better prognosis; p16+; E6/E7-driven,False
-HNSC_HPV_neg,HPV- HNSC,carcinoma-head-neck,oral_cavity,solid_primary,HNSC,,TCGA/HPV,TREEHOUSE_POLYA_25_01_TCGA_HNSC_HPV,PMID:25631445,Smoking/alcohol; TP53-mutant,False
-KICH,Kidney Chromophobe,carcinoma-gu,kidney,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False
-KIRC,Kidney Renal Clear Cell,carcinoma-gu,kidney,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,VHL-driven,False
-KIRP,Kidney Renal Papillary,carcinoma-gu,kidney,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Type 1 (MET) + Type 2 lumped,False
-LAML,Acute Myeloid Leukemia,heme-myeloid,bone_marrow,heme_marrow,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Umbrella — see APL / ELN subtypes,False
-LAML_APL,Acute Promyelocytic Leukemia,heme-myeloid,bone_marrow,heme_marrow,LAML,apl,BEATAML,BEATAML_OHSU_2022,PMID:36109543,PML-RARA; ATRA + ATO chemo-free cure,False
-LAML_ELN_Fav,AML ELN2017 Favorable,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,NPM1+/FLT3- or CBF; chemo-sensitive,False
-LAML_ELN_Int,AML ELN2017 Intermediate,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,Mixed; individualized therapy,False
-LAML_ELN_Adv,AML ELN2017 Adverse,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,TP53/complex karyo; transplant-first,False
-LGG,Lower Grade Glioma,cns,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-mutant (per 2021 WHO); vorasidenib-eligible,False
-LIHC,Liver Hepatocellular Carcinoma,carcinoma-gi,liver,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HBV/HCV/NASH etiologies,False
-LUAD,Lung Adenocarcinoma,carcinoma-lung,lung,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,EGFR / KRAS / STK11-KEAP1 axes — therapy-gating,False
-LUAD_EGFR,EGFR-mutant LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Osimertinib-first; often never-smoker,False
-LUAD_KRAS,KRAS-mutant LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Sotorasib (G12C); smoker-associated,False
-LUAD_STK11,STK11/KEAP1 LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Cold-immune; IO-refractory axis,False
-LUSC,Lung Squamous Cell Carcinoma,carcinoma-lung,lung,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False
-MESO,Mesothelioma,carcinoma-mesothelial,pleura,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Pleural + peritoneal; BAP1/NF2,False
-OV,Ovarian Serous Cystadenocarcinoma,carcinoma-gu,ovary,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HGSOC-dominant; BRCA/HRD + PARP,False
-PAAD,Pancreatic Adenocarcinoma,carcinoma-gi,pancreas,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Adenocarcinoma only; panNET/acinar separate,False
-PCPG,Pheochromocytoma and Paraganglioma,endocrine,adrenal_medulla,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Extra-adrenal paragangliomas + pheos,False
-PRAD,Prostate Adenocarcinoma,carcinoma-gu,prostate,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,AR-driven; CRPC / NEPC disease states,False
-READ,Rectum Adenocarcinoma,carcinoma-gi,rectum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Similar to COAD; MSI-H matters,False
-SARC,Sarcoma,sarcoma,soft_tissue,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Umbrella — soft-tissue only (no OS/Ewing/RMS),True
-SKCM,Skin Cutaneous Melanoma,melanoma,skin,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,BRAF/NRAS/KIT/triple-WT mutation classes,False
-STAD,Stomach Adenocarcinoma,carcinoma-gi,stomach,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,EBV+ / MSI-H / CIN / GS molecular subtypes,False
-TGCT,Testicular Germ Cell Tumors,germ-cell,testis,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Seminoma + non-seminoma; chemo-cure,False
-THCA,Thyroid Carcinoma,endocrine,thyroid,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Papillary-dominant; follicular / anaplastic separate; medullary distinct,False
-THYM,Thymoma,thymic,thymus,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False
-UCEC,Uterine Corpus Endometrial Carcinoma,carcinoma-gu,endometrium,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Endometrioid + serous — different therapy,False
-UCS,Uterine Carcinosarcoma,carcinoma-gu,endometrium,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Mixed epithelial + sarcomatoid,False
-UVM,Uveal Melanoma,melanoma,eye,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,GNAQ/GNA11; liver met tropism,False
-SARC_LMS,Leiomyosarcoma,sarcoma,smooth_muscle,primary_smooth_muscle,SARC,leiomyosarcoma,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24071852,Uterine + extrauterine; chemo + trabectedin,False
-SARC_DDLPS,Dedifferentiated Liposarcoma,sarcoma,adipose,primary_adipose,SARC,dedifferentiated_liposarcoma,GEO,GSE75885_DELESPAUL_2017,PMID:24071852,MDM2-amp; brigimadlin / milademetan trials,False
-SARC_WDLPS,Well-Differentiated Liposarcoma,sarcoma,adipose,primary_adipose,SARC,dedifferentiated_liposarcoma,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,MDM2-amp; surgery-first,False
-SARC_MYXLPS,Myxoid Liposarcoma,sarcoma,adipose,primary_adipose,SARC,myxoid_liposarcoma,GEO,GSE30929_SINGER_2007_LPS,PMID:22241786,"FUS-DDIT3; NY-ESO-1 TCR-T target. v5.6.0: Singer 2007 MSKCC GPL96 microarray (n=28 = 17 classic myxoid + 11 myxoid/round-cell which is the high-grade WHO variant of the same FUS::DDIT3-fusion entity). Biology validates: FABP4 2799, ADIPOQ 917, PPARG 424 (adipogenic), FUS+DDIT3 both ~165 (fusion partners both expressed), SOX9 122 (chondroid), STAT3 253 + JAK1 207 (FUS-DDIT3/JAK-STAT axis).",False
-SARC_SYN,Synovial Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,synovial_sarcoma,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24071852,SS18-SSX; afami-cel (MAGE-A4 TCR-T) approved,False
-SARC_DSRCT,Desmoplastic Small Round Cell Tumor,sarcoma,peritoneum,primary_peritoneal_mesenchymal,SARC,dsrct,Treehouse,TREEHOUSE_POLYA_25_01,,EWSR1-WT1; WT1 TCR-T trials,False
-SARC_GIST,Gastrointestinal Stromal Tumor,sarcoma,gi_wall,primary_gi_wall,SARC,gist,TCGA,TREEHOUSE_POLYA_25_01,PMID:24071852,KIT/PDGFRA; imatinib ladder + avapritinib,False
-SARC_MPNST,Malignant Peripheral Nerve Sheath Tumor,sarcoma,nerve_sheath,primary_nerve_sheath,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,NF1-associated; SMARCB1/EED/SUZ12 loss,False
-SARC_ANGIO,Angiosarcoma,sarcoma,vascular_endothelium,primary_vascular,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Tumor IS endothelial — constrained deduct,False
-SARC_UPS,Undifferentiated Pleomorphic Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24071852,Previously MFH; diagnosis of exclusion,False
-OS,Osteosarcoma,pediatric-bone,bone,primary_bone,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:32427717,Not in TCGA — TARGET OS; GD2/HER2 trials,False
-EWS,Ewing Sarcoma,pediatric-bone,bone,primary_bone,,,Treehouse,TREEHOUSE_POLYA_25_01,,EWSR1-FLI1/ERG; CD99+; VDC/IE,False
-CHON,Chondrosarcoma,sarcoma,cartilage,primary_cartilage,,,GEO,GSE299759_MEIJER_2026,,IDH1/IDH2 + EXT1/EXT2; conventional / mesenchymal / dediff variants,False
-CHOR,Chordoma,rare,notochord,primary_notochord,,,Treehouse/RiboD,TREEHOUSE_RIBOD_25_01,,T (brachyury) defining; skull-base / sacral,False
-RMS_ERMS,Embryonal Rhabdomyosarcoma,pediatric-soft,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24436047,MYOD1/MYOG; better prognosis than ARMS,False
-RMS_ARMS,Alveolar Rhabdomyosarcoma,pediatric-soft,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24436047,PAX3-FOXO1 or PAX7-FOXO1; aggressive,False
-NBL,Neuroblastoma,pediatric-net,sympathetic_ganglia,primary_neural_crest,,,TARGET,TARGET_NBL_2018,PMID:30019323,MYCN amp vs non-amp — therapy-gating,False
-NBL_MYCN_amp,Neuroblastoma MYCN-amplified,pediatric-net,sympathetic_ganglia,primary_neural_crest,NBL,,TARGET,TARGET_NBL_2018,PMID:30019323,High-risk; dinutuximab + chemo,False
-NBL_MYCN_nonamp,Neuroblastoma MYCN-non-amplified,pediatric-net,sympathetic_ganglia,primary_neural_crest,NBL,,TARGET,TARGET_NBL_2018,PMID:30019323,Intermediate/low-risk; better prognosis,False
-WILMS,Wilms Tumor / Nephroblastoma,pediatric-embryonal,kidney,primary_embryonal,,,TARGET,TARGET_WT_2015,PMID:25622910,WT1/CTNNB1/AMER1; favorable vs anaplastic,False
-RT,Rhabdoid Tumor,pediatric-embryonal,kidney_cns_soft,primary_embryonal,,,TARGET,TARGET_RT_2017,PMID:29568089,SMARCB1 loss; malignant; CNS AT/RT subset,False
-ATRT,Atypical Teratoid/Rhabdoid Tumor,pediatric-cns,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCB1 loss; CNS-only rhabdoid,False
-MBL,Medulloblastoma,pediatric-cns,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SHH / WNT / Group 3 / Group 4 subgroups,False
-MBL_WNT,Medulloblastoma WNT,pediatric-cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Excellent prognosis; CTNNB1,False
-MBL_SHH,Medulloblastoma SHH,pediatric-cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,PTCH1/SMO; vismodegib-eligible,False
-MBL_G3,Medulloblastoma Group 3,pediatric-cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,MYC-amp; worst prognosis,False
-MBL_G4,Medulloblastoma Group 4,pediatric-cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Most common; MYCN/CDK6,False
-RB,Retinoblastoma,pediatric-eye,retina,solid_primary,,,Treehouse/RiboD,TREEHOUSE_RIBOD_25_01,,RB1 loss; pediatric eye,False
-HEPB,Hepatoblastoma,pediatric-liver,liver,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,CTNNB1; pediatric liver,False
-CLL,Chronic Lymphocytic Leukemia,heme-bcell,peripheral_blood,heme_blood,,,CLL-map,CLLMAP_2022,,IGHV mutation status; BTK/BCL2 inhibitors,False
-MCL,Mantle Cell Lymphoma,heme-bcell,lymph_node,heme_nodal,,,GEO,GSE271664_BODOR_2025,,CCND1-IgH; blastoid variant aggressive,False
-FL,Follicular Lymphoma,heme-bcell,lymph_node,heme_nodal,,,GEO,GSE142334_FL_TFL_2021,PMID:33569544,BCL2-IgH; indolent; transforms to DLBCL,False
-HL,Hodgkin Lymphoma,heme-bcell,lymph_node,heme_nodal,,,GEO,GSE120328_LAMPRECHT_2018,PMID:30546079,Reed-Sternberg cells; CD30+; brentuximab,False
-BL,Burkitt Lymphoma,heme-bcell,lymph_node,heme_nodal,,,CGCI,CGCI_BLGSP,,MYC-Ig translocation; endemic/sporadic/immunodef,False
-MM,Multiple Myeloma,heme-plasma,bone_marrow,heme_marrow,,,CoMMpass,MMRF_COMMPASS,PMID:30337648,Plasma-cell malignancy; BCMA/FCRH5 bispecifics,False
-MDS,Myelodysplastic Syndrome,heme-myeloid,bone_marrow,heme_marrow,,,GEO,GSE114922_SHIOZAWA_2018,,Pre-leukemic; IPSS-R risk; luspatercept,False
-MPN,Myeloproliferative Neoplasms,heme-myeloid,bone_marrow,heme_marrow,,,GEO,GSE283710_WASHU_2024,,PV / ET / MF; JAK2 V617F,False
-CML,Chronic Myeloid Leukemia,heme-myeloid,peripheral_blood,heme_blood,,,GEO,GSE100026_DING_2017,,BCR-ABL; imatinib-cure paradigm,False
-B_ALL,B-cell Acute Lymphoblastic Leukemia,heme-bcell,bone_marrow,heme_marrow,,,TARGET,TARGET_ALL_2018,PMID:30046113,BCR-ABL-like + other fusions; blinatumomab / tisa-cel,False
-T_ALL,T-cell Acute Lymphoblastic Leukemia,heme-tcell,bone_marrow,heme_marrow,,,TARGET,TARGET_ALL_2018,PMID:30046113,NOTCH1; nelarabine,False
-CTCL,Cutaneous T-cell Lymphoma,heme-tcell,skin,heme_skin,,,GEO,GSE171811_ECCITE_CTCL,,Mycosis fungoides / Sezary; mogamulizumab,False
-PANNET,Pancreatic Neuroendocrine Tumor,net,pancreas,solid_primary,,,GEO,GSE118014_ALVAREZ_2018,PMID:30296526,"PanNET — Alvarez 2018 (GSE118014, 33 samples log2-TPM); octreotide/lanreotide, 177Lu-DOTATATE, everolimus",False
-MID_NET,Midgut / Small Bowel Carcinoid,net,small_intestine,solid_primary,,,GEO,GSE98894_ALVAREZ_2018_NET,PMID:30013182,"Serotonin-secreting; 177Lu-DOTATATE; reference cohort is GSE98894 liver metastases (not primary), tagged tumor_origin=metastasis",False
-REC_NET,Rectal Neuroendocrine Tumor,net,rectum,solid_primary,,,GEO,GSE98894_ALVAREZ_2018_NET,PMID:30013182,Most common GI-NET in some Asian cohorts; reference is GSE98894 liver mets (tumor_origin=metastasis),False
-LUNG_NET_LC,Lung Typical/Atypical Carcinoid,net,lung,solid_primary,,,GEO,DRMETRICS_ALCALA_2019_LNEN,PMID:31431620,Low-grade lung NE; distinct from SCLC,False
-LUNG_NET_LCNEC,Large-Cell Neuroendocrine Carcinoma Lung,net,lung,solid_primary,,,GEO,DRMETRICS_ALCALA_2019_LNEN,PMID:33203751,Intermediate between carcinoid and SCLC,False
-SCLC,Small Cell Lung Cancer,net,lung,solid_primary,,,University of Cologne,SCLC_UCOLOGNE_2015,,Rudin/George 2015; ASCL1/NEUROD1/POU2F3/YAP1 subtypes,False
-SCLC_ASCL1,SCLC ASCL1-dominant,net,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Classic neuroendocrine; DLL3 target,False
-SCLC_NEUROD1,SCLC NEUROD1-dominant,net,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Neural; ASCL1-low,False
-SCLC_POU2F3,SCLC POU2F3-dominant,net,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Tuft-cell-like; non-NE,False
-SCLC_YAP1,SCLC YAP1-dominant,net,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Inflamed; proposed IO-responsive,False
-MEC,Merkel Cell Carcinoma,net,skin,solid_primary,,,curated,LITERATURE_CURATED,,MCPyV+ vs UV; avelumab-sensitive,False
-NUTM,NUT Carcinoma,rare,midline_structures,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,NUT-BRD3/4 fusion; midline aggressive,False
-ACINIC,Acinic Cell Carcinoma,salivary,salivary_gland,solid_primary,,,curated,LITERATURE_CURATED,,Salivary gland low-grade,False
-ADCC,Adenoid Cystic Carcinoma,salivary,salivary_gland,solid_primary,,,GEO,GSE294016_BARTL_2025_SGC,PMID:40506428,MYB-NFIB; salivary + lacrimal + breast,False
-MTC,Medullary Thyroid Carcinoma,endocrine,thyroid_c_cell,solid_primary,,,GEO,GSE32662_PRINGLE_2012_MTC,GSE32662,Calcitonin; RET-driven; separate from TCGA THCA (follicular-cell). Pringle 2012 GPL6480 Agilent microarray TPM-proxy (n=52 hybridizations across 49 primary cases). CALCA p95 ~3400 TPM-proxy confirms cohort.,False
-NPC,Nasopharyngeal Carcinoma,carcinoma-head-neck,nasopharynx,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,EBV-driven; distinct from TCGA HNSC,False
-HCL,Hairy Cell Leukemia,heme-bcell,spleen_marrow,heme_marrow,,,curated,LITERATURE_CURATED,,BRAF V600E; vemurafenib effective,False
-PCN,Plasmacytoma,heme-plasma,soft_tissue,solid_primary,MM,,curated,LITERATURE_CURATED,,Solitary plasma-cell mass (solitary bone / extramedullary),False
-SARC_EPITH,Epithelioid Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:32105697,SMARCB1/INI1 loss; tazemetostat (EZH2 inhibitor) approved 2020,False
-SARC_DFSP,Dermatofibrosarcoma Protuberans,sarcoma,skin,solid_primary,SARC,,curated,LITERATURE_CURATED,PMID:19805687,COL1A1-PDGFB fusion; imatinib approved; surgery-first,False
-SARC_ASPS,Alveolar Soft Part Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:36516078,ASPSCR1-TFE3; atezolizumab approved 2022; anti-angiogenic TKIs,False
-SARC_CCS,Clear Cell Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,GEO,GSE248751_HUMAN_CCS_2023,PMID:14576204,EWSR1-ATF1 fusion; melanoma-like biology but not BRAF-driven,False
-SARC_IFS,Infantile Fibrosarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:29466156,ETV6-NTRK3; larotrectinib / entrectinib approved,False
-SARC_EHE,Epithelioid Hemangioendothelioma,sarcoma,vascular_endothelium,primary_vascular,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:22265237,WWTR1-CAMTA1 (majority) or YAP1-TFE3; indolent-to-aggressive,False
-SARC_PEC,PEComa (Perivascular Epithelioid Cell Tumor),sarcoma,soft_tissue,solid_primary,SARC,,GEO,GSE328026_PECOMA_2026,PMID:34133196,TSC1/TSC2 loss or TFE3 fusion; nab-sirolimus (FYARRO) approved 2021,False
-SARC_KS,Kaposi Sarcoma,sarcoma,vascular_endothelium,primary_vascular,SARC,,GEO,GSE241095_KS_SKIN_2023,PMID:7997879,HHV8-driven endothelial; immune-reconstitution / chemo,False
-SARC_MYXFIB,Myxofibrosarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:21304266,Previously MFH myxoid-type; elderly limbs; surgery + chemo,False
-SARC_SFT,Solitary Fibrous Tumor,sarcoma,soft_tissue,solid_primary,SARC,,curated,LITERATURE_CURATED,PMID:23313955,NAB2-STAT6 fusion; previously hemangiopericytoma,False
-SARC_IMT,Inflammatory Myofibroblastic Tumor,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:20147977,"ALK fusion in ~50% (crizotinib), also ROS1/NTRK/RET fusion subsets",False
-GCTB,Giant Cell Tumor of Bone,sarcoma,bone,primary_bone,,,curated,LITERATURE_CURATED,PMID:23940309,H3F3A G34W mutation; denosumab approved for unresectable,False
-ESS_LG,Low-grade Endometrial Stromal Sarcoma,sarcoma,endometrium,solid_primary,,,curated,LITERATURE_CURATED,PMID:11445439,JAZF1-SUZ12 or similar; hormone-responsive; aromatase inhibitors,False
-ESS_HG,High-grade Endometrial Stromal Sarcoma,sarcoma,endometrium,solid_primary,,,curated,LITERATURE_CURATED,PMID:22354060,YWHAE-NUTM2 or BCOR rearrangement; aggressive; chemo,False
-SARC_LGFMS,Low-grade Fibromyxoid Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,GEO,GSE75885_DELESPAUL_2017,PMID:17592252,FUS-CREB3L2 or FUS-CREB3L1; late recurrences,False
-SARC_EMC,Extraskeletal Myxoid Chondrosarcoma,sarcoma,soft_tissue,solid_primary,SARC,,curated,LITERATURE_CURATED,PMID:17934065,EWSR1-NR4A3 (majority); distinct from skeletal chondrosarcoma,False
-SARC_PLEOLPS,Pleomorphic Liposarcoma,sarcoma,adipose,primary_adipose,SARC,,GEO,GSE75885_DELESPAUL_2017,PMID:18703001,No pathognomonic fusion; aggressive; differs from WDLPS/DDLPS/myxoid,False
-RMS_PRMS,Pleomorphic Rhabdomyosarcoma,sarcoma,skeletal_muscle,primary_skeletal_muscle,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:18829983,Adult; distinct from pediatric ERMS/ARMS; no fusion,False
-RMS_SSRMS,Spindle Cell / Sclerosing Rhabdomyosarcoma,pediatric-soft,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24054308,MYOD1 (congenital) or VGLL2/NCOA2 (infantile); distinct from ERMS/ARMS,False
-SARC_LPS_UNSPEC,Liposarcoma (Unspecified / Aggregate),sarcoma,adipose,primary_adipose,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Treehouse v25.01 LPS aggregate (n=92); DDLPS/WDLPS/MYXLPS mixed,False
-SARC_CIC,CIC-rearranged Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Ewing-like undifferentiated round cell sarcoma (n=5 Treehouse); CIC-DUX4 majority; ETV4/PEA3 + WT1 activation; more aggressive than Ewing,False
-SARC_BCOR,BCOR-rearranged Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Undifferentiated round cell sarcoma (n=2 Treehouse); BCOR-CCNB3 (Xp11) majority; BCOR-ITD in infantile,False
-SARC_MYOEP,Soft Tissue Myoepithelial Carcinoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Myoepithelioma/myoepithelial carcinoma (n=5 Treehouse); EWSR1-POU5F1/PBX1 or FUS-POU5F1,False
-SARC_SMARCA4,SMARCA4-deficient Thoracic Sarcoma,sarcoma,thorax,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCA4/BRG1 loss (n=13 Treehouse); undifferentiated thoracic; smoking-associated; not fusion-driven,False
+code,name,family,primary_tissue,primary_template,parent_code,subtype_key,expression_source,source_cohort,source_pmid,notes,mixture_cohort,pediatric,differentiation
+ACC,Adrenocortical Carcinoma,endocrine,adrenal_cortex,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False,False,
+BLCA,Bladder Urothelial Carcinoma,carcinoma-gu,bladder,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False,False,
+BRCA,Breast Invasive Carcinoma,carcinoma-breast,breast,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Umbrella — use PAM50 subtypes for subtype-aware inference,False,False,
+BRCA_LumA,Luminal A,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,ER+/PR+ HER2-; endocrine-first,False,False,
+BRCA_LumB,Luminal B,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,ER+ proliferative; endocrine + chemo,False,False,
+BRCA_HER2,HER2-enriched,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,ERBB2-amp; HER2-directed therapy,False,False,
+BRCA_Basal,Basal-like,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,TNBC proxy; chemo + sacituzumab,False,False,
+BRCA_Normal,Normal-like,carcinoma-breast,breast,solid_primary,BRCA,,TCGA/PAM50,TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50,PMID:26451490,rare; low-confidence stratum,False,False,
+CESC,Cervical Squamous / Adenocarcinoma,carcinoma-gu,cervix,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HPV-driven,False,False,
+CHOL,Cholangiocarcinoma,carcinoma-gi,bile_duct,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Intrahepatic + extrahepatic + gallbladder lumped,False,False,
+COAD,Colon Adenocarcinoma,carcinoma-gi,colon,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,CMS1-4 molecular subtypes + MSI-H axis,False,False,
+DLBC,Diffuse Large B-cell Lymphoma,heme-bcell,lymph_node,heme_nodal,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,ABC vs GCB subtypes,False,False,
+ESCA,Esophageal Carcinoma,carcinoma-gi,esophagus,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Adenocarcinoma + squamous lumped — biologically distinct,False,False,
+GBM,Glioblastoma Multiforme,cns,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-wildtype per 2021 WHO; mes/classical/proneural subtypes,False,False,
+HNSC,Head and Neck Squamous Cell Carcinoma,carcinoma-head-neck,pharynx,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HPV+ vs HPV- — two distinct diseases,False,False,
+HNSC_HPV_pos,HPV+ HNSC,carcinoma-head-neck,oropharynx,solid_primary,HNSC,,TCGA/HPV,TREEHOUSE_POLYA_25_01_TCGA_HNSC_HPV,PMID:25631445,Better prognosis; p16+; E6/E7-driven,False,False,
+HNSC_HPV_neg,HPV- HNSC,carcinoma-head-neck,oral_cavity,solid_primary,HNSC,,TCGA/HPV,TREEHOUSE_POLYA_25_01_TCGA_HNSC_HPV,PMID:25631445,Smoking/alcohol; TP53-mutant,False,False,
+KICH,Kidney Chromophobe,carcinoma-gu,kidney,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False,False,
+KIRC,Kidney Renal Clear Cell,carcinoma-gu,kidney,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,VHL-driven,False,False,
+KIRP,Kidney Renal Papillary,carcinoma-gu,kidney,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Type 1 (MET) + Type 2 lumped,False,False,
+LAML,Acute Myeloid Leukemia,heme-myeloid,bone_marrow,heme_marrow,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Umbrella — see APL / ELN subtypes,False,False,
+LAML_APL,Acute Promyelocytic Leukemia,heme-myeloid,bone_marrow,heme_marrow,LAML,apl,BEATAML,BEATAML_OHSU_2022,PMID:36109543,PML-RARA; ATRA + ATO chemo-free cure,False,False,
+LAML_ELN_Fav,AML ELN2017 Favorable,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,NPM1+/FLT3- or CBF; chemo-sensitive,False,False,
+LAML_ELN_Int,AML ELN2017 Intermediate,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,Mixed; individualized therapy,False,False,
+LAML_ELN_Adv,AML ELN2017 Adverse,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,TP53/complex karyo; transplant-first,False,False,
+LGG,Lower Grade Glioma,cns,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-mutant (per 2021 WHO); vorasidenib-eligible,False,False,
+LIHC,Liver Hepatocellular Carcinoma,carcinoma-gi,liver,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HBV/HCV/NASH etiologies,False,False,
+LUAD,Lung Adenocarcinoma,carcinoma-lung,lung,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,EGFR / KRAS / STK11-KEAP1 axes — therapy-gating,False,False,
+LUAD_EGFR,EGFR-mutant LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Osimertinib-first; often never-smoker,False,False,
+LUAD_KRAS,KRAS-mutant LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Sotorasib (G12C); smoker-associated,False,False,
+LUAD_STK11,STK11/KEAP1 LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Cold-immune; IO-refractory axis,False,False,
+LUSC,Lung Squamous Cell Carcinoma,carcinoma-lung,lung,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False,False,
+MESO,Mesothelioma,carcinoma-mesothelial,pleura,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Pleural + peritoneal; BAP1/NF2,False,False,
+OV,Ovarian Serous Cystadenocarcinoma,carcinoma-gu,ovary,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HGSOC-dominant; BRCA/HRD + PARP,False,False,
+PAAD,Pancreatic Adenocarcinoma,carcinoma-gi,pancreas,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Adenocarcinoma only; panNET/acinar separate,False,False,
+PCPG,Pheochromocytoma and Paraganglioma,endocrine,adrenal_medulla,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Extra-adrenal paragangliomas + pheos,False,False,
+PRAD,Prostate Adenocarcinoma,carcinoma-gu,prostate,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,AR-driven; CRPC / NEPC disease states,False,False,
+READ,Rectum Adenocarcinoma,carcinoma-gi,rectum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Similar to COAD; MSI-H matters,False,False,
+SARC,Sarcoma,sarcoma,soft_tissue,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Umbrella — soft-tissue only (no OS/Ewing/RMS),True,False,
+SKCM,Skin Cutaneous Melanoma,melanoma,skin,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,BRAF/NRAS/KIT/triple-WT mutation classes,False,False,
+STAD,Stomach Adenocarcinoma,carcinoma-gi,stomach,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,EBV+ / MSI-H / CIN / GS molecular subtypes,False,False,
+TGCT,Testicular Germ Cell Tumors,germ-cell,testis,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Seminoma + non-seminoma; chemo-cure,False,False,
+THCA,Thyroid Carcinoma,endocrine,thyroid,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Papillary-dominant; follicular / anaplastic separate; medullary distinct,False,False,
+THYM,Thymoma,thymic,thymus,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,,False,False,
+UCEC,Uterine Corpus Endometrial Carcinoma,carcinoma-gu,endometrium,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Endometrioid + serous — different therapy,False,False,
+UCS,Uterine Carcinosarcoma,carcinoma-gu,endometrium,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Mixed epithelial + sarcomatoid,False,False,
+UVM,Uveal Melanoma,melanoma,eye,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,GNAQ/GNA11; liver met tropism,False,False,
+SARC_LMS,Leiomyosarcoma,sarcoma,smooth_muscle,primary_smooth_muscle,SARC,leiomyosarcoma,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24071852,Uterine + extrauterine; chemo + trabectedin,False,False,
+SARC_DDLPS,Dedifferentiated Liposarcoma,sarcoma,adipose,primary_adipose,SARC,dedifferentiated_liposarcoma,GEO,GSE75885_DELESPAUL_2017,PMID:24071852,MDM2-amp; brigimadlin / milademetan trials,False,False,
+SARC_WDLPS,Well-Differentiated Liposarcoma,sarcoma,adipose,primary_adipose,SARC,dedifferentiated_liposarcoma,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,MDM2-amp; surgery-first,False,False,
+SARC_MYXLPS,Myxoid Liposarcoma,sarcoma,adipose,primary_adipose,SARC,myxoid_liposarcoma,GEO,GSE30929_SINGER_2007_LPS,PMID:22241786,"FUS-DDIT3; NY-ESO-1 TCR-T target. v5.6.0: Singer 2007 MSKCC GPL96 microarray (n=28 = 17 classic myxoid + 11 myxoid/round-cell which is the high-grade WHO variant of the same FUS::DDIT3-fusion entity). Biology validates: FABP4 2799, ADIPOQ 917, PPARG 424 (adipogenic), FUS+DDIT3 both ~165 (fusion partners both expressed), SOX9 122 (chondroid), STAT3 253 + JAK1 207 (FUS-DDIT3/JAK-STAT axis).",False,False,
+SARC_SYN,Synovial Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,synovial_sarcoma,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24071852,SS18-SSX; afami-cel (MAGE-A4 TCR-T) approved,False,False,
+SARC_DSRCT,Desmoplastic Small Round Cell Tumor,sarcoma,peritoneum,primary_peritoneal_mesenchymal,SARC,dsrct,Treehouse,TREEHOUSE_POLYA_25_01,,EWSR1-WT1; WT1 TCR-T trials,False,False,
+SARC_GIST,Gastrointestinal Stromal Tumor,sarcoma,gi_wall,primary_gi_wall,SARC,gist,TCGA,TREEHOUSE_POLYA_25_01,PMID:24071852,KIT/PDGFRA; imatinib ladder + avapritinib,False,False,
+SARC_MPNST,Malignant Peripheral Nerve Sheath Tumor,sarcoma,nerve_sheath,primary_nerve_sheath,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,NF1-associated; SMARCB1/EED/SUZ12 loss,False,False,
+SARC_ANGIO,Angiosarcoma,sarcoma,vascular_endothelium,primary_vascular,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Tumor IS endothelial — constrained deduct,False,False,
+SARC_UPS,Undifferentiated Pleomorphic Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24071852,Previously MFH; diagnosis of exclusion,False,False,
+OS,Osteosarcoma,sarcoma,bone,primary_bone,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:32427717,Not in TCGA — TARGET OS; GD2/HER2 trials,False,True,
+EWS,Ewing Sarcoma,sarcoma,bone,primary_bone,,,Treehouse,TREEHOUSE_POLYA_25_01,,EWSR1-FLI1/ERG; CD99+; VDC/IE,False,True,
+CHON,Chondrosarcoma,sarcoma,cartilage,primary_cartilage,,,GEO,GSE299759_MEIJER_2026,,IDH1/IDH2 + EXT1/EXT2; conventional / mesenchymal / dediff variants,False,False,
+CHOR,Chordoma,sarcoma,notochord,primary_notochord,,,Treehouse/RiboD,TREEHOUSE_RIBOD_25_01,,T (brachyury) defining; skull-base / sacral,False,False,
+RMS_ERMS,Embryonal Rhabdomyosarcoma,sarcoma,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24436047,MYOD1/MYOG; better prognosis than ARMS,False,True,
+RMS_ARMS,Alveolar Rhabdomyosarcoma,sarcoma,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24436047,PAX3-FOXO1 or PAX7-FOXO1; aggressive,False,True,
+NBL,Neuroblastoma,neuroendocrine,sympathetic_ganglia,primary_neural_crest,,,TARGET,TARGET_NBL_2018,PMID:30019323,MYCN amp vs non-amp — therapy-gating,False,True,
+NBL_MYCN_amp,Neuroblastoma MYCN-amplified,neuroendocrine,sympathetic_ganglia,primary_neural_crest,NBL,,TARGET,TARGET_NBL_2018,PMID:30019323,High-risk; dinutuximab + chemo,False,True,
+NBL_MYCN_nonamp,Neuroblastoma MYCN-non-amplified,neuroendocrine,sympathetic_ganglia,primary_neural_crest,NBL,,TARGET,TARGET_NBL_2018,PMID:30019323,Intermediate/low-risk; better prognosis,False,True,
+WILMS,Wilms Tumor / Nephroblastoma,embryonal,kidney,primary_embryonal,,,TARGET,TARGET_WT_2015,PMID:25622910,WT1/CTNNB1/AMER1; favorable vs anaplastic,False,True,
+RT,Rhabdoid Tumor,embryonal,kidney_cns_soft,primary_embryonal,,,TARGET,TARGET_RT_2017,PMID:29568089,SMARCB1 loss; malignant; CNS AT/RT subset,False,True,
+ATRT,Atypical Teratoid/Rhabdoid Tumor,cns,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCB1 loss; CNS-only rhabdoid,False,True,
+MBL,Medulloblastoma,cns,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SHH / WNT / Group 3 / Group 4 subgroups,False,True,
+MBL_WNT,Medulloblastoma WNT,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Excellent prognosis; CTNNB1,False,True,
+MBL_SHH,Medulloblastoma SHH,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,PTCH1/SMO; vismodegib-eligible,False,True,
+MBL_G3,Medulloblastoma Group 3,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,MYC-amp; worst prognosis,False,True,
+MBL_G4,Medulloblastoma Group 4,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Most common; MYCN/CDK6,False,True,
+RB,Retinoblastoma,embryonal,retina,solid_primary,,,Treehouse/RiboD,TREEHOUSE_RIBOD_25_01,,RB1 loss; pediatric eye,False,True,
+HEPB,Hepatoblastoma,embryonal,liver,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,CTNNB1; pediatric liver,False,True,
+CLL,Chronic Lymphocytic Leukemia,heme-bcell,peripheral_blood,heme_blood,,,CLL-map,CLLMAP_2022,,IGHV mutation status; BTK/BCL2 inhibitors,False,False,
+MCL,Mantle Cell Lymphoma,heme-bcell,lymph_node,heme_nodal,,,GEO,GSE271664_BODOR_2025,,CCND1-IgH; blastoid variant aggressive,False,False,
+FL,Follicular Lymphoma,heme-bcell,lymph_node,heme_nodal,,,GEO,GSE142334_FL_TFL_2021,PMID:33569544,BCL2-IgH; indolent; transforms to DLBCL,False,False,
+HL,Hodgkin Lymphoma,heme-bcell,lymph_node,heme_nodal,,,GEO,GSE120328_LAMPRECHT_2018,PMID:30546079,Reed-Sternberg cells; CD30+; brentuximab,False,False,
+BL,Burkitt Lymphoma,heme-bcell,lymph_node,heme_nodal,,,CGCI,CGCI_BLGSP,,MYC-Ig translocation; endemic/sporadic/immunodef,False,False,
+MM,Multiple Myeloma,heme-plasma,bone_marrow,heme_marrow,,,CoMMpass,MMRF_COMMPASS,PMID:30337648,Plasma-cell malignancy; BCMA/FCRH5 bispecifics,False,False,
+MDS,Myelodysplastic Syndrome,heme-myeloid,bone_marrow,heme_marrow,,,GEO,GSE114922_SHIOZAWA_2018,,Pre-leukemic; IPSS-R risk; luspatercept,False,False,
+MPN,Myeloproliferative Neoplasms,heme-myeloid,bone_marrow,heme_marrow,,,GEO,GSE283710_WASHU_2024,,PV / ET / MF; JAK2 V617F,False,False,
+CML,Chronic Myeloid Leukemia,heme-myeloid,peripheral_blood,heme_blood,,,GEO,GSE100026_DING_2017,,BCR-ABL; imatinib-cure paradigm,False,False,
+B_ALL,B-cell Acute Lymphoblastic Leukemia,heme-bcell,bone_marrow,heme_marrow,,,TARGET,TARGET_ALL_2018,PMID:30046113,BCR-ABL-like + other fusions; blinatumomab / tisa-cel,False,False,
+T_ALL,T-cell Acute Lymphoblastic Leukemia,heme-tcell,bone_marrow,heme_marrow,,,TARGET,TARGET_ALL_2018,PMID:30046113,NOTCH1; nelarabine,False,False,
+CTCL,Cutaneous T-cell Lymphoma,heme-tcell,skin,heme_skin,,,GEO,GSE171811_ECCITE_CTCL,,Mycosis fungoides / Sezary; mogamulizumab,False,False,
+PANNET,Pancreatic Neuroendocrine Tumor,neuroendocrine,pancreas,solid_primary,,,GEO,GSE118014_ALVAREZ_2018,PMID:30296526,"PanNET — Alvarez 2018 (GSE118014, 33 samples log2-TPM); octreotide/lanreotide, 177Lu-DOTATATE, everolimus",False,False,NET
+MID_NET,Midgut / Small Bowel Carcinoid,neuroendocrine,small_intestine,solid_primary,,,GEO,GSE98894_ALVAREZ_2018_NET,PMID:30013182,"Serotonin-secreting; 177Lu-DOTATATE; reference cohort is GSE98894 liver metastases (not primary), tagged tumor_origin=metastasis",False,False,NET
+REC_NET,Rectal Neuroendocrine Tumor,neuroendocrine,rectum,solid_primary,,,GEO,GSE98894_ALVAREZ_2018_NET,PMID:30013182,Most common GI-NET in some Asian cohorts; reference is GSE98894 liver mets (tumor_origin=metastasis),False,False,NET
+LUNG_NET_LC,Lung Typical/Atypical Carcinoid,neuroendocrine,lung,solid_primary,,,GEO,DRMETRICS_ALCALA_2019_LNEN,PMID:31431620,Low-grade lung NE; distinct from SCLC,False,False,NET
+LUNG_NET_LCNEC,Large-Cell Neuroendocrine Carcinoma Lung,neuroendocrine,lung,solid_primary,,,GEO,DRMETRICS_ALCALA_2019_LNEN,PMID:33203751,Intermediate between carcinoid and SCLC,False,False,NEC
+SCLC,Small Cell Lung Cancer,neuroendocrine,lung,solid_primary,,,University of Cologne,SCLC_UCOLOGNE_2015,,Rudin/George 2015; ASCL1/NEUROD1/POU2F3/YAP1 subtypes,False,False,NEC
+SCLC_ASCL1,SCLC ASCL1-dominant,neuroendocrine,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Classic neuroendocrine; DLL3 target,False,False,NEC
+SCLC_NEUROD1,SCLC NEUROD1-dominant,neuroendocrine,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Neural; ASCL1-low,False,False,NEC
+SCLC_POU2F3,SCLC POU2F3-dominant,neuroendocrine,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Tuft-cell-like; non-NE,False,False,NEC
+SCLC_YAP1,SCLC YAP1-dominant,neuroendocrine,lung,solid_primary,SCLC,,University of Cologne,SCLC_UCOLOGNE_2015_TF_DOMINANCE,PMID:26168399,Inflamed; proposed IO-responsive,False,False,NEC
+MEC,Merkel Cell Carcinoma,neuroendocrine,skin,solid_primary,,,curated,LITERATURE_CURATED,,MCPyV+ vs UV; avelumab-sensitive,False,False,NEC
+NUTM,NUT Carcinoma,carcinoma-other,midline_structures,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,NUT-BRD3/4 fusion; midline aggressive,False,False,
+ACINIC,Acinic Cell Carcinoma,salivary,salivary_gland,solid_primary,,,curated,LITERATURE_CURATED,,Salivary gland low-grade,False,False,
+ADCC,Adenoid Cystic Carcinoma,salivary,salivary_gland,solid_primary,,,GEO,GSE294016_BARTL_2025_SGC,PMID:40506428,MYB-NFIB; salivary + lacrimal + breast,False,False,
+MTC,Medullary Thyroid Carcinoma,endocrine,thyroid_c_cell,solid_primary,,,GEO,GSE32662_PRINGLE_2012_MTC,GSE32662,Calcitonin; RET-driven; separate from TCGA THCA (follicular-cell). Pringle 2012 GPL6480 Agilent microarray TPM-proxy (n=52 hybridizations across 49 primary cases). CALCA p95 ~3400 TPM-proxy confirms cohort.,False,False,
+NPC,Nasopharyngeal Carcinoma,carcinoma-head-neck,nasopharynx,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,EBV-driven; distinct from TCGA HNSC,False,False,
+HCL,Hairy Cell Leukemia,heme-bcell,spleen_marrow,heme_marrow,,,curated,LITERATURE_CURATED,,BRAF V600E; vemurafenib effective,False,False,
+PCN,Plasmacytoma,heme-plasma,soft_tissue,solid_primary,MM,,curated,LITERATURE_CURATED,,Solitary plasma-cell mass (solitary bone / extramedullary),False,False,
+SARC_EPITH,Epithelioid Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:32105697,SMARCB1/INI1 loss; tazemetostat (EZH2 inhibitor) approved 2020,False,False,
+SARC_DFSP,Dermatofibrosarcoma Protuberans,sarcoma,skin,solid_primary,SARC,,curated,LITERATURE_CURATED,PMID:19805687,COL1A1-PDGFB fusion; imatinib approved; surgery-first,False,False,
+SARC_ASPS,Alveolar Soft Part Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:36516078,ASPSCR1-TFE3; atezolizumab approved 2022; anti-angiogenic TKIs,False,False,
+SARC_CCS,Clear Cell Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,GEO,GSE248751_HUMAN_CCS_2023,PMID:14576204,EWSR1-ATF1 fusion; melanoma-like biology but not BRAF-driven,False,False,
+SARC_IFS,Infantile Fibrosarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:29466156,ETV6-NTRK3; larotrectinib / entrectinib approved,False,True,
+SARC_EHE,Epithelioid Hemangioendothelioma,sarcoma,vascular_endothelium,primary_vascular,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:22265237,WWTR1-CAMTA1 (majority) or YAP1-TFE3; indolent-to-aggressive,False,False,
+SARC_PEC,PEComa (Perivascular Epithelioid Cell Tumor),sarcoma,soft_tissue,solid_primary,SARC,,GEO,GSE328026_PECOMA_2026,PMID:34133196,TSC1/TSC2 loss or TFE3 fusion; nab-sirolimus (FYARRO) approved 2021,False,False,
+SARC_KS,Kaposi Sarcoma,sarcoma,vascular_endothelium,primary_vascular,SARC,,GEO,GSE241095_KS_SKIN_2023,PMID:7997879,HHV8-driven endothelial; immune-reconstitution / chemo,False,False,
+SARC_MYXFIB,Myxofibrosarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:21304266,Previously MFH myxoid-type; elderly limbs; surgery + chemo,False,False,
+SARC_SFT,Solitary Fibrous Tumor,sarcoma,soft_tissue,solid_primary,SARC,,curated,LITERATURE_CURATED,PMID:23313955,NAB2-STAT6 fusion; previously hemangiopericytoma,False,False,
+SARC_IMT,Inflammatory Myofibroblastic Tumor,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:20147977,"ALK fusion in ~50% (crizotinib), also ROS1/NTRK/RET fusion subsets",False,False,
+GCTB,Giant Cell Tumor of Bone,sarcoma,bone,primary_bone,,,curated,LITERATURE_CURATED,PMID:23940309,H3F3A G34W mutation; denosumab approved for unresectable,False,False,
+ESS_LG,Low-grade Endometrial Stromal Sarcoma,sarcoma,endometrium,solid_primary,,,curated,LITERATURE_CURATED,PMID:11445439,JAZF1-SUZ12 or similar; hormone-responsive; aromatase inhibitors,False,False,
+ESS_HG,High-grade Endometrial Stromal Sarcoma,sarcoma,endometrium,solid_primary,,,curated,LITERATURE_CURATED,PMID:22354060,YWHAE-NUTM2 or BCOR rearrangement; aggressive; chemo,False,False,
+SARC_LGFMS,Low-grade Fibromyxoid Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,GEO,GSE75885_DELESPAUL_2017,PMID:17592252,FUS-CREB3L2 or FUS-CREB3L1; late recurrences,False,False,
+SARC_EMC,Extraskeletal Myxoid Chondrosarcoma,sarcoma,soft_tissue,solid_primary,SARC,,curated,LITERATURE_CURATED,PMID:17934065,EWSR1-NR4A3 (majority); distinct from skeletal chondrosarcoma,False,False,
+SARC_PLEOLPS,Pleomorphic Liposarcoma,sarcoma,adipose,primary_adipose,SARC,,GEO,GSE75885_DELESPAUL_2017,PMID:18703001,No pathognomonic fusion; aggressive; differs from WDLPS/DDLPS/myxoid,False,False,
+RMS_PRMS,Pleomorphic Rhabdomyosarcoma,sarcoma,skeletal_muscle,primary_skeletal_muscle,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:18829983,Adult; distinct from pediatric ERMS/ARMS; no fusion,False,False,
+RMS_SSRMS,Spindle Cell / Sclerosing Rhabdomyosarcoma,sarcoma,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24054308,MYOD1 (congenital) or VGLL2/NCOA2 (infantile); distinct from ERMS/ARMS,False,True,
+SARC_LPS_UNSPEC,Liposarcoma (Unspecified / Aggregate),sarcoma,adipose,primary_adipose,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Treehouse v25.01 LPS aggregate (n=92); DDLPS/WDLPS/MYXLPS mixed,False,False,
+SARC_CIC,CIC-rearranged Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Ewing-like undifferentiated round cell sarcoma (n=5 Treehouse); CIC-DUX4 majority; ETV4/PEA3 + WT1 activation; more aggressive than Ewing,False,False,
+SARC_BCOR,BCOR-rearranged Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Undifferentiated round cell sarcoma (n=2 Treehouse); BCOR-CCNB3 (Xp11) majority; BCOR-ITD in infantile,False,False,
+SARC_MYOEP,Soft Tissue Myoepithelial Carcinoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Myoepithelioma/myoepithelial carcinoma (n=5 Treehouse); EWSR1-POU5F1/PBX1 or FUS-POU5F1,False,False,
+SARC_SMARCA4,SMARCA4-deficient Thoracic Sarcoma,sarcoma,thorax,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCA4/BRG1 loss (n=13 Treehouse); undifferentiated thoracic; smoking-associated; not fusion-driven,False,False,

--- a/pirlygenes/data/cancer-type-registry.csv
+++ b/pirlygenes/data/cancer-type-registry.csv
@@ -101,7 +101,7 @@ MEC,Merkel Cell Carcinoma,net,skin,solid_primary,,,curated,LITERATURE_CURATED,,M
 NUTM,NUT Carcinoma,rare,midline_structures,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,NUT-BRD3/4 fusion; midline aggressive,False
 ACINIC,Acinic Cell Carcinoma,salivary,salivary_gland,solid_primary,,,curated,LITERATURE_CURATED,,Salivary gland low-grade,False
 ADCC,Adenoid Cystic Carcinoma,salivary,salivary_gland,solid_primary,,,GEO,GSE294016_BARTL_2025_SGC,PMID:40506428,MYB-NFIB; salivary + lacrimal + breast,False
-MTC,Medullary Thyroid Carcinoma,endocrine,thyroid_c_cell,solid_primary,,,GEO,GSE32662_PRINGLE_2012_MTC,GSE32662,"Calcitonin; RET-driven; separate from TCGA THCA (follicular-cell). Pringle 2012 GPL6480 Agilent microarray TPM-proxy (n=52 hybridizations across 49 primary cases). CALCA p95 ~3400 TPM-proxy confirms cohort.",False
+MTC,Medullary Thyroid Carcinoma,endocrine,thyroid_c_cell,solid_primary,,,GEO,GSE32662_PRINGLE_2012_MTC,GSE32662,Calcitonin; RET-driven; separate from TCGA THCA (follicular-cell). Pringle 2012 GPL6480 Agilent microarray TPM-proxy (n=52 hybridizations across 49 primary cases). CALCA p95 ~3400 TPM-proxy confirms cohort.,False
 NPC,Nasopharyngeal Carcinoma,carcinoma-head-neck,nasopharynx,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,EBV-driven; distinct from TCGA HNSC,False
 HCL,Hairy Cell Leukemia,heme-bcell,spleen_marrow,heme_marrow,,,curated,LITERATURE_CURATED,,BRAF V600E; vemurafenib effective,False
 PCN,Plasmacytoma,heme-plasma,soft_tissue,solid_primary,MM,,curated,LITERATURE_CURATED,,Solitary plasma-cell mass (solitary bone / extramedullary),False
@@ -125,3 +125,7 @@ SARC_PLEOLPS,Pleomorphic Liposarcoma,sarcoma,adipose,primary_adipose,SARC,,GEO,G
 RMS_PRMS,Pleomorphic Rhabdomyosarcoma,sarcoma,skeletal_muscle,primary_skeletal_muscle,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:18829983,Adult; distinct from pediatric ERMS/ARMS; no fusion,False
 RMS_SSRMS,Spindle Cell / Sclerosing Rhabdomyosarcoma,pediatric-soft,skeletal_muscle,primary_skeletal_muscle,,,Treehouse,TREEHOUSE_POLYA_25_01,PMID:24054308,MYOD1 (congenital) or VGLL2/NCOA2 (infantile); distinct from ERMS/ARMS,False
 SARC_LPS_UNSPEC,Liposarcoma (Unspecified / Aggregate),sarcoma,adipose,primary_adipose,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Treehouse v25.01 LPS aggregate (n=92); DDLPS/WDLPS/MYXLPS mixed,False
+SARC_CIC,CIC-rearranged Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Ewing-like undifferentiated round cell sarcoma (n=5 Treehouse); CIC-DUX4 majority; ETV4/PEA3 + WT1 activation; more aggressive than Ewing,False
+SARC_BCOR,BCOR-rearranged Sarcoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Undifferentiated round cell sarcoma (n=2 Treehouse); BCOR-CCNB3 (Xp11) majority; BCOR-ITD in infantile,False
+SARC_MYOEP,Soft Tissue Myoepithelial Carcinoma,sarcoma,soft_tissue,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,Myoepithelioma/myoepithelial carcinoma (n=5 Treehouse); EWSR1-POU5F1/PBX1 or FUS-POU5F1,False
+SARC_SMARCA4,SMARCA4-deficient Thoracic Sarcoma,sarcoma,thorax,solid_primary,SARC,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCA4/BRG1 loss (n=13 Treehouse); undifferentiated thoracic; smoking-associated; not fusion-driven,False

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -944,6 +944,38 @@ def is_mixture_cohort(code):
     return code in set(mixture_cohort_codes())
 
 
+# Registry `family` values that denote a sarcoma lineage, plus prefix-agnostic
+# extras. This is the membership the `SARC` grand-union aggregate pools over —
+# it deliberately spans soft-tissue (family=sarcoma, incl. the SARC_* codes),
+# bone/pediatric (OS, EWS; family=pediatric-bone), and pediatric soft-tissue
+# rhabdomyosarcomas (family=pediatric-soft), regardless of code prefix (OS/EWS/
+# RMS_* keep their established codes; see the prefix-normalization follow-up).
+_SARCOMA_FAMILIES = {"sarcoma", "pediatric-bone", "pediatric-soft"}
+_SARCOMA_EXTRA_CODES = {"CHOR"}  # chordoma: notochordal, family="rare"
+
+
+def sarcoma_lineage_codes(*, with_expression_only=False):
+    """Return every registry code that is a sarcoma by lineage, prefix-agnostic.
+
+    Spans soft-tissue (``SARC``/``SARC_*``, ``CHON``), bone/pediatric (``OS``,
+    ``EWS``), pediatric rhabdomyosarcomas (``RMS_*``), endometrial stromal
+    sarcomas (``ESS_LG``/``ESS_HG``), and chordoma (``CHOR``). This is the
+    membership the ``SARC`` grand-union aggregate pools over.
+
+    ``with_expression_only`` drops codes with no per-sample expression source
+    (the ``LITERATURE_CURATED`` entries — e.g. ESS_LG/HG, GCTB, SARC_SFT),
+    leaving only codes that actually contribute samples to a pooled aggregate.
+    """
+    df = cancer_type_registry()
+    fam = df["family"].astype(str)
+    is_sarc = fam.isin(_SARCOMA_FAMILIES) | df["code"].isin(_SARCOMA_EXTRA_CODES)
+    sub = df[is_sarc]
+    if with_expression_only:
+        src = sub["expression_source"].astype(str).str.lower()
+        sub = sub[~src.isin(["curated", "nan", ""])]
+    return sub["code"].tolist()
+
+
 # ---------- Cancer-pathway panels (tumor-evidence Step-0 signals) ----------
 #
 # Each panel is a coordinated-program set — genes that move together in

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -888,8 +888,9 @@ def cancer_type_registry():
 def cancer_types_in_family(family):
     """Return cancer-type codes belonging to a registry family.
 
-    Families span more than TCGA — ``sarcoma`` includes TCGA SARC
-    subtype-tiles and the pediatric-bone / pediatric-soft cohorts;
+    Families are lineage/organ-system only (age is a separate ``pediatric``
+    flag): ``sarcoma`` spans soft-tissue + bone + rhabdomyosarcomas regardless
+    of patient age; ``neuroendocrine`` spans NET + NEC across organs;
     ``heme-myeloid`` covers LAML + MDS + MPN + CML etc.
     """
     df = cancer_type_registry()
@@ -944,32 +945,23 @@ def is_mixture_cohort(code):
     return code in set(mixture_cohort_codes())
 
 
-# Registry `family` values that denote a sarcoma lineage, plus prefix-agnostic
-# extras. This is the membership the `SARC` grand-union aggregate pools over —
-# it deliberately spans soft-tissue (family=sarcoma, incl. the SARC_* codes),
-# bone/pediatric (OS, EWS; family=pediatric-bone), and pediatric soft-tissue
-# rhabdomyosarcomas (family=pediatric-soft), regardless of code prefix (OS/EWS/
-# RMS_* keep their established codes; see the prefix-normalization follow-up).
-_SARCOMA_FAMILIES = {"sarcoma", "pediatric-bone", "pediatric-soft"}
-_SARCOMA_EXTRA_CODES = {"CHOR"}  # chordoma: notochordal, family="rare"
-
-
 def sarcoma_lineage_codes(*, with_expression_only=False):
-    """Return every registry code that is a sarcoma by lineage, prefix-agnostic.
+    """Return every registry code that is a sarcoma by lineage.
 
-    Spans soft-tissue (``SARC``/``SARC_*``, ``CHON``), bone/pediatric (``OS``,
-    ``EWS``), pediatric rhabdomyosarcomas (``RMS_*``), endometrial stromal
-    sarcomas (``ESS_LG``/``ESS_HG``), and chordoma (``CHOR``). This is the
-    membership the ``SARC`` grand-union aggregate pools over.
+    After the Phase-C ontology refactor the sarcoma lineage is a single
+    ``family == "sarcoma"`` bucket: soft-tissue (``SARC``/``SARC_*``, ``CHON``),
+    bone (``OS``, ``EWS``, ``GCTB``), rhabdomyosarcomas (``RMS_*``), endometrial
+    stromal sarcomas (``ESS_LG``/``ESS_HG``), and chordoma (``CHOR``) — bone and
+    pediatric sarcomas were folded in from the retired ``pediatric-bone`` /
+    ``pediatric-soft`` families (age is now a separate ``pediatric`` flag). This
+    is the membership the ``SARC`` grand-union aggregate pools over.
 
     ``with_expression_only`` drops codes with no per-sample expression source
     (the ``LITERATURE_CURATED`` entries — e.g. ESS_LG/HG, GCTB, SARC_SFT),
     leaving only codes that actually contribute samples to a pooled aggregate.
     """
     df = cancer_type_registry()
-    fam = df["family"].astype(str)
-    is_sarc = fam.isin(_SARCOMA_FAMILIES) | df["code"].isin(_SARCOMA_EXTRA_CODES)
-    sub = df[is_sarc]
+    sub = df[df["family"].astype(str) == "sarcoma"]
     if with_expression_only:
         src = sub["expression_source"].astype(str).str.lower()
         sub = sub[~src.isin(["curated", "nan", ""])]

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -2064,6 +2064,36 @@ def disease_state_rules_df():
     return get_data("disease-state-rules")
 
 
+def cancer_tmb_df():
+    """Return the curated ``cancer-tmb.csv`` reference: median tumor
+    mutational burden (mut/Mb) per cancer-type code, with a per-row
+    published source/PMID and a confidence flag.
+
+    Cohorts with no defensible published per-Mb median are present with a
+    blank ``median_tmb_mut_mb`` (and a ``confidence`` of ``none``) so the
+    gap is explicit rather than silently absent. Values mix WES-anchored
+    medians (Lawrence 2013) with panel-based medians (Chalmers 2017) and
+    disease-specific studies; see the ``source``/``notes`` columns — panel
+    and WES TMB are not strictly comparable in the low-TMB range."""
+    return get_data("cancer-tmb")
+
+
+def cancer_tmb(cancer_type=None):
+    """Median TMB (mut/Mb) for one cancer type, or the whole
+    ``{code: median_tmb}`` map (codes with no published value omitted).
+
+    ``cancer_type`` is resolved through :func:`resolve_cancer_type`, so
+    aliases and display names work; returns ``None`` if the type has no
+    curated TMB value."""
+    df = cancer_tmb_df()
+    vals = df.dropna(subset=["median_tmb_mut_mb"])
+    mapping = dict(zip(vals["cancer_code"].astype(str),
+                       vals["median_tmb_mut_mb"].astype(float)))
+    if cancer_type is None:
+        return mapping
+    return mapping.get(resolve_cancer_type(cancer_type))
+
+
 # Per-cohort median tumor-cell purity from TCGA (Aran et al., Nat Commun 2015).
 # Used by trufflepig's purity-confidence reasoning; published here as reference
 # data so consumers don't have to depend on the analysis package just to look

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -2126,6 +2126,73 @@ def cancer_tmb(cancer_type=None):
     return mapping.get(resolve_cancer_type(cancer_type))
 
 
+def cancer_fusions_df():
+    """Return the curated ``cancer-fusions.csv`` reference: characteristic gene
+    fusions / oncogenic translocations per cancer-type code.
+
+    One row per concrete pairing (so promiscuous partner sets are explicit),
+    with the 5'/3' partner genes and their protein families annotated
+    (``gene_5prime_family`` / ``gene_3prime_family`` — e.g. FET, ETS, BET,
+    MiT/TFE, PAX, FOX, RTK, Ig locus). ``is_defining`` marks the characteristic
+    lesion of the entity; ``pathognomonic`` is the stronger claim that the
+    gene-pair maps to a single entity (diagnostic in context). Characteristically
+    fusion-negative entities carry a single ``fusion_family="(none)"`` row naming
+    the real driver. ``mechanism`` distinguishes chimeric ``fusion_transcript``
+    from ``ig_enhancer_hijack`` / ``promoter_swap`` / ``enhancer_hijack`` (which
+    have no chimeric transcript — see ``rnaseq_detectable``)."""
+    return get_data("cancer-fusions")
+
+
+def cancer_fusions(cancer_type=None, *, defining_only=False, pathognomonic_only=False):
+    """Fusion rows for one cancer type (resolved via :func:`resolve_cancer_type`),
+    or the whole table when ``cancer_type`` is None. ``defining_only`` /
+    ``pathognomonic_only`` filter to the characteristic / diagnostic rows."""
+    df = cancer_fusions_df()
+    if cancer_type is not None:
+        df = df[df["cancer_code"].astype(str) == resolve_cancer_type(cancer_type)]
+    # is_defining / pathognomonic load as bool (get_data coerces true/false);
+    # compare via lowercased string so the filter works whether bool or str.
+    if defining_only:
+        df = df[df["is_defining"].astype(str).str.lower() == "true"]
+    if pathognomonic_only:
+        df = df[df["pathognomonic"].astype(str).str.lower() == "true"]
+    return df.reset_index(drop=True)
+
+
+def fusion_partners(gene, *, side=None):
+    """Return the set of fusion partners of ``gene`` observed in the table.
+
+    ``side=None`` returns all partners (gene on either end); ``side="5prime"``
+    returns partners when ``gene`` is the 5' member (i.e. the observed 3'
+    partners); ``side="3prime"`` returns the observed 5' partners. Useful for
+    making sense of promiscuous sets — e.g. ``fusion_partners("EWSR1")`` spans
+    FLI1/ERG/WT1/ATF1/NR4A3/POU5F1/…, ``fusion_partners("NR4A3", side="3prime")``
+    returns EWSR1/TAF15/TCF12."""
+    g = str(gene).strip().upper()
+    df = cancer_fusions_df()
+    out = set()
+    if side in (None, "5prime"):
+        out |= set(df.loc[df["gene_5prime"].astype(str).str.upper() == g, "gene_3prime"])
+    if side in (None, "3prime"):
+        out |= set(df.loc[df["gene_3prime"].astype(str).str.upper() == g, "gene_5prime"])
+    return {p for p in out if isinstance(p, str) and p.strip()}
+
+
+def protein_family(gene):
+    """Protein/gene family of a fusion partner (e.g. EWSR1->FET, FLI1->ETS,
+    BRD4->BET, PAX3->PAX, FOXO1->FOX, ALK->RTK), or ``None`` if the gene has no
+    clear family annotation in ``cancer-fusions.csv``."""
+    g = str(gene).strip().upper()
+    df = cancer_fusions_df()
+    for col, fam in (("gene_5prime", "gene_5prime_family"),
+                     ("gene_3prime", "gene_3prime_family")):
+        hit = df.loc[df[col].astype(str).str.upper() == g, fam]
+        for v in hit:
+            if isinstance(v, str) and v.strip():
+                return v
+    return None
+
+
 # Per-cohort median tumor-cell purity from TCGA (Aran et al., Nat Commun 2015).
 # Used by trufflepig's purity-confidence reasoning; published here as reference
 # data so consumers don't have to depend on the analysis package just to look

--- a/tests/test_cancer_fusions.py
+++ b/tests/test_cancer_fusions.py
@@ -1,0 +1,86 @@
+"""Tests for the curated characteristic-fusion reference (cancer-fusions.csv)."""
+
+from pirlygenes.gene_sets_cancer import (
+    cancer_fusions,
+    cancer_fusions_df,
+    fusion_partners,
+    protein_family,
+    resolve_cancer_type,
+)
+
+_EXPECTED_COLS = [
+    "cancer_code", "fusion_family", "gene_5prime", "gene_5prime_family",
+    "gene_3prime", "gene_3prime_family", "frequency", "is_defining",
+    "pathognomonic", "rnaseq_detectable", "mechanism", "confidence",
+    "pmid", "notes",
+]
+
+
+def test_schema_and_codes_resolve():
+    df = cancer_fusions_df()
+    assert list(df.columns) == _EXPECTED_COLS
+    for code in df["cancer_code"].astype(str).unique():
+        assert resolve_cancer_type(code) is not None  # every code is a registry code
+
+
+def test_pathognomonic_implies_defining_and_unique():
+    df = cancer_fusions_df()
+    patho = df[df["pathognomonic"].astype(bool)]
+    assert len(patho) > 0
+    assert patho["is_defining"].astype(bool).all()
+    # a pathognomonic gene-pair must map to exactly one cancer code
+    for r in patho.itertuples():
+        codes = set(df[(df.gene_5prime == r.gene_5prime)
+                       & (df.gene_3prime == r.gene_3prime)]["cancer_code"])
+        assert codes == {r.cancer_code}
+
+
+def test_known_pathognomonic_and_shared():
+    # pathognomonic: EWSR1-WT1 -> DSRCT only; PML-RARA -> APL; SS18-SSX -> synovial
+    patho = set(zip(cancer_fusions(pathognomonic_only=True)["gene_5prime"],
+                    cancer_fusions(pathognomonic_only=True)["gene_3prime"]))
+    assert ("EWSR1", "WT1") in patho
+    assert ("PML", "RARA") in patho
+    # shared (defining but NOT pathognomonic): ETV6-NTRK3 spans many entities,
+    # ZC3H7B-BCOR is in both BCOR-sarcoma and HG-ESS.
+    df = cancer_fusions_df()
+    etv6 = df[(df.gene_5prime == "ETV6") & (df.gene_3prime == "NTRK3")]
+    assert not etv6["pathognomonic"].astype(bool).any()
+    assert etv6["cancer_code"].nunique() > 1
+
+
+def test_pax_and_fox_are_separate_families():
+    assert protein_family("PAX3") == "PAX"
+    assert protein_family("PAX7") == "PAX"
+    assert protein_family("FOXO1") == "FOX"
+    assert protein_family("PAX3") != protein_family("FOXO1")
+    # FET partners share a family (why they're interchangeable 5' partners)
+    assert protein_family("EWSR1") == protein_family("FUS") == "FET"
+    assert protein_family("FLI1") == "ETS"
+
+
+def test_fusion_partners_promiscuous_sets():
+    # EWSR1 is a promiscuous 5' partner across sarcoma entities
+    ewsr1_3p = fusion_partners("EWSR1", side="5prime")  # 3' partners of EWSR1
+    assert {"FLI1", "WT1", "NR4A3", "ATF1", "POU5F1"} <= ewsr1_3p
+    # NR4A3 takes multiple 5' partners (EMC)
+    nr4a3_5p = fusion_partners("NR4A3", side="3prime")
+    assert {"EWSR1", "TAF15", "TCF12"} <= nr4a3_5p
+
+
+def test_round_cell_entities_present():
+    # the entities the gaps surfaced: CIC / BCOR / myoepithelial / NUT
+    for code, g5, g3 in [("SARC_CIC", "CIC", "DUX4"),
+                         ("SARC_BCOR", "BCOR", "CCNB3"),
+                         ("SARC_MYOEP", "EWSR1", "POU5F1"),
+                         ("NUTM", "BRD4", "NUTM1")]:
+        rows = cancer_fusions(code)
+        assert ((rows.gene_5prime == g5) & (rows.gene_3prime == g3)).any()
+
+
+def test_fusion_negative_entities_marked():
+    # leiomyosarcoma / GIST / MTC are fusion-negative -> a single (none) row
+    for code in ("SARC_LMS", "SARC_GIST", "MTC"):
+        rows = cancer_fusions(code)
+        assert (rows["fusion_family"] == "(none)").any()
+        assert rows["is_defining"].astype(bool).sum() == 0

--- a/tests/test_cancer_tmb.py
+++ b/tests/test_cancer_tmb.py
@@ -1,0 +1,77 @@
+"""Tests for the curated per-cancer-type median-TMB reference (cancer-tmb.csv)."""
+
+import math
+
+import pandas as pd
+
+from pirlygenes.gene_sets_cancer import cancer_tmb, cancer_tmb_df, resolve_cancer_type
+
+_EXPECTED_COLS = [
+    "cancer_code",
+    "median_tmb_mut_mb",
+    "source",
+    "pmid_doi",
+    "confidence",
+    "notes",
+]
+
+
+def test_schema_and_unique_codes():
+    df = cancer_tmb_df()
+    assert list(df.columns) == _EXPECTED_COLS
+    codes = df["cancer_code"].astype(str)
+    assert codes.is_unique
+    # Every code must be a real registry code.
+    for code in codes:
+        assert resolve_cancer_type(code) is not None
+
+
+def test_values_positive_and_plausible():
+    df = cancer_tmb_df()
+    vals = df.dropna(subset=["median_tmb_mut_mb"])["median_tmb_mut_mb"].astype(float)
+    assert (vals > 0).all()
+    # Median TMB by type should sit in a sane range (mut/Mb); melanoma is the
+    # high end (~13), pheo/retinoblastoma the low end (<0.1).
+    assert vals.max() < 50
+    assert vals.min() >= 0.01
+
+
+def test_every_value_is_cited():
+    """A non-blank TMB value must carry a source + PMID/DOI; a blank value must
+    be explicitly flagged confidence=none (an honest gap, not a silent absence)."""
+    df = cancer_tmb_df()
+    for row in df.itertuples():
+        has_value = isinstance(row.median_tmb_mut_mb, float) and not math.isnan(
+            row.median_tmb_mut_mb
+        )
+        if has_value:
+            assert isinstance(row.source, str) and row.source.strip()
+            assert isinstance(row.pmid_doi, str) and row.pmid_doi.strip()
+            assert row.confidence in {"high", "medium", "low"}
+        else:
+            assert row.confidence == "none"
+
+
+def test_accessor_map_omits_blanks():
+    mapping = cancer_tmb()
+    assert isinstance(mapping, dict)
+    # Blank-value codes (no published median) are absent from the map.
+    assert "MPN" not in mapping
+    assert "CML" not in mapping
+    # Well-established values are present.
+    assert "SKCM" in mapping and "PRAD" in mapping
+
+
+def test_accessor_resolves_aliases():
+    # melanoma -> SKCM (high TMB), prostate -> PRAD (low TMB)
+    assert cancer_tmb("melanoma") == cancer_tmb("SKCM")
+    assert cancer_tmb("melanoma") > cancer_tmb("prostate")
+    # A code with no curated value returns None rather than raising.
+    assert cancer_tmb("MPN") is None
+
+
+def test_skcm_is_highest_among_common_types():
+    mapping = cancer_tmb()
+    assert mapping["SKCM"] == max(
+        mapping[c] for c in ("SKCM", "LUAD", "LUSC", "BLCA", "BRCA", "PRAD")
+    )

--- a/tests/test_cancer_type_registry.py
+++ b/tests/test_cancer_type_registry.py
@@ -197,11 +197,14 @@ def test_heme_myeloid_family_contains_laml_and_related():
         assert need in myeloid
 
 
-def test_net_family_contains_sclc_and_pannet():
-    net = set(cancer_types_in_family("net"))
-    assert "SCLC" in net
-    assert "PANNET" in net
-    assert "MEC" in net  # Merkel cell carcinoma
+def test_neuroendocrine_family_contains_sclc_and_pannet():
+    # Phase-C: the `net` family was renamed `neuroendocrine` (it spans both
+    # well-diff NET and poorly-diff NEC; the differentiation column carries
+    # that split). SCLC/PANNET keep their famous codes.
+    ne = set(cancer_types_in_family("neuroendocrine"))
+    assert "SCLC" in ne
+    assert "PANNET" in ne
+    assert "MEC" in ne  # Merkel cell carcinoma (NEC)
 
 
 def test_parent_codes_reference_registry_entries():

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,122 @@
+"""Tests for pirlygenes.coverage (cohort-level patient coverage of a gene set).
+
+Uses a synthetic per-sample matrix written to a tmp cache — never real
+patient/clinical data."""
+
+import pandas as pd
+import pytest
+
+from pirlygenes import cohorts, coverage
+from pirlygenes.cli import main as cli_main
+
+
+# A 3-gene × 4-sample synthetic cohort with hand-chosen TPM so coverage is
+# deterministic at threshold 25:
+#   GENEA > 25 in s1, s2          (covers 2/4)
+#   GENEB > 25 in s2, s3          (adds s3 -> 3/4)
+#   GENEC > 25 in s1              (adds nothing new)
+# greedy plateau = 3/4 = 75%.
+_SYNTH = pd.DataFrame(
+    {
+        "Ensembl_Gene_ID": ["ENSG00000001", "ENSG00000002", "ENSG00000003"],
+        "Symbol": ["GENEA", "GENEB", "GENEC"],
+        "s1": [100.0, 1.0, 80.0],
+        "s2": [60.0, 90.0, 2.0],
+        "s3": [3.0, 40.0, 1.0],
+        "s4": [0.0, 0.0, 0.0],
+    }
+)
+
+
+@pytest.fixture
+def synth_source(tmp_path, monkeypatch):
+    """Register a synthetic cohort 'SYNTH' backed by a tmp-dir parquet."""
+    derived = tmp_path / "derived"
+    derived.mkdir()
+    _SYNTH.to_parquet(derived / "SYNTH_per_sample_tpm.parquet", index=False)
+
+    monkeypatch.setattr(coverage._cohorts.downloads, "source_cache_dir",
+                        lambda source_id, **k: tmp_path)
+    monkeypatch.setitem(
+        cohorts._REGISTRY, "synth",
+        {"SYNTH": cohorts.Cohort("SYNTH", "SYNTH", "synth")},
+    )
+    return tmp_path
+
+
+def _symbol_csv(tmp_path):
+    p = tmp_path / "panel.csv"
+    p.write_text("Symbol\nGENEA\nGENEB\nGENEC\n")
+    return p
+
+
+# --- resolve_gene_set ------------------------------------------------------
+
+def test_resolve_named_panels():
+    label, ensgs, symbols = coverage.resolve_gene_set("cta")
+    assert label == "CTA" and len(ensgs) > 50 and not symbols
+
+    label, ensgs, symbols = coverage.resolve_gene_set("lineage:PRAD")
+    assert label == "lineage:PRAD"
+    assert ensgs or symbols  # lineage panel has ENSG and/or symbols
+
+
+def test_resolve_csv_path(tmp_path):
+    label, ensgs, symbols = coverage.resolve_gene_set(str(_symbol_csv(tmp_path)))
+    assert symbols == {"GENEA", "GENEB", "GENEC"}
+
+
+def test_resolve_unknown_raises():
+    with pytest.raises(ValueError):
+        coverage.resolve_gene_set("definitely-not-a-panel")
+
+
+# --- matrix + greedy + counts ----------------------------------------------
+
+def test_cohort_matrix_filters_to_panel(synth_source):
+    cohort = cohorts.cohorts_for_source("synth")["SYNTH"]
+    mat = coverage.cohort_matrix(cohort, symbols={"GENEA", "GENEB"})
+    assert set(mat.index) == {"GENEA", "GENEB"}
+    assert mat.shape == (2, 4)
+
+
+def test_greedy_coverage_plateau(synth_source):
+    cohort = cohorts.cohorts_for_source("synth")["SYNTH"]
+    mat = coverage.cohort_matrix(cohort, symbols={"GENEA", "GENEB", "GENEC"})
+    order, cum, n = coverage.greedy_coverage(mat, threshold=25)
+    assert n == 4
+    assert cum[-1] == pytest.approx(0.75)  # 3 of 4 patients
+    assert mat.index[order[0]] == "GENEA"  # most-covering gene first
+
+
+def test_patient_coverage_counts(synth_source, tmp_path):
+    df = coverage.patient_coverage(str(_symbol_csv(tmp_path)), source_id="synth",
+                                   thresholds=(25,))
+    a = df[df.Symbol == "GENEA"].iloc[0]
+    assert a.n_samples == 4 and a.n_gt25 == 2 and a.pct_gt25 == 50.0
+    # GENEC is >25 in one sample, so it is retained (any_hit), not dropped.
+    assert "GENEC" in set(df.Symbol)
+
+
+# --- CLI dispatch ----------------------------------------------------------
+
+def test_cli_patient_coverage(synth_source, tmp_path):
+    out = tmp_path / "out"
+    rc = cli_main([
+        "plot", "patient-coverage", "--gene-set", str(_symbol_csv(tmp_path)),
+        "--source", "synth", "--threshold", "25", "--out", str(out),
+    ])
+    assert rc == 0
+    assert (out / "panel_csv_patient_counts.csv").exists()
+    assert (out / "panel_csv_stacked_coverage_t25.png").exists()
+
+
+def test_cli_bad_gene_set_returns_2(tmp_path):
+    rc = cli_main([
+        "plot", "patient-coverage", "--gene-set", "nope", "--out", str(tmp_path),
+    ])
+    assert rc == 2
+
+
+def test_cli_plot_no_action_returns_2():
+    assert cli_main(["plot"]) == 2

--- a/tests/test_downloads_and_cli.py
+++ b/tests/test_downloads_and_cli.py
@@ -2,8 +2,9 @@
 
 Covers the foundation shipped in the expression-data refresh project
 (see docs/expression-data-refresh-plan.md). Heavy behavior (build,
-fetch, plot) is scaffolded only — those subcommands return a clear
-NotImplemented pointer and are not exercised here.
+fetch) is scaffolded only — those subcommands return a clear
+NotImplemented pointer and are not exercised here. `plot
+patient-coverage` is implemented and covered in test_coverage.py.
 """
 
 from __future__ import annotations
@@ -147,11 +148,12 @@ def test_cli_build_ambiguous_cancer_code_lists_candidates():
     pass
 
 
-def test_cli_plot_scaffolded_but_not_implemented():
-    rc, _, err = _run_cli(["plot", "FATE1"])
+def test_cli_plot_requires_an_action():
+    # `plot` is now implemented (patient-coverage); with no action it prints a
+    # usage line naming the available action and exits non-zero.
+    rc, _, err = _run_cli(["plot"])
     assert rc == 2
-    assert "not implemented" in err
-    assert "milestone 7" in err
+    assert "patient-coverage" in err
 
 
 def test_cli_analyze_redirects_to_trufflepig():

--- a/tests/test_sarcoma_lineage.py
+++ b/tests/test_sarcoma_lineage.py
@@ -11,7 +11,7 @@ def test_spans_soft_tissue_bone_and_pediatric():
     assert {"OS", "EWS"} <= codes
     # pediatric rhabdomyosarcomas
     assert {"RMS_ERMS", "RMS_ARMS"} <= codes
-    # chordoma (notochordal, family="rare") included via the extra-codes set
+    # chordoma (notochordal) folded into the sarcoma family in the refactor
     assert "CHOR" in codes
 
 

--- a/tests/test_sarcoma_lineage.py
+++ b/tests/test_sarcoma_lineage.py
@@ -1,0 +1,39 @@
+"""Tests for the prefix-agnostic sarcoma-lineage membership (Phase C foundation)."""
+
+from pirlygenes.gene_sets_cancer import sarcoma_lineage_codes
+
+
+def test_spans_soft_tissue_bone_and_pediatric():
+    codes = set(sarcoma_lineage_codes())
+    # soft-tissue SARC_* + the umbrella + chondrosarcoma
+    assert {"SARC", "SARC_LMS", "SARC_DDLPS", "SARC_SYN", "CHON"} <= codes
+    # bone/pediatric sarcomas keep their (non-SARC_) codes but are members
+    assert {"OS", "EWS"} <= codes
+    # pediatric rhabdomyosarcomas
+    assert {"RMS_ERMS", "RMS_ARMS"} <= codes
+    # chordoma (notochordal, family="rare") included via the extra-codes set
+    assert "CHOR" in codes
+
+
+def test_endometrial_stromal_sarcomas_included():
+    # ESS_LG/HG are family=sarcoma (curated, no per-sample data) — they belong
+    # to the taxonomy even though they contribute no samples to the aggregate.
+    codes = set(sarcoma_lineage_codes())
+    assert {"ESS_LG", "ESS_HG"} <= codes
+
+
+def test_excludes_non_sarcomas():
+    codes = set(sarcoma_lineage_codes())
+    for non_sarc in ("BRCA", "SKCM", "GBM", "PRAD", "NBL", "MTC"):
+        assert non_sarc not in codes
+
+
+def test_with_expression_only_drops_curated_entries():
+    all_codes = set(sarcoma_lineage_codes())
+    data_codes = set(sarcoma_lineage_codes(with_expression_only=True))
+    assert data_codes <= all_codes
+    # curated, no per-sample expression -> dropped from the expression subset
+    assert "ESS_LG" in all_codes and "ESS_LG" not in data_codes
+    # a Treehouse-backed code survives
+    assert "SARC_LMS" in data_codes
+    assert "OS" in data_codes


### PR DESCRIPTION
Foundation for the sarcoma/NEN taxonomy rebuild (Phase C). The heavy data rebuild + code renames + DATA_VERSION deploy come in follow-up commits on this branch.

- **cancer-fusions.csv** (170 rows, 68 codes): characteristic fusions across sarcoma/heme/NUT/salivary/thyroid/lung/prostate/glioma/secretory; one row per concrete pairing; 5'/3' protein-family columns (FET/ETS/BET/MiT-TFE/PAX/FOX/RTK/...); is_defining + pathognomonic; mechanism (fusion_transcript/ig_enhancer_hijack/promoter_swap); fusion-negative entities marked. PMIDs flagged via confidence column (audit pending).
- **sarcoma_lineage_codes()** — prefix-agnostic sarcoma roster (37 codes).
- **4 new Treehouse-backed round-cell sarcoma codes**: SARC_CIC, SARC_BCOR, SARC_MYOEP, SARC_SMARCA4.
- Accessors: cancer_fusions / fusion_partners / protein_family; tests; full suite green (368).