### PR TITLE
Honor tsarina's MANUALLY_EXPRESSED_CTA rescue in CTA gene sets (closes #279)

### DIFF
--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -1359,6 +1359,35 @@ def _bool_mask(series: pd.Series) -> pd.Series:
     return series.astype(str).str.strip().str.lower() == "true"
 
 
+def _manually_expressed_cta() -> frozenset:
+    """tsarina's per-gene "expressed" rescue set (single source of truth).
+
+    Borderline-but-real CTAs (e.g. XAGE5) are flagged ``never_expressed`` in the
+    bundled table (HPA truth) but curated back into the expressed set by tsarina
+    via ``tsarina.tissues.MANUALLY_EXPRESSED_CTA``.  Honor it here so the
+    curation decision flows through to pirlygenes instead of being dropped by
+    this module's local ``never_expressed`` filter.  See tsarina#78 / #279.
+    """
+    try:
+        from tsarina.tissues import MANUALLY_EXPRESSED_CTA
+
+        return frozenset(MANUALLY_EXPRESSED_CTA)
+    except Exception:
+        return frozenset()
+
+
+def _never_expressed_mask(df: pd.DataFrame) -> pd.Series:
+    """``never_expressed`` rows, minus tsarina's manually rescued CTAs."""
+    if "never_expressed" not in df.columns:
+        return pd.Series(False, index=df.index)
+    mask = _bool_mask(df["never_expressed"])
+    rescued_ids = _manually_expressed_cta()
+    if rescued_ids and "Ensembl_Gene_ID" in df.columns:
+        rescued = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0].isin(rescued_ids)
+        mask = mask & ~rescued
+    return mask
+
+
 def _cta_filter_mask(df: pd.DataFrame) -> pd.Series:
     column = _cta_filter_column(df)
     if column is None:
@@ -1391,7 +1420,7 @@ def _cta_df(filtered_only=False, exclude_never_expressed=False):
     if filtered_only:
         mask = mask & _cta_filter_mask(df)
     if exclude_never_expressed and "never_expressed" in df.columns:
-        mask = mask & ~_bool_mask(df["never_expressed"])
+        mask = mask & ~_never_expressed_mask(df)
     return df[mask]
 
 
@@ -1623,7 +1652,7 @@ def _build_partition(ensembl_release=112):
     all_pc_ids = set(all_pc_genes.keys())
 
     filtered_mask = _cta_filter_mask(evidence_df)
-    never_expr_mask = _bool_mask(evidence_df["never_expressed"])
+    never_expr_mask = _never_expressed_mask(evidence_df)
 
     cta_mask = filtered_mask & ~never_expr_mask
     never_expressed_mask = filtered_mask & never_expr_mask

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -1437,6 +1437,21 @@ def _cta_by_column(column, filtered_only=False, exclude_never_expressed=False):
     return result
 
 
+def cta_symbol_for_alias(name):
+    """Resolve a CTA gene name or synonym to its official symbol.
+
+    Case- and punctuation-insensitive, so ``"NY-ESO-1"``, ``"ESO1"`` and
+    ``"CTAG1B"`` all resolve to ``"CTAG1B"``; returns ``None`` for unknown
+    names.  Delegates to tsarina (the curation source of truth); see
+    tsarina#77.  Returns ``None`` if tsarina is too old to provide it.
+    """
+    try:
+        from tsarina.gene_sets import cta_symbol_for_alias as _resolve
+    except Exception:
+        return None
+    return _resolve(name)
+
+
 def CTA_gene_names():
     """CTA gene symbols: filtered AND expressed (>= 2 nTPM somewhere).
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.12.0"
+__version__ = "5.12.1"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
## Problem (#279)

pirlygenes reimplements tsarina's CTA filter against the raw evidence table (`_cta_df` / `_build_partition`), so tsarina's **code-layer** "expressed" rescue is dropped here. **XAGE5** is curated back into the expressed set by tsarina (`tsarina.tissues.MANUALLY_EXPRESSED_CTA`, tsarina#78) but was excluded in pirlygenes — `CTA_gene_names()` returned 262 vs tsarina's 263.

## Fix

Route the `never_expressed` exclusion through a single `_never_expressed_mask` helper that subtracts tsarina's `MANUALLY_EXPRESSED_CTA` (single source of truth), applied at both chokepoints. The set is imported from tsarina, so XAGE5 and future curated rescues flow automatically. Defensive: falls back to no rescue if tsarina is too old.

## Verification

- `CTA_gene_names()` 262 to **263**, exact match to `tsarina.gene_sets.CTA_gene_names()`. XAGE5 / XAGE2 / XAGE3 / MAGEB6 / CT83 / PRM3 all present.
- XAGE5 moves out of `CTA_never_expressed_gene_names()`; three-way partition stays disjoint.
- Minimal diff: 2 files. ruff check clean. Verified against tsarina 1.4.5.

Version 5.12.0 to 5.12.1. Closes #279.

Note: clean re-cut off origin/main (the earlier #283 was accidentally based on unpushed local WIP). main CI is currently red for unrelated reasons (missing matplotlib in CI env; test_gene_ids cancer-reference-expression resolution) — neither touched by this change.