### PR TITLE
Complete CTA re-export (cta_symbol_for_alias + axis accessors); fix bispecific typo

### DIFF
--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -1427,8 +1427,8 @@ bispecific_antibody_approved_target_gene_ids = _deprecate(
 bispecific_antibody_target_gene_names = _deprecate(
     "bispecific_antibody_target_gene_names", "bispecific-antibodies", "names"
 )
-bispecific_antibody_targets_gene_ids = _deprecate(
-    "bispecific_antibody_targets_gene_ids", "bispecific-antibodies", "ids"
+bispecific_antibody_target_gene_ids = _deprecate(
+    "bispecific_antibody_target_gene_ids", "bispecific-antibodies", "ids"
 )
 radio_target_gene_names = _deprecate("radio_target_gene_names", "radioligand", "names")
 radio_target_gene_ids = _deprecate("radio_target_gene_ids", "radioligand", "ids")
@@ -1450,6 +1450,7 @@ radioligand_target_gene_ids = _deprecate(
 # no tsarina equivalent.
 from tsarina.evidence import CTA_evidence as _tsarina_CTA_evidence  # noqa: E402
 from tsarina.gene_sets import (  # noqa: E402,F401
+    CTA_by_axes,
     CTA_excluded_gene_ids,
     CTA_excluded_gene_names,
     CTA_filtered_gene_ids,
@@ -1458,8 +1459,13 @@ from tsarina.gene_sets import (  # noqa: E402,F401
     CTA_gene_names,
     CTA_never_expressed_gene_ids,
     CTA_never_expressed_gene_names,
+    CTA_placental_restricted_gene_ids,
+    CTA_placental_restricted_gene_names,
+    CTA_testis_restricted_gene_ids,
+    CTA_testis_restricted_gene_names,
     CTA_unfiltered_gene_ids,
     CTA_unfiltered_gene_names,
+    cta_symbol_for_alias,
 )
 from tsarina.partition import (  # noqa: E402,F401
     CTAPartitionDataFrames,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.17.0"
+__version__ = "5.17.1"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -355,3 +355,26 @@ def test_gene_loaders_are_exported_from_package():
         "cancer_family_panels",
     ]:
         assert hasattr(pirlygenes, name), f"{name} not re-exported"
+
+
+def test_cta_symbol_for_alias_reexported_from_tsarina():
+    """pirlygenes re-exports tsarina's alias resolver so callers can resolve
+    CTA names/synonyms without importing tsarina directly."""
+    from pirlygenes.gene_sets_cancer import cta_symbol_for_alias
+
+    assert cta_symbol_for_alias("NY-ESO-1") == "CTAG1B"
+    assert cta_symbol_for_alias("CT12.2") == "XAGE2"
+    assert cta_symbol_for_alias("not-a-gene") is None
+
+
+def test_cta_axis_accessors_reexported_from_tsarina():
+    """The CTA restriction-axis + by-axes accessors are re-exported too."""
+    from pirlygenes.gene_sets_cancer import (
+        CTA_by_axes,
+        CTA_placental_restricted_gene_names,
+        CTA_testis_restricted_gene_names,
+    )
+
+    assert "CTAG1B" in CTA_testis_restricted_gene_names()
+    assert len(CTA_placental_restricted_gene_names()) > 0
+    assert callable(CTA_by_axes)


### PR DESCRIPTION
## What

Two small fixes on top of the 5.14.0 CTA delegation.

### 1. Complete the tsarina CTA passthrough
The delegation re-exported the gene-set *list* functions but omitted the rest of tsarina's CTA API, so `from pirlygenes.gene_sets_cancer import cta_symbol_for_alias` raised `ImportError`. Added the missing re-exports (all trivial passthroughs to `tsarina.gene_sets`, verified present in tsarina ≥1.4.8):
- **`cta_symbol_for_alias`** — resolve CTA name/synonym → official symbol (NY-ESO-1/ESO1 → CTAG1B, CT12.2 → XAGE2)
- `CTA_by_axes`, `CTA_testis_restricted_gene_names/ids`, `CTA_placental_restricted_gene_names/ids`

### 2. Fix a typo in the deprecation shims
`bispecific_antibody_targets_gene_ids` → `bispecific_antibody_target_gene_ids`. Every other entry in the `*_target_gene_names/ids` family uses the singular "target"; the plural name was the lone outlier, so a caller using the consistent name hit `AttributeError`. Verified **0** references to the old name (repo + tests), so the rename is safe.

## Tests
- New tests assert the re-exports import and resolve (`cta_symbol_for_alias("NY-ESO-1") == "CTAG1B"`; restriction-axis accessors work).
- `ruff check` clean. Version 5.17.0 → 5.17.1.