### PR TITLE
Fix #317 silent misnormalization: clean-TPM runtime rejects symbol-only input

### DIFF
--- a/pirlygenes/expression/normalize.py
+++ b/pirlygenes/expression/normalize.py
@@ -145,14 +145,22 @@ def _clean_tpm_normalize(
     """
     import pandas as pd
 
+    # Clean-TPM censoring is ENSG-keyed (the canonical censored-gene list). A
+    # symbol-only frame can't be censored, and silently censoring nothing while
+    # still rescaling to the fixed-fraction budget would misnormalize — so
+    # require a real Ensembl_Gene_ID column for any non-zero censored_fill. The
+    # legacy censored_fill="zero" path (classify_gene_qc, symbol-capable) does
+    # not reach here.
+    if not id_col or id_col not in out.columns:
+        raise ValueError(
+            f"clean-TPM normalization (censored_fill={censored_fill!r}) needs an "
+            f"'{id_col}' Ensembl-gene-id column — the censored-gene list is "
+            "ENSG-keyed; resolve symbols to Ensembl ids first, or use "
+            "censored_fill='zero' for the legacy symbol-based transform")
     gene_table = pd.DataFrame(
         {
             "Symbol": out[label_col].fillna("").astype(str),
-            "Ensembl_Gene_ID": (
-                out[id_col].fillna("").astype(str)
-                if id_col and id_col in out.columns
-                else pd.Series([""] * len(out), index=out.index)
-            ),
+            "Ensembl_Gene_ID": out[id_col].fillna("").astype(str),
         },
         index=out.index,
     )
@@ -649,8 +657,9 @@ def clean_tpm_matrix(values, removable=None, *, gene_table=None,
     ``values`` is genes (rows) × samples (cols). Provide either an explicit
     boolean ``removable`` mask (aligned to ``values.index``) or a ``gene_table``
     (``Symbol`` + ``Ensembl_Gene_ID``, row-aligned to ``values``) — in which
-    case the mask is built via :func:`clean_tpm_removal_mask`, which **excludes
-    ribosomal proteins by default**.
+    case the mask is built via :func:`clean_tpm_removal_mask`, which **censors
+    ribosomal proteins by default** (``exclude_ribosomal_proteins=True`` removes
+    them from the biological signal; pass ``False`` for technical-only).
 
     ``censored_fill`` controls what happens to the censored (removable) rows
     (``"fixed_fraction"`` is the default as of clean_tpm_v4 — see below):

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.21.20"
+__version__ = "5.21.21"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_clean_tpm_shared.py
+++ b/tests/test_clean_tpm_shared.py
@@ -170,6 +170,20 @@ def test_runtime_wrapper_default_is_legacy_zero_unchanged():
     assert (out.loc[3, ["TPM_S1", "TPM_S2"]] > 0).all()
 
 
+def test_clean_tpm_runtime_rejects_symbol_only_input():
+    """A symbol-only frame can't be censored (the list is ENSG-keyed), so the
+    clean-TPM runtime path RAISES rather than silently censoring nothing while
+    still rescaling to the fixed-fraction budget (#317 follow-up). The legacy
+    zero path stays symbol-capable."""
+    import pytest
+    df = pd.DataFrame({"Symbol": ["MT-CO1", "TP53"], "TPM_S1": [5e5, 1e5]})
+    with pytest.raises(ValueError):
+        normalize_technical_rna_columns(df, censored_fill="fixed_fraction")
+    # legacy zero path (classify_gene_qc, symbol-capable) does not raise
+    out, info = normalize_technical_rna_columns(df)  # default censored_fill="zero"
+    assert "removed_feature_mode" in info
+
+
 def test_runtime_long_table_v4_per_group_budget():
     """The long-table wrapper applies the v4 transform within each cohort group:
     every group's biological compartment lands on 750k."""


### PR DESCRIPTION
Reviewer-found bug in 5.21.19: `normalize_technical_rna_columns` / `_clean_tpm_normalize` silently **misnormalized** a symbol-only frame — with no `Ensembl_Gene_ID` it synthesized blank ids, the ENSG-keyed `clean_tpm_removal_mask` censored **zero** genes, yet `fixed_fraction` still rescaled the whole sample into the 750k biological budget and reported `applied=True`.

- `_clean_tpm_normalize` now **raises ValueError** when `Ensembl_Gene_ID` is absent for any non-zero `censored_fill` (resolve symbols→ENSG first, or use `censored_fill='zero'` for the legacy symbol-capable path). No more blank-id synthesis.
- Fixed the misleading `clean_tpm_matrix` docstring ('excludes' → 'censors ribosomal proteins by default').
- Regression test added.

Full gate green (466). Code-only; DATA_VERSION unchanged.