### PR TITLE
Centralize per-sample cohort/source registry in cohorts.py (#329)

### DIFF
--- a/pirlygenes/cohorts.py
+++ b/pirlygenes/cohorts.py
@@ -101,15 +101,62 @@ def _treehouse_polya_25_01() -> dict[str, Cohort]:
     return out
 
 
+# Single source of truth for the per-sample expression sources: ``source_id ->
+# (source_cohort label, project)``. The generators and the package accessors all
+# read this — don't duplicate the list in scripts. ``label`` is the
+# ``source_cohort`` value used in provenance; ``project`` is the data origin.
+PER_SAMPLE_SOURCES: dict[str, tuple[str, str]] = {
+    "treehouse-polya-25-01": ("TREEHOUSE_POLYA_25_01", "Treehouse"),
+    "treehouse-ribod-25-01": ("TREEHOUSE_RIBOD_25_01", "Treehouse"),
+    # Neuroendocrine axis (#318/#326) — per-sample parquets built by
+    # scripts/build_ne_per_sample_parquets.py from the cached NE source data.
+    "gse118014-pannet": ("GSE118014_ALVAREZ_2018", "GEO"),
+    "sclc-ucologne-2015": ("SCLC_UCOLOGNE_2015", "UCologne"),
+    "drmetrics-lnen-2020": ("DRMETRICS_ALCALA_2019_LNEN", "IARC LNEN"),
+}
+
+# Sources with an explicit code→Cohort map (mixed-case stems that don't
+# round-trip from the parquet name). Every other source in PER_SAMPLE_SOURCES
+# discovers its cohorts from disk with ``code == stem``.
 _REGISTRY: dict[str, dict[str, Cohort]] = {
     "treehouse-polya-25-01": _treehouse_polya_25_01(),
 }
 
 
+def source_label(source_id: str) -> str | None:
+    """The ``source_cohort`` provenance label for a per-sample source."""
+    entry = PER_SAMPLE_SOURCES.get(source_id)
+    return entry[0] if entry else None
+
+
+def source_project(source_id: str) -> str | None:
+    """The data-origin project for a per-sample source (Treehouse/GEO/…)."""
+    entry = PER_SAMPLE_SOURCES.get(source_id)
+    return entry[1] if entry else None
+
+
+def _discovered_cohorts(source_id: str) -> dict[str, Cohort]:
+    """Cohorts inferred from a source's cached ``derived`` parquet stems, with
+    ``code == stem`` — for sources without an explicit registry map."""
+    derived = downloads.source_cache_dir(source_id) / "derived"
+    out: dict[str, Cohort] = {}
+    if derived.exists():
+        for p in sorted(derived.glob("*_per_sample_tpm.parquet")):
+            stem = p.name[: -len("_per_sample_tpm.parquet")]
+            out[stem] = Cohort(stem, stem, source_id)
+    return out
+
+
 def cohorts_for_source(source_id: str) -> dict[str, Cohort]:
-    """All registered cohorts for ``source_id`` ({code: Cohort}); empty if the
-    source has no per-sample cohort registry."""
-    return dict(_REGISTRY.get(source_id, {}))
+    """All cohorts for ``source_id`` ({code: Cohort}). Explicit-map sources
+    (treehouse-polya) return their registered map; other per-sample sources
+    discover cohorts from the cached ``derived`` parquets (code == stem); an
+    unknown source returns empty."""
+    if source_id in _REGISTRY:
+        return dict(_REGISTRY[source_id])
+    if source_id in PER_SAMPLE_SOURCES:
+        return _discovered_cohorts(source_id)
+    return {}
 
 
 def parquet_path(cohort: Cohort):
@@ -123,3 +170,14 @@ def available_cohorts(source_id: str) -> dict[str, Cohort]:
     local cache (i.e. usable right now without a build/download)."""
     return {code: c for code, c in cohorts_for_source(source_id).items()
             if parquet_path(c).exists()}
+
+
+def all_available_cohorts() -> dict[str, Cohort]:
+    """Every per-sample cohort present on disk across **all**
+    :data:`PER_SAMPLE_SOURCES`. On a code collision the first source in
+    registration order wins (treehouse-polya is canonical)."""
+    out: dict[str, Cohort] = {}
+    for source_id in PER_SAMPLE_SOURCES:
+        for code, cohort in available_cohorts(source_id).items():
+            out.setdefault(code, cohort)
+    return out

--- a/pirlygenes/coverage.py
+++ b/pirlygenes/coverage.py
@@ -42,6 +42,16 @@ from . import gene_sets_cancer as gsc
 DEFAULT_SOURCE = "treehouse-polya-25-01"
 DEFAULT_THRESHOLDS = (25, 50, 100, 200)
 
+
+def _available(source_id):
+    """Cohorts with cached per-sample matrices for ``source_id``, or — when
+    ``source_id == "all"`` — across every registered per-sample source (#275).
+    Cross-source is safe because each cohort carries its own ``source_id`` and
+    :func:`cohort_matrix` reads that cohort's own parquet."""
+    if source_id == "all":
+        return _cohorts.all_available_cohorts()
+    return _cohorts.available_cohorts(source_id)
+
 # --- gene-set resolution ---------------------------------------------------
 
 # A panel is an **ENSG set**. Gene symbols are only ever used to *look up* an
@@ -189,7 +199,7 @@ def patient_coverage(gene_set: str, source_id: str = DEFAULT_SOURCE,
     a cached per-sample matrix for ``source_id``.
     """
     _label, ensgs = resolve_gene_set(gene_set)
-    avail = _cohorts.available_cohorts(source_id)
+    avail = _available(source_id)
     if codes:
         want = {gsc.resolve_cancer_type(c) for c in codes}
         avail = {k: v for k, v in avail.items() if k in want}
@@ -254,7 +264,7 @@ def render(gene_set: str, source_id: str = DEFAULT_SOURCE, codes=None,
 
     # Per-cohort greedy coverage (reuse the loaded matrices once). Greedy order
     # is computed on ENSG-indexed rows; symbols are mapped in only for display.
-    avail = _cohorts.available_cohorts(source_id)
+    avail = _available(source_id)
     if codes:
         want = {gsc.resolve_cancer_type(c) for c in codes}
         avail = {k: v for k, v in avail.items() if k in want}

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.21.26"
+__version__ = "5.21.27"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/scripts/generate_representative_cohort_samples.py
+++ b/scripts/generate_representative_cohort_samples.py
@@ -47,24 +47,17 @@ OUT_DIR = Path(__file__).resolve().parent.parent / "pirlygenes" / "data" \
     / "cancer-reference-expression-representatives"
 CACHE = Path.home() / ".cache" / "pirlygenes" / "expression"
 
-# (source_id, source_cohort label, source_project) for every source that ships
-# per-sample parquets. The label mirrors the reference-expression source_cohort.
-_SOURCES = [
-    ("treehouse-polya-25-01", "TREEHOUSE_POLYA_25_01", "Treehouse"),
-    ("treehouse-ribod-25-01", "TREEHOUSE_RIBOD_25_01", "Treehouse"),
-    # Neuroendocrine axis (#318) — per-sample parquets built by
-    # scripts/build_ne_per_sample_parquets.py from the cached NE source data.
-    ("gse118014-pannet", "GSE118014_ALVAREZ_2018", "GEO"),
-    ("sclc-ucologne-2015", "SCLC_UCOLOGNE_2015", "UCologne"),
-    ("drmetrics-lnen-2020", "DRMETRICS_ALCALA_2019_LNEN", "IARC LNEN"),
-]
+# (source_id, source_cohort label, source_project) per per-sample source — the
+# single source of truth lives in pirlygenes.cohorts.PER_SAMPLE_SOURCES; this is
+# just a view of it (imported by the percentile generator too).
+_SOURCES = [(sid, label, project)
+            for sid, (label, project) in _cohorts.PER_SAMPLE_SOURCES.items()]
 
 
 def _stem_to_code(source_id: str) -> dict[str, str]:
-    """{parquet_stem: cancer_code} for a source — via the cohort registry where
-    present, else identity (uppercased) for sources with no registry yet."""
-    reg = _cohorts.cohorts_for_source(source_id)
-    return {c.stem: c.code for c in reg.values()}
+    """{parquet_stem: cancer_code} for a source, via the centralized cohort
+    registry (explicit map for treehouse-polya; code==stem discovery elsewhere)."""
+    return {c.stem: c.code for c in _cohorts.cohorts_for_source(source_id).values()}
 
 
 def build(k: int = 12) -> None:

--- a/tests/test_cohorts_registry.py
+++ b/tests/test_cohorts_registry.py
@@ -1,0 +1,50 @@
+"""Centralized per-sample cohort/source registry (#329).
+
+cohorts.py is the single source of truth for which per-sample expression sources
+exist and which cohorts they hold (explicit map for treehouse-polya; code==stem
+discovery from the cached derived parquets elsewhere)."""
+
+import pandas as pd
+
+from pirlygenes import cohorts
+
+
+def test_per_sample_sources_complete():
+    src = cohorts.PER_SAMPLE_SOURCES
+    # all sources the per-sample pipeline produces are registered here, not in a
+    # script — incl. ribod + the NE sources added by #318/#326.
+    assert {"treehouse-polya-25-01", "treehouse-ribod-25-01", "gse118014-pannet",
+            "sclc-ucologne-2015", "drmetrics-lnen-2020"} <= set(src)
+    for sid, (label, project) in src.items():
+        assert cohorts.source_label(sid) == label
+        assert cohorts.source_project(sid) == project
+    assert cohorts.source_label("not-a-source") is None
+
+
+def test_explicit_source_uses_registry_map():
+    # treehouse-polya has an explicit code->Cohort map (mixed-case stems)
+    th = cohorts.cohorts_for_source("treehouse-polya-25-01")
+    assert th["PRAD"].stem == "tcga_prad"           # stem != code
+    assert th["ATRT"].stem == "ATRT"
+
+
+def test_discovery_source_uses_stem_equals_code(tmp_path, monkeypatch):
+    """A source without an explicit map discovers cohorts from its derived
+    parquet stems, with code == stem."""
+    derived = tmp_path / "derived"
+    derived.mkdir()
+    df = pd.DataFrame({"Ensembl_Gene_ID": ["ENSG00000141510"], "Symbol": ["TP53"],
+                       "s1": [10.0], "s2": [20.0]})
+    df.to_parquet(derived / "NET_PANCREAS_per_sample_tpm.parquet", index=False)
+    monkeypatch.setattr(cohorts.downloads, "source_cache_dir",
+                        lambda source_id, **k: tmp_path)
+    monkeypatch.setitem(cohorts.PER_SAMPLE_SOURCES, "fake-ne",
+                        ("FAKE_NE", "GEO"))
+    got = cohorts.cohorts_for_source("fake-ne")
+    assert set(got) == {"NET_PANCREAS"}
+    assert got["NET_PANCREAS"].stem == "NET_PANCREAS"   # code == stem
+    assert "NET_PANCREAS" in cohorts.all_available_cohorts()
+
+
+def test_unknown_source_empty():
+    assert cohorts.cohorts_for_source("nope") == {}


### PR DESCRIPTION
The per-sample source registry was fragmented — `cohorts.py` knew only `treehouse-polya`, while the full list (ribod + the 3 NE sources) was duplicated in a script and invisible to the package accessors.

- `cohorts.PER_SAMPLE_SOURCES` is now the single source of truth (id→label,project) + `source_label()`/`source_project()`.
- `cohorts_for_source()` generalized: explicit map for treehouse-polya, code==stem discovery from cached `derived` parquets elsewhere; `all_available_cohorts()` spans all sources.
- The representatives generator's `_SOURCES` is now a thin view of it (percentile generator imports from there) — script-level duplication removed.
- `coverage.py`: `source_id='all'` spans every per-sample source (step toward #275).

Code-only, behaviour-preserving. Full gate green (481). Closes #329.