### PR TITLE
Single source of truth for per-sample matrix I/O (#329)

### DIFF
--- a/pirlygenes/cohorts.py
+++ b/pirlygenes/cohorts.py
@@ -29,7 +29,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pandas as pd
+
 from . import downloads
+
+# Canonical per-sample-parquet layout — the single source of truth for the
+# filename suffix and the non-sample id columns, so every reader/writer agrees.
+PER_SAMPLE_SUFFIX = "_per_sample_tpm.parquet"
+ID_COLS = ("Ensembl_Gene_ID", "Symbol")
 
 
 @dataclass(frozen=True)
@@ -141,8 +148,8 @@ def _discovered_cohorts(source_id: str) -> dict[str, Cohort]:
     derived = downloads.source_cache_dir(source_id) / "derived"
     out: dict[str, Cohort] = {}
     if derived.exists():
-        for p in sorted(derived.glob("*_per_sample_tpm.parquet")):
-            stem = p.name[: -len("_per_sample_tpm.parquet")]
+        for p in sorted(derived.glob(f"*{PER_SAMPLE_SUFFIX}")):
+            stem = p.name[: -len(PER_SAMPLE_SUFFIX)]
             out[stem] = Cohort(stem, stem, source_id)
     return out
 
@@ -162,7 +169,7 @@ def cohorts_for_source(source_id: str) -> dict[str, Cohort]:
 def parquet_path(cohort: Cohort):
     """Path to a cohort's per-sample TPM parquet (may not exist on disk)."""
     return (downloads.source_cache_dir(cohort.source_id) / "derived"
-            / f"{cohort.stem}_per_sample_tpm.parquet")
+            / f"{cohort.stem}{PER_SAMPLE_SUFFIX}")
 
 
 def available_cohorts(source_id: str) -> dict[str, Cohort]:
@@ -181,3 +188,53 @@ def all_available_cohorts() -> dict[str, Cohort]:
         for code, cohort in available_cohorts(source_id).items():
             out.setdefault(code, cohort)
     return out
+
+
+# --- canonical per-sample matrix I/O (single source of truth) --------------
+
+def sample_columns(df: pd.DataFrame) -> list[str]:
+    """The per-sample value columns of a per-sample frame (everything that
+    isn't an :data:`ID_COLS` id column)."""
+    return [c for c in df.columns if c not in ID_COLS]
+
+
+def read_per_sample(cohort: Cohort) -> pd.DataFrame:
+    """Read a cohort's per-sample TPM parquet (the canonical open + error).
+
+    Returns the raw frame: ``ID_COLS`` + one column per sample (linear TPM).
+    Use :func:`sample_columns` to get the value columns. Raises a helpful
+    ``FileNotFoundError`` if the matrix isn't cached."""
+    path = parquet_path(cohort)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"no per-sample parquet for {cohort.code} at {path} — run "
+            f"`pirlygenes build {cohort.source_id}` or `downloads fetch` first")
+    return pd.read_parquet(path)
+
+
+def iter_per_sample_cohorts(*, sources=None):
+    """Yield ``(cohort, df)`` for every per-sample cohort present on disk across
+    ``sources`` (default: all :data:`PER_SAMPLE_SOURCES`, in registration order).
+    The single iteration point shared by the representatives / percentile
+    generators so the source list and parquet layout live in one place."""
+    for source_id in (sources or list(PER_SAMPLE_SOURCES)):
+        for _code, cohort in available_cohorts(source_id).items():
+            yield cohort, read_per_sample(cohort)
+
+
+def write_per_sample(gene_table: pd.DataFrame, values: pd.DataFrame,
+                     source_id: str, code: str):
+    """Write a cohort's per-sample TPM parquet in the canonical layout
+    (``ID_COLS`` + sample columns) to ``<source-cache>/derived/``; returns the
+    path. Shared by the per-sample builders so the on-disk format has one
+    writer."""
+    derived = downloads.source_cache_dir(source_id) / "derived"
+    derived.mkdir(parents=True, exist_ok=True)
+    out = pd.concat(
+        [gene_table[list(ID_COLS)].reset_index(drop=True),
+         values.reset_index(drop=True)],
+        axis=1,
+    )
+    path = derived / f"{code}{PER_SAMPLE_SUFFIX}"
+    out.to_parquet(path, index=False)
+    return path

--- a/pirlygenes/coverage.py
+++ b/pirlygenes/coverage.py
@@ -143,18 +143,13 @@ def cohort_matrix(cohort, ensgs=None) -> pd.DataFrame:
     a ``{ensg: symbol}`` display map is stashed in ``df.attrs['symbols']`` so
     downstream rendering can label rows without ever joining on the symbol.
     """
-    path = _cohorts.parquet_path(cohort)
-    if not path.exists():
-        raise FileNotFoundError(
-            f"no per-sample parquet for {cohort.code} at {path} — run "
-            f"`pirlygenes build {cohort.source_id}` or `downloads fetch` first")
-    df = pd.read_parquet(path)
+    df = _cohorts.read_per_sample(cohort)
     ensgs = ensgs or set()
     ensg_col = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
     mask = ensg_col.isin(ensgs) if ensgs else pd.Series(False, index=df.index)
     sub = df.loc[mask].copy()
     sub["Ensembl_Gene_ID"] = ensg_col[mask]
-    sample_cols = [c for c in sub.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    sample_cols = _cohorts.sample_columns(sub)
     symbol_map = {}
     if "Symbol" in sub.columns:
         symbol_map = dict(zip(sub["Ensembl_Gene_ID"], sub["Symbol"].astype(str)))

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.21.27"
+__version__ = "5.21.28"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/scripts/build_ne_per_sample_parquets.py
+++ b/scripts/build_ne_per_sample_parquets.py
@@ -28,6 +28,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from pirlygenes import cohorts as _cohorts  # noqa: E402
 from pirlygenes.builders.treehouse import (  # noqa: E402
     _aggregate_by_ensembl,
     _build_or_load_symbol_mapping,
@@ -43,17 +44,10 @@ ENSEMBL = 112
 
 def _write(gene_table: pd.DataFrame, values: pd.DataFrame, source_dir: Path,
            code: str) -> int:
-    derived = source_dir / "derived"
-    derived.mkdir(parents=True, exist_ok=True)
-    out = pd.concat(
-        [gene_table[["Ensembl_Gene_ID", "Symbol"]].reset_index(drop=True),
-         values.reset_index(drop=True)],
-        axis=1,
-    )
-    out.to_parquet(derived / f"{code}_per_sample_tpm.parquet", index=False)
+    # source_dir is CACHE/<source_id>; the canonical writer is keyed on source_id
+    path = _cohorts.write_per_sample(gene_table, values, source_dir.name, code)
     n = values.shape[1]
-    print(f"  {code}: {len(out)} genes × {n} samples -> "
-          f"{derived / f'{code}_per_sample_tpm.parquet'}", flush=True)
+    print(f"  {code}: {len(gene_table)} genes × {n} samples -> {path}", flush=True)
     return n
 
 

--- a/scripts/generate_cohort_gene_percentiles.py
+++ b/scripts/generate_cohort_gene_percentiles.py
@@ -33,17 +33,12 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from generate_representative_cohort_samples import (  # noqa: E402
-    _SOURCES,
-    _stem_to_code,
-)
-
+from pirlygenes import cohorts as _cohorts  # noqa: E402
 from pirlygenes.expression.normalize import (  # noqa: E402
     clean_tpm_matrix,
     drop_technical_genes,
 )
 
-CACHE = Path.home() / ".cache" / "pirlygenes" / "expression"
 OUT_DIR = Path(__file__).resolve().parent.parent / "pirlygenes" / "data" \
     / "cancer-reference-expression-percentiles"
 
@@ -56,35 +51,27 @@ def build() -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     cols = [f"p{b}" for b in BREAKPOINTS]
     n_cohorts = 0
-    for source_id, _label, _project in _SOURCES:
-        derived = CACHE / source_id / "derived"
-        if not derived.exists():
+    for cohort, df in _cohorts.iter_per_sample_cohorts():
+        code = cohort.code
+        sample_cols = _cohorts.sample_columns(df)
+        if len(sample_cols) < 2:
             continue
-        stem_to_code = _stem_to_code(source_id)
-        for parquet in sorted(derived.glob("*_per_sample_tpm.parquet")):
-            stem = parquet.name[: -len("_per_sample_tpm.parquet")]
-            code = stem_to_code.get(stem, stem.upper())
-            df = pd.read_parquet(parquet)
-            sample_cols = [c for c in df.columns
-                           if c not in ("Ensembl_Gene_ID", "Symbol")]
-            if len(sample_cols) < 2:
-                continue
-            clean = clean_tpm_matrix(df[sample_cols],
-                                     gene_table=df[["Symbol", "Ensembl_Gene_ID"]],
-                                     censored_fill="fixed_fraction")
-            clean.insert(0, "Ensembl_Gene_ID", df["Ensembl_Gene_ID"].astype(str).values)
-            clean.insert(0, "Symbol", df["Symbol"].astype(str).values)
-            bio = drop_technical_genes(clean)
-            biovals = bio[sample_cols].to_numpy(dtype=np.float64)
-            pct = np.percentile(biovals, BREAKPOINTS, axis=1).T  # genes × 26
-            out = pd.DataFrame(np.log1p(pct).astype(np.float16), columns=cols)
-            out.insert(0, "Ensembl_Gene_ID", bio["Ensembl_Gene_ID"].values)
-            out.insert(0, "Symbol", bio["Symbol"].values)
-            out.to_parquet(OUT_DIR / f"{code}.parquet", index=False,
-                           compression="zstd")
-            n_cohorts += 1
-            print(f"  {code}: {len(out)} genes × {len(BREAKPOINTS)} breakpoints "
-                  f"(n={len(sample_cols)})", flush=True)
+        clean = clean_tpm_matrix(df[sample_cols],
+                                 gene_table=df[["Symbol", "Ensembl_Gene_ID"]],
+                                 censored_fill="fixed_fraction")
+        clean.insert(0, "Ensembl_Gene_ID", df["Ensembl_Gene_ID"].astype(str).values)
+        clean.insert(0, "Symbol", df["Symbol"].astype(str).values)
+        bio = drop_technical_genes(clean)
+        biovals = bio[sample_cols].to_numpy(dtype=np.float64)
+        pct = np.percentile(biovals, BREAKPOINTS, axis=1).T  # genes × 26
+        out = pd.DataFrame(np.log1p(pct).astype(np.float16), columns=cols)
+        out.insert(0, "Ensembl_Gene_ID", bio["Ensembl_Gene_ID"].values)
+        out.insert(0, "Symbol", bio["Symbol"].values)
+        out.to_parquet(OUT_DIR / f"{code}.parquet", index=False,
+                       compression="zstd")
+        n_cohorts += 1
+        print(f"  {code}: {len(out)} genes × {len(BREAKPOINTS)} breakpoints "
+              f"(n={len(sample_cols)})", flush=True)
     total_mb = sum(f.stat().st_size for f in OUT_DIR.glob("*.parquet")) / 1e6
     print(f"\ndone: {n_cohorts} cohorts, {total_mb:.0f} MB -> {OUT_DIR}", flush=True)
 

--- a/scripts/generate_representative_cohort_samples.py
+++ b/scripts/generate_representative_cohort_samples.py
@@ -45,74 +45,52 @@ from pirlygenes.expression import (
 
 OUT_DIR = Path(__file__).resolve().parent.parent / "pirlygenes" / "data" \
     / "cancer-reference-expression-representatives"
-CACHE = Path.home() / ".cache" / "pirlygenes" / "expression"
-
-# (source_id, source_cohort label, source_project) per per-sample source — the
-# single source of truth lives in pirlygenes.cohorts.PER_SAMPLE_SOURCES; this is
-# just a view of it (imported by the percentile generator too).
-_SOURCES = [(sid, label, project)
-            for sid, (label, project) in _cohorts.PER_SAMPLE_SOURCES.items()]
-
-
-def _stem_to_code(source_id: str) -> dict[str, str]:
-    """{parquet_stem: cancer_code} for a source, via the centralized cohort
-    registry (explicit map for treehouse-polya; code==stem discovery elsewhere)."""
-    return {c.stem: c.code for c in _cohorts.cohorts_for_source(source_id).values()}
 
 
 def build(k: int = 12) -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     provenance = []
     n_cohorts = 0
-    for source_id, source_cohort, source_project in _SOURCES:
-        derived = CACHE / source_id / "derived"
-        if not derived.exists():
-            print(f"[skip] no cache for {source_id}", flush=True)
+    for cohort, df in _cohorts.iter_per_sample_cohorts():
+        code = cohort.code
+        sample_cols = _cohorts.sample_columns(df)
+        if not sample_cols:
             continue
-        stem_to_code = _stem_to_code(source_id)
-        for parquet in sorted(derived.glob("*_per_sample_tpm.parquet")):
-            stem = parquet.name[: -len("_per_sample_tpm.parquet")]
-            code = stem_to_code.get(stem, stem.upper())
-            df = pd.read_parquet(parquet)
-            sample_cols = [c for c in df.columns
-                           if c not in ("Ensembl_Gene_ID", "Symbol")]
-            if not sample_cols:
-                continue
-            gene_table = df[["Symbol", "Ensembl_Gene_ID"]]
-            clean = clean_tpm_matrix(df[sample_cols], gene_table=gene_table,
-                                     censored_fill="fixed_fraction")
-            # Select medoids on the BIOLOGY-ONLY view so the choice rides on
-            # biological signal and is insensitive to the clean_tpm_v4
-            # fixed-fraction technical floor (#304); store the full clean_tpm_v4
-            # vectors for the chosen samples (matching the aggregate references).
-            sel_frame = clean.copy()
-            sel_frame.insert(0, "Ensembl_Gene_ID",
-                             df["Ensembl_Gene_ID"].astype(str).values)
-            sel_frame.insert(0, "Symbol", df["Symbol"].astype(str).values)
-            bio = drop_technical_genes(sel_frame)
-            chosen = select_representative_samples(bio[sample_cols], k)
-            reps = clean[chosen]
-            rep_ids = [f"{code}_rep{i:02d}" for i in range(1, len(chosen) + 1)]
-            out = pd.DataFrame({
-                "Ensembl_Gene_ID": df["Ensembl_Gene_ID"].astype(str).values,
-                "Symbol": df["Symbol"].astype(str).values,
+        gene_table = df[["Symbol", "Ensembl_Gene_ID"]]
+        clean = clean_tpm_matrix(df[sample_cols], gene_table=gene_table,
+                                 censored_fill="fixed_fraction")
+        # Select medoids on the BIOLOGY-ONLY view so the choice rides on
+        # biological signal and is insensitive to the clean_tpm_v4
+        # fixed-fraction technical floor (#304); store the full clean_tpm_v4
+        # vectors for the chosen samples (matching the aggregate references).
+        sel_frame = clean.copy()
+        sel_frame.insert(0, "Ensembl_Gene_ID",
+                         df["Ensembl_Gene_ID"].astype(str).values)
+        sel_frame.insert(0, "Symbol", df["Symbol"].astype(str).values)
+        bio = drop_technical_genes(sel_frame)
+        chosen = select_representative_samples(bio[sample_cols], k)
+        reps = clean[chosen]
+        rep_ids = [f"{code}_rep{i:02d}" for i in range(1, len(chosen) + 1)]
+        out = pd.DataFrame({
+            "Ensembl_Gene_ID": df["Ensembl_Gene_ID"].astype(str).values,
+            "Symbol": df["Symbol"].astype(str).values,
+        })
+        for rid, col in zip(rep_ids, chosen):
+            out[rid] = reps[col].to_numpy(dtype=np.float32)
+        out.to_parquet(OUT_DIR / f"{code}.parquet", index=False,
+                       compression="zstd")
+        for rank, rid in enumerate(rep_ids, start=1):
+            provenance.append({
+                "cancer_code": code,
+                "representative_id": rid,
+                "source_cohort": _cohorts.source_label(cohort.source_id),
+                "source_project": _cohorts.source_project(cohort.source_id),
+                "n_cohort_samples": len(sample_cols),
+                "cluster_rank": rank,
             })
-            for rid, col in zip(rep_ids, chosen):
-                out[rid] = reps[col].to_numpy(dtype=np.float32)
-            out.to_parquet(OUT_DIR / f"{code}.parquet", index=False,
-                           compression="zstd")
-            for rank, rid in enumerate(rep_ids, start=1):
-                provenance.append({
-                    "cancer_code": code,
-                    "representative_id": rid,
-                    "source_cohort": source_cohort,
-                    "source_project": source_project,
-                    "n_cohort_samples": len(sample_cols),
-                    "cluster_rank": rank,
-                })
-            n_cohorts += 1
-            print(f"  {code}: {len(sample_cols)} samples -> {len(chosen)} reps",
-                  flush=True)
+        n_cohorts += 1
+        print(f"  {code}: {len(sample_cols)} samples -> {len(chosen)} reps",
+              flush=True)
     prov = pd.DataFrame(provenance).sort_values(["cancer_code", "cluster_rank"])
     prov.to_csv(OUT_DIR / "_provenance.csv", index=False)
     total_mb = sum(f.stat().st_size for f in OUT_DIR.glob("*.parquet")) / 1e6


### PR DESCRIPTION
Follow-on to #330: the per-sample parquet **layout** (suffix, id columns, read/iterate/write) was duplicated across `coverage.py` + both generators + `build_ne`. `cohorts.py` now owns it:
- `PER_SAMPLE_SUFFIX` + `ID_COLS`; `sample_columns(df)`; `read_per_sample()` (canonical open + error); `iter_per_sample_cohorts()` (one iteration point, used by both generators); `write_per_sample()` (one writer, used by build_ne).
- `coverage.cohort_matrix` + the 3 scripts refactored onto these — removed the duplicated read/split loop, the script-level `_SOURCES`/`_stem_to_code`/`CACHE`, and the hand-rolled writer.

**Behaviour-preserving:** regenerated both bundle artifacts → byte-identical (0 shard changes), no DATA_VERSION bump. Full gate green (481). Code-only.