### PR TITLE
Final per-sample dedup: shared shard-codes helper + single breakpoints def (#329)

### DIFF
--- a/pirlygenes/expression/accessors.py
+++ b/pirlygenes/expression/accessors.py
@@ -1159,16 +1159,26 @@ def _bundle_subdir(name: str):
     return data_bundle.cache_dir() / name
 
 
+def _available_shard_codes(root) -> list[str]:
+    """Sorted cohort codes that ship a parquet shard under ``root`` (the shared
+    body of the ``available_*_cohorts`` accessors). ``root`` is resolved by the
+    per-artifact root function so test monkeypatches on those still apply."""
+    if not root.exists():
+        return []
+    return sorted(p.stem for p in root.glob("*.parquet"))
+
+
 def _representatives_root():
     return _bundle_subdir(_REPRESENTATIVES_DIR)
 
 
+def _percentiles_root():
+    return _bundle_subdir(_PERCENTILES_DIR)
+
+
 def available_representative_cohorts() -> list[str]:
     """Registry codes that ship a representative-samples shard (sorted)."""
-    root = _representatives_root()
-    if not root.exists():
-        return []
-    return sorted(p.stem for p in root.glob("*.parquet"))
+    return _available_shard_codes(_representatives_root())
 
 
 def representative_cohort_samples(
@@ -1276,10 +1286,7 @@ _PERCENTILES_DIR = "cancer-reference-expression-percentiles"
 
 def available_percentile_cohorts() -> list[str]:
     """Cohort codes that ship a per-gene percentile-vector shard (sorted)."""
-    root = _bundle_subdir(_PERCENTILES_DIR)
-    if not root.exists():
-        return []
-    return sorted(p.stem for p in root.glob("*.parquet"))
+    return _available_shard_codes(_percentiles_root())
 
 
 def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame:
@@ -1300,7 +1307,7 @@ def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame
     """
     from ..gene_sets_cancer import resolve_cancer_type
     code = resolve_cancer_type(cancer_type)
-    shard = _bundle_subdir(_PERCENTILES_DIR) / f"{code}.parquet"
+    shard = _percentiles_root() / f"{code}.parquet"
     if not shard.exists():
         raise ValueError(
             f"no percentile vector for {code!r} — only cohorts with per-sample "

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.21.28"
+__version__ = "5.21.29"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cohort_gene_percentiles.py
+++ b/tests/test_cohort_gene_percentiles.py
@@ -1,5 +1,8 @@
 """Per-gene × cohort tail-weighted percentile vectors (#298)."""
 
+import sys
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -8,7 +11,11 @@ from pirlygenes.expression import (
     cohort_gene_percentiles,
 )
 
-_BP = [f"p{b}" for b in ([0, 1] + list(range(5, 91, 5)) + [95, 96, 97, 98, 99, 100])]
+# single source of truth for the breakpoints: the generator defines them.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from generate_cohort_gene_percentiles import BREAKPOINTS  # noqa: E402
+
+_BP = [f"p{b}" for b in BREAKPOINTS]
 
 
 def _skip_if_absent():


### PR DESCRIPTION
Last single-source-of-truth gaps in the recent code:
- `_available_shard_codes(root)` — shared body of `available_representative_cohorts`/`available_percentile_cohorts` (was the same glob-stem twice); both now go through their root resolver (added `_percentiles_root` for symmetry + to keep the test monkeypatch seam).
- the percentile test imports `BREAKPOINTS` from the generator instead of re-listing the 26 breakpoints.

Code-only, behaviour-preserving. Full gate green (481).