### PR TITLE
Centralize strip_version onto the single core primitive

### DIFF
--- a/pirlygenes/gene_families.py
+++ b/pirlygenes/gene_families.py
@@ -42,6 +42,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from .gene_ids import strip_version as _strip_version
+
 
 _DATA_DIR = Path(__file__).resolve().parent / "data"
 
@@ -75,11 +77,6 @@ GENE_FAMILIES: tuple[GeneFamily, ...] = (
 
 
 # ---------- helpers ----------
-
-
-def _strip_version(ensg: str) -> str:
-    """``ENSG00000251562.5`` → ``ENSG00000251562``."""
-    return str(ensg or "").split(".", 1)[0].strip()
 
 
 @lru_cache(maxsize=1)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.21.29"
+__version__ = "5.21.30"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/scripts/build_bl_gdc_reference_expression.py
+++ b/scripts/build_bl_gdc_reference_expression.py
@@ -23,6 +23,7 @@ import pandas as pd
 from pyensembl import EnsemblRelease
 
 from pirlygenes.builders.gene_mapping import resolve_symbol
+from pirlygenes.gene_ids import strip_version as _strip_version
 from pirlygenes.expression.stats import (
     REFERENCE_COLUMNS,
     assign_stats,
@@ -71,10 +72,6 @@ BL_DIAGNOSES = {
     "Burkitt lymphoma, NOS (Includes all variants)",
     "Burkitt-like lymphoma",
 }
-
-
-def _strip_version(value: object) -> str:
-    return str(value).split(".", 1)[0]
 
 
 def _gdc_filters() -> dict:

--- a/scripts/build_cllmap_reference_expression.py
+++ b/scripts/build_cllmap_reference_expression.py
@@ -20,6 +20,7 @@ import pandas as pd
 from pyensembl import EnsemblRelease
 
 from pirlygenes.builders.gene_mapping import resolve_symbol
+from pirlygenes.gene_ids import strip_version as _strip_version
 from pirlygenes.expression.stats import (
     REFERENCE_COLUMNS,
     assign_stats,
@@ -49,10 +50,6 @@ SOURCE_VERSION = (
     "CLL-map RNA-SeQC v2.3.6 GENCODE19; Ensembl IDs harmonized to "
     "Ensembl release 112; downloaded 2026-05-18"
 )
-
-
-def _strip_version(value: object) -> str:
-    return str(value).split(".", 1)[0]
 
 
 def _read_tpm_matrix(path: Path) -> pd.DataFrame:

--- a/scripts/build_mmrf_reference_expression.py
+++ b/scripts/build_mmrf_reference_expression.py
@@ -22,6 +22,7 @@ import pandas as pd
 from pyensembl import EnsemblRelease
 
 from pirlygenes.builders.gene_mapping import resolve_symbol
+from pirlygenes.gene_ids import strip_version as _strip_version
 from pirlygenes.expression.stats import (
     REFERENCE_COLUMNS,
     assign_stats,
@@ -44,10 +45,6 @@ SOURCE_VERSION = (
     "Ensembl release 112; queried 2026-05-18"
 )
 STAR_TPM_COL = "tpm_unstranded"
-
-
-def _strip_version(value: object) -> str:
-    return str(value).split(".", 1)[0]
 
 
 def _gdc_filters() -> dict:

--- a/scripts/build_target_all_reference_expression.py
+++ b/scripts/build_target_all_reference_expression.py
@@ -26,6 +26,7 @@ import pandas as pd
 from pyensembl import EnsemblRelease
 
 from pirlygenes.builders.gene_mapping import resolve_symbol
+from pirlygenes.gene_ids import strip_version as _strip_version
 from pirlygenes.expression.stats import (
     REFERENCE_COLUMNS,
     assign_stats,
@@ -65,10 +66,6 @@ PRIMARY_SAMPLE_TYPES = {
     "Primary Blood Derived Cancer - Bone Marrow": 0,
     "Primary Blood Derived Cancer - Peripheral Blood": 1,
 }
-
-
-def _strip_version(value: object) -> str:
-    return str(value).split(".", 1)[0]
 
 
 def _gdc_filters() -> dict:

--- a/scripts/build_target_subprojects.py
+++ b/scripts/build_target_subprojects.py
@@ -31,6 +31,7 @@ import pandas as pd
 from pyensembl import EnsemblRelease
 
 from pirlygenes.builders.gene_mapping import resolve_symbol
+from pirlygenes.gene_ids import strip_version as _strip_version
 from pirlygenes.expression.stats import (
     REFERENCE_COLUMNS,
     assign_stats,
@@ -85,10 +86,6 @@ PROJECTS = [
         cache_subdir="target-wt",
     ),
 ]
-
-
-def _strip_version(v: object) -> str:
-    return str(v).split(".", 1)[0]
 
 
 def _gdc_filters(project_id: str) -> dict:


### PR DESCRIPTION
## What

Part of the gene-list / mapping centralization audit ("every gene list, mapping, &c is centralized and never duplicated or inconsistent"). This collapses the most clear-cut duplication found: **`strip_version` had 6 copies**.

Canonical primitive: `pirlygenes.gene_ids.strip_version` (`ENSG00000251562.5` -> `ENSG00000251562`). Per CLAUDE.md's "one path per task", everything now imports it:

- **`pirlygenes/gene_families.py`** (shipped) dropped its local `_strip_version` and imports the core primitive. Behavior-preserving: both call sites (`_load_table`, `gene_family_for_ensembl_id`) operate on already-`str`-cast ENSG values, where the two implementations are identical.
- **5 build-time scripts** (`build_bl_gdc`, `build_target_all`, `build_mmrf`, `build_cllmap`, `build_target_subprojects`) replace their identical local `_strip_version` with an import alias; call sites unchanged.

## Audit context

The broader audit confirmed these are **already single-source** (no action): clean-TPM censor list, symbol/ID resolution (`resolve_symbol`/`entrez_to_gene`), cancer-code->name registry. And these are **intentional documented divergences** (left as-is, tested): `filter_technical_rna` vs `clean_tpm_removal_mask`, gene-family CSVs vs clean-tpm-censored (both derived from the one `classify_gene_qc` regex), `is_extended_housekeeping_symbol`.

One genuine item remains and needs a decision (not in this PR): the cohort code lists are duplicated across the 8 `sweep_treehouse_*` scripts (build-time) and `cohorts.py` (read-time registry), and have drifted. Candidate for a drift-guard test rather than a risky hoist.

## Verification

No data change -> `DATA_VERSION` unchanged. `__version__` 5.21.29 -> 5.21.30. Full gate green: **481 passed**.
