### PR TITLE
Unify per-sample cohort definitions into one registry

### DIFF
--- a/pirlygenes/builders/treehouse.py
+++ b/pirlygenes/builders/treehouse.py
@@ -124,6 +124,30 @@ class TreehouseCohort:
         return self.cache_stem or self.cancer_code
 
 
+def _tcga_case_id(row: dict) -> str | None:
+    """The TCGA case submitter-id prefix (e.g. ``TCGA-AB-1234``) for a Treehouse
+    clinical row, or None if the sample isn't a TCGA sample."""
+    dsid = str(row.get("th_dataset_id", ""))
+    if not dsid.startswith("TCGA"):
+        return None
+    return "-".join(dsid.split("-")[:3])
+
+
+def tcga_only_predicate() -> Callable[[dict], bool]:
+    """Sample predicate: keep only TCGA samples (``th_dataset_id`` starts with
+    ``TCGA``). The one definition the TCGA-subset sweeps share."""
+    return lambda row: _tcga_case_id(row) is not None
+
+
+def tcga_case_predicate(cases: Iterable[str]) -> Callable[[dict], bool]:
+    """Sample predicate: keep TCGA samples whose case submitter-id is in
+    ``cases`` (a set fetched per-sweep from cBioPortal / GDC). The one
+    definition the molecular/histology-split sweeps share, so the
+    TCGA-only + case-membership logic isn't copy-pasted into each script."""
+    wanted = set(cases)
+    return lambda row: (cid := _tcga_case_id(row)) is not None and cid in wanted
+
+
 def _log(msg: str) -> None:
     print(f"[treehouse {time.strftime('%H:%M:%S')}] {msg}", flush=True)
 

--- a/pirlygenes/cohorts.py
+++ b/pirlygenes/cohorts.py
@@ -41,11 +41,38 @@ ID_COLS = ("Ensembl_Gene_ID", "Symbol")
 
 @dataclass(frozen=True)
 class Cohort:
-    """One materialised per-sample cohort within a build source."""
+    """One materialised per-sample cohort within a build source.
+
+    The first three fields (``code``, ``stem``, ``source_id``) are all the
+    read path needs. The remaining fields are the **build-time** definition
+    that previously lived only in the ``scripts/sweep_treehouse_*`` scripts;
+    hoisting them here makes this registry the single source of truth that
+    *both* the read accessors and the build sweeps consume (so the two can
+    never drift):
+
+    * ``group`` — which build sweep materialises this cohort (the sweep
+      filters the registry by it via :func:`cohorts_for_group`).
+    * ``disease_label`` — the Treehouse clinical ``disease`` label the sweep
+      filters samples on.
+    * ``selection`` — a declarative subset selector the sweep turns into a
+      ``sample_predicate``. Grammar (``""`` = no predicate, take every sample
+      with ``disease_label``):
+
+        ``tcga``                    TCGA-only subset (th_dataset_id startswith TCGA)
+        ``gdc_project:TCGA-GBM``    TCGA-only + GDC case→project membership
+        ``pam50:BRCA_Basal``        TCGA-only + cBioPortal PAM50 call
+        ``hpv:HNSC_HPV+``           TCGA-only + cBioPortal HPV call
+        ``mutation:STK11,KEAP1``    TCGA-only + cBioPortal mutation in ANY gene
+        ``histology:Dedifferentiated liposarcoma``
+                                    TCGA-only + GDC primary_diagnosis
+    """
 
     code: str        # registry cancer-type code (e.g. "GBM", "BRCA_LumA")
     stem: str        # per-sample parquet stem (filename minus _per_sample_tpm.parquet)
     source_id: str   # expression source id (downloads registry)
+    group: str = "direct"      # build sweep that materialises it
+    disease_label: str = ""    # Treehouse clinical `disease` label to filter on
+    selection: str = ""        # declarative subset selector (see class docstring)
 
     @property
     def source_kind(self) -> str:
@@ -64,50 +91,7 @@ class Cohort:
         return f"{self.source_kind}:{self.code}"
 
 
-# --- treehouse-polya-25-01 -------------------------------------------------
-# Pediatric / sarcoma / rare cohorts: parquet stem == cancer code.
-_TH_DIRECT = [
-    "ATRT", "SARC_EWS", "HEPB", "MBL", "NPC", "NUTM", "SARC_OS",
-    "SARC_RMS_ARMS", "SARC_RMS_ERMS", "SARC_RMS_PRMS", "SARC_RMS_SSRMS",
-    "SARC_ANGIO", "SARC_ASPS", "SARC_DSRCT", "SARC_EHE", "SARC_EPITH",
-    "SARC_GIST", "SARC_IFS", "SARC_IMT", "SARC_LGFMS", "SARC_LMS",
-    "SARC_LPS_UNSPEC", "SARC_MPNST", "SARC_MYXFIB", "SARC_SYN", "SARC_UPS",
-]
-# TCGA-via-Treehouse direct projects: stem == "tcga_<lower(code)>".
-_TH_TCGA = [
-    "ACC", "BLCA", "BRCA", "CESC", "CHOL", "COAD", "DLBC", "ESCA", "GBM",
-    "HNSC", "KICH", "KIRC", "KIRP", "LAML", "LGG", "LIHC", "LUAD", "LUSC",
-    "MESO", "OV", "PAAD", "PCPG", "PRAD", "READ", "SKCM", "STAD",
-    "TGCT", "THCA", "THYM", "UCEC", "UCS", "UVM",
-]
-# NB: no "SARC" — the bare SARC code is the computed pan-sarcoma grand union (its
-# TCGA-SARC leiomyosarcoma samples are already in the SARC_LMS atom), not a
-# concrete per-sample cohort.
-# Molecular / histology sub-cohorts (mixed-case codes -> explicit stems).
-_TH_DERIVED = {
-    "BRCA_Basal": "tcga_brca_basal", "BRCA_HER2": "tcga_brca_her2",
-    "BRCA_LumA": "tcga_brca_luma", "BRCA_LumB": "tcga_brca_lumb",
-    "BRCA_Normal": "tcga_brca_normal",
-    "HNSC_HPVneg": "tcga_hnsc_hpv_neg", "HNSC_HPVpos": "tcga_hnsc_hpv_pos",
-    "LUAD_EGFR": "tcga_luad_egfr", "LUAD_KRAS": "tcga_luad_kras",
-    "LUAD_STK11": "tcga_luad_stk11",
-    "SARC_DDLPS": "tcga_sarc_ddlps", "SARC_PLEOLPS": "tcga_sarc_pleolps",
-    "SARC_WDLPS": "tcga_sarc_wdlps",
-}
-
-
-def _treehouse_polya_25_01() -> dict[str, Cohort]:
-    src = "treehouse-polya-25-01"
-    out: dict[str, Cohort] = {}
-    for code in _TH_DIRECT:
-        out[code] = Cohort(code, code, src)
-    for code in _TH_TCGA:
-        out[code] = Cohort(code, f"tcga_{code.lower()}", src)
-    for code, stem in _TH_DERIVED.items():
-        out[code] = Cohort(code, stem, src)
-    return out
-
-
+# ---------------------------------------------------------------------------
 # Single source of truth for the per-sample expression sources: ``source_id ->
 # (source_cohort label, project)``. The generators and the package accessors all
 # read this — don't duplicate the list in scripts. ``label`` is the
@@ -122,12 +106,196 @@ PER_SAMPLE_SOURCES: dict[str, tuple[str, str]] = {
     "drmetrics-lnen-2020": ("DRMETRICS_ALCALA_2019_LNEN", "IARC LNEN"),
 }
 
-# Sources with an explicit code→Cohort map (mixed-case stems that don't
-# round-trip from the parquet name). Every other source in PER_SAMPLE_SOURCES
-# discovers its cohorts from disk with ``code == stem``.
+
+# ---------------------------------------------------------------------------
+# The single declarative registry of every Treehouse per-sample cohort —
+# (code, stem, disease_label, selection) per build group. This is the one
+# source of truth the read accessors AND the ``scripts/sweep_treehouse_*``
+# build sweeps both consume; neither side enumerates cohorts independently, so
+# they can't drift. ``group`` names the sweep that materialises the rows.
+# ---------------------------------------------------------------------------
+
+_POLYA = "treehouse-polya-25-01"
+_RIBOD = "treehouse-ribod-25-01"
+
+# Pediatric / sarcoma / rare cohorts registered as their own Treehouse disease
+# label; parquet stem == code, no sample predicate (whole disease label).
+# group "polya_pediatric" -> scripts/sweep_treehouse_polya_cohorts.py
+_POLYA_PEDIATRIC = [
+    ("ATRT", "atypical teratoid/rhabdoid tumor"),
+    ("SARC_EWS", "Ewing sarcoma"),
+    ("HEPB", "hepatoblastoma"),
+    ("MBL", "medulloblastoma"),
+    ("NUTM", "NUT midline carcinoma"),
+    ("SARC_OS", "osteosarcoma"),
+    ("SARC_RMS_ARMS", "alveolar rhabdomyosarcoma"),
+    ("SARC_RMS_ERMS", "embryonal rhabdomyosarcoma"),
+    ("SARC_RMS_PRMS", "pleomorphic rhabdomyosarcoma"),
+    ("SARC_RMS_SSRMS", "spindle cell/sclerosing rhabdomyosarcoma"),
+    ("SARC_LMS", "leiomyosarcoma"),
+    ("SARC_LPS_UNSPEC", "liposarcoma"),
+    ("SARC_MYXFIB", "myxofibrosarcoma"),
+    ("SARC_SYN", "synovial sarcoma"),
+    ("SARC_UPS", "undifferentiated pleomorphic sarcoma"),
+]
+# Rare-subtype Treehouse-direct codes (zero-download, own disease labels).
+# group "sarc_rare_direct" -> scripts/sweep_sarc_rare_subtypes.py (direct path).
+# NPC is not a sarcoma but uses the same Treehouse-direct pattern.
+_SARC_RARE_DIRECT = [
+    ("SARC_ANGIO", "angiosarcoma"),
+    ("SARC_ASPS", "alveolar soft part sarcoma"),
+    ("SARC_DSRCT", "desmoplastic small round cell tumor"),
+    ("SARC_EPITH", "epithelioid sarcoma"),
+    ("SARC_IMT", "inflammatory myofibroblastic tumor"),
+    ("SARC_IFS", "infantile fibrosarcoma"),
+    ("SARC_MPNST", "malignant peripheral nerve sheath tumor"),
+    ("SARC_EHE", "epithelioid hemangioendothelioma"),
+    ("SARC_LGFMS", "low grade fibromyxoid sarcoma"),
+    ("NPC", "nasopharyngeal carcinoma"),
+]
+# TCGA-via-Treehouse direct projects: stem == "tcga_<lower(code)>", TCGA-only.
+# group "tcga_direct" -> scripts/sweep_treehouse_tcga_cohorts.py.
+# NB: GBM/LGG are split out (tcga_glioma group); the bare "SARC" code is the
+# computed pan-sarcoma grand union, not a concrete per-sample cohort.
+_TCGA_DIRECT = [
+    ("ACC", "adrenocortical carcinoma"),
+    ("BLCA", "bladder urothelial carcinoma"),
+    ("BRCA", "breast invasive carcinoma"),
+    ("CESC", "cervical & endocervical cancer"),
+    ("CHOL", "cholangiocarcinoma"),
+    ("COAD", "colon adenocarcinoma"),
+    ("DLBC", "diffuse large B-cell lymphoma"),
+    ("ESCA", "esophageal carcinoma"),
+    ("HNSC", "head & neck squamous cell carcinoma"),
+    ("KICH", "kidney chromophobe"),
+    ("KIRC", "kidney clear cell carcinoma"),
+    ("KIRP", "kidney papillary cell carcinoma"),
+    ("LAML", "acute myeloid leukemia"),
+    ("LIHC", "hepatocellular carcinoma"),
+    ("LUAD", "lung adenocarcinoma"),
+    ("LUSC", "lung squamous cell carcinoma"),
+    ("MESO", "mesothelioma"),
+    ("OV", "ovarian serous cystadenocarcinoma"),
+    ("PAAD", "pancreatic adenocarcinoma"),
+    ("PCPG", "pheochromocytoma & paraganglioma"),
+    ("PRAD", "prostate adenocarcinoma"),
+    ("READ", "rectum adenocarcinoma"),
+    ("SKCM", "skin cutaneous melanoma"),
+    ("STAD", "stomach adenocarcinoma"),
+    ("TGCT", "testicular germ cell tumor"),
+    ("THCA", "thyroid carcinoma"),
+    ("THYM", "thymoma"),
+    ("UCEC", "uterine corpus endometrioid carcinoma"),
+    ("UCS", "uterine carcinosarcoma"),
+    ("UVM", "uveal melanoma"),
+]
+
+
+def _treehouse_registry() -> tuple[Cohort, ...]:
+    rows: list[Cohort] = []
+    for code, label in _POLYA_PEDIATRIC:
+        rows.append(Cohort(code, code, _POLYA, group="polya_pediatric",
+                           disease_label=label))
+    for code, label in _SARC_RARE_DIRECT:
+        rows.append(Cohort(code, code, _POLYA, group="sarc_rare_direct",
+                           disease_label=label))
+    # gastrointestinal stromal tumour: Treehouse-direct (not in TCGA-SARC).
+    rows.append(Cohort("SARC_GIST", "SARC_GIST", _POLYA, group="sarc_subtypes",
+                       disease_label="gastrointestinal stromal tumor"))
+    for code, label in _TCGA_DIRECT:
+        rows.append(Cohort(code, f"tcga_{code.lower()}", _POLYA,
+                           group="tcga_direct", disease_label=label,
+                           selection="tcga"))
+    # glioma: Treehouse's single "glioma" label split TCGA-GBM vs TCGA-LGG.
+    for code in ("GBM", "LGG"):
+        rows.append(Cohort(code, f"tcga_{code.lower()}", _POLYA,
+                           group="tcga_glioma", disease_label="glioma",
+                           selection=f"gdc_project:TCGA-{code}"))
+    # TCGA-BRCA PAM50 molecular subtypes (cBioPortal calls). selection holds the
+    # cBioPortal PAM50 label (case differs from the registry code, e.g. Her2).
+    for code, pam50 in [("BRCA_Basal", "BRCA_Basal"), ("BRCA_HER2", "BRCA_Her2"),
+                        ("BRCA_LumA", "BRCA_LumA"), ("BRCA_LumB", "BRCA_LumB"),
+                        ("BRCA_Normal", "BRCA_Normal")]:
+        suffix = code.removeprefix("BRCA_").lower()
+        rows.append(Cohort(code, f"tcga_brca_{suffix}", _POLYA,
+                           group="tcga_brca_pam50",
+                           disease_label="breast invasive carcinoma",
+                           selection=f"pam50:{pam50}"))
+    # TCGA-HNSC HPV split (cBioPortal calls).
+    for code, hpv, suffix in [("HNSC_HPVpos", "HNSC_HPV+", "hpv_pos"),
+                              ("HNSC_HPVneg", "HNSC_HPV-", "hpv_neg")]:
+        rows.append(Cohort(code, f"tcga_hnsc_{suffix}", _POLYA,
+                           group="tcga_hnsc_hpv",
+                           disease_label="head & neck squamous cell carcinoma",
+                           selection=f"hpv:{hpv}"))
+    # TCGA-LUAD driver-mutation subtypes (cBioPortal MAF; any gene in the set).
+    for code, genes in [("LUAD_EGFR", "EGFR"), ("LUAD_KRAS", "KRAS"),
+                        ("LUAD_STK11", "STK11,KEAP1")]:
+        suffix = code.removeprefix("LUAD_").lower()
+        rows.append(Cohort(code, f"tcga_luad_{suffix}", _POLYA,
+                           group="tcga_luad_mut",
+                           disease_label="lung adenocarcinoma",
+                           selection=f"mutation:{genes}"))
+    # TCGA-SARC histology overlays (GDC primary_diagnosis). WDLPS is built by
+    # the sarc_subtypes sweep; DDLPS/PLEOLPS by the sarc_rare overlay path.
+    for code, diagnosis, grp in [
+            ("SARC_WDLPS", "Liposarcoma, well differentiated", "sarc_subtypes"),
+            ("SARC_DDLPS", "Dedifferentiated liposarcoma", "sarc_rare_overlay"),
+            ("SARC_PLEOLPS", "Pleomorphic liposarcoma", "sarc_rare_overlay")]:
+        suffix = code.removeprefix("SARC_").lower()
+        rows.append(Cohort(code, f"tcga_sarc_{suffix}", _POLYA, group=grp,
+                           disease_label="liposarcoma",
+                           selection=f"histology:{diagnosis}"))
+    # treehouse-ribod-25-01 (ribo-depleted release): stem == code.
+    rows.append(Cohort("SARC_CHOR", "SARC_CHOR", _RIBOD, group="ribod",
+                       disease_label="chordoma"))
+    rows.append(Cohort("RB", "RB", _RIBOD, group="ribod",
+                       disease_label="retinoblastoma"))
+    return tuple(rows)
+
+
+_TREEHOUSE_COHORTS: tuple[Cohort, ...] = _treehouse_registry()
+
+
+# Neuroendocrine per-sample cohorts, built by
+# scripts/build_ne_per_sample_parquets.py from cached NE source data (GEO
+# log2TPM pancreatic NET, UCologne FPKM small-cell lung, IARC LNEN counts lung
+# NET/NEC). Declared here — with ``stem == code`` — so the registry is the
+# *complete* per-sample source of truth: the read path can enumerate them
+# without the cache present, rather than only discovering them from disk. Their
+# sample→code *selection* lives in the source-specific builders (e.g. the LNEN
+# histology map), exactly as the Treehouse predicates do; the registry owns the
+# cohort *list*, not the per-source build mechanism.
+_NE_COHORTS: tuple[Cohort, ...] = (
+    Cohort("NET_PANCREAS", "NET_PANCREAS", "gse118014-pannet", group="neuroendocrine"),
+    Cohort("SCLC", "SCLC", "sclc-ucologne-2015", group="neuroendocrine"),
+    Cohort("NET_LUNG", "NET_LUNG", "drmetrics-lnen-2020", group="neuroendocrine"),
+    Cohort("NEC_LUNG_LARGECELL", "NEC_LUNG_LARGECELL", "drmetrics-lnen-2020",
+           group="neuroendocrine"),
+)
+
+# The single declarative registry of EVERY per-sample cohort across all sources.
+_PER_SAMPLE_COHORTS: tuple[Cohort, ...] = _TREEHOUSE_COHORTS + _NE_COHORTS
+
+
+def _registry_for_source(source_id: str) -> dict[str, Cohort]:
+    return {c.code: c for c in _PER_SAMPLE_COHORTS if c.source_id == source_id}
+
+
+# Sources with an explicit code→Cohort map. A source that has rows in the
+# registry above uses that map; any other source in PER_SAMPLE_SOURCES (e.g. a
+# newly added one) still discovers its cohorts from disk with ``code == stem``.
 _REGISTRY: dict[str, dict[str, Cohort]] = {
-    "treehouse-polya-25-01": _treehouse_polya_25_01(),
+    sid: _registry_for_source(sid)
+    for sid in {c.source_id for c in _PER_SAMPLE_COHORTS}
 }
+
+
+def cohorts_for_group(group: str) -> list[Cohort]:
+    """All registry cohorts in a given build group (in registry order). The
+    build sweeps call this instead of enumerating cohorts inline, so the
+    (code, stem, disease_label, selection) of every cohort lives here once."""
+    return [c for c in _PER_SAMPLE_COHORTS if c.group == group]
 
 
 def source_label(source_id: str) -> str | None:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.21.30"
+__version__ = "5.21.31"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/scripts/build_ne_per_sample_parquets.py
+++ b/scripts/build_ne_per_sample_parquets.py
@@ -58,12 +58,19 @@ def _mapping(symbols, source_dir: Path):
         refresh=False)
 
 
+def _only_code(source_id: str) -> str:
+    """The single registered cohort code for a source — the registry in
+    pirlygenes.cohorts is the source of truth for the code, not a literal here."""
+    (code,) = _cohorts.cohorts_for_source(source_id)
+    return code
+
+
 def build_net_pancreas() -> None:
     d = CACHE / "gse118014-pannet"
     log2v = pannet._read_log2tpm(d / "GSE118014_PanNETs_log2TPM.txt.gz")
     tpm = _inverse_log2(log2v)
     gene_table, values = _aggregate_by_ensembl(tpm, _mapping(log2v.index, d))
-    _write(gene_table, values, d, "NET_PANCREAS")
+    _write(gene_table, values, d, _only_code(d.name))
 
 
 def build_sclc() -> None:
@@ -71,7 +78,7 @@ def build_sclc() -> None:
     fpkm = sclc._read_fpkm(d / "data_mrna_seq_fpkm.txt")
     tpm = sclc._fpkm_to_tpm(fpkm)
     gene_table, values = _aggregate_by_ensembl(tpm, _mapping(fpkm.index, d))
-    _write(gene_table, values, d, "SCLC")
+    _write(gene_table, values, d, _only_code(d.name))
 
 
 def build_lung_ne() -> None:
@@ -107,6 +114,10 @@ def build_lung_ne() -> None:
         raw_code = sample_to_code.get(col)
         if raw_code:
             by_code.setdefault(canonical_cancer_code(raw_code), []).append(col)
+    # The LNEN histology map (+ canonical_cancer_code) is the sample->code
+    # *selection*; the registry owns the cohort *list*. Guard they agree.
+    registered = set(_cohorts.cohorts_for_source(d.name))
+    assert set(by_code) <= registered, (set(by_code), registered)
     for code, cols in by_code.items():
         _write(gene_table, values[cols], d, code)
 

--- a/scripts/sweep_sarc_rare_subtypes.py
+++ b/scripts/sweep_sarc_rare_subtypes.py
@@ -47,7 +47,9 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_case_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -86,43 +88,17 @@ RELEASE_TCGA = TreehouseRelease(
 )
 
 
-TREEHOUSE_DIRECT = [
-    ("SARC_ANGIO", "angiosarcoma"),
-    ("SARC_ASPS", "alveolar soft part sarcoma"),
-    ("SARC_DSRCT", "desmoplastic small round cell tumor"),
-    ("SARC_EPITH", "epithelioid sarcoma"),
-    ("SARC_IMT", "inflammatory myofibroblastic tumor"),
-    ("SARC_IFS", "infantile fibrosarcoma"),
-    ("SARC_MPNST", "malignant peripheral nerve sheath tumor"),
-    ("SARC_EHE", "epithelioid hemangioendothelioma"),
-    ("SARC_LGFMS", "low grade fibromyxoid sarcoma"),
-    # Not a sarcoma but uses the same Treehouse-direct pattern — kept
-    # here for code reuse. Low n but populates the registry code.
-    ("NPC", "nasopharyngeal carcinoma"),
-]
-
-# TCGA-SARC primary_diagnosis → registry code
-TCGA_SARC_OVERLAYS = [
-    ("SARC_DDLPS", "Dedifferentiated liposarcoma", "liposarcoma"),
-    ("SARC_PLEOLPS", "Pleomorphic liposarcoma", "liposarcoma"),
-]
+# Cohort definitions (code, stem, disease_label, selection) come from the
+# single registry in pirlygenes.cohorts: group "sarc_rare_direct" (Treehouse
+# direct) and group "sarc_rare_overlay" (TCGA-SARC histology overlays).
 
 
 def _build_histology_predicate(histology: pd.DataFrame, primary_diagnosis: str):
-    cases = set(
-        histology.loc[
-            histology["primary_diagnosis"].eq(primary_diagnosis),
-            "submitter_id",
-        ].astype(str)
-    )
-
-    def _pred(row: dict) -> bool:
-        dsid = str(row.get("th_dataset_id", ""))
-        if not dsid.startswith("TCGA"):
-            return False
-        case_id = "-".join(dsid.split("-")[:3])
-        return case_id in cases
-    return _pred
+    cases = histology.loc[
+        histology["primary_diagnosis"].eq(primary_diagnosis),
+        "submitter_id",
+    ].astype(str)
+    return tcga_case_predicate(cases)
 
 
 def main() -> int:
@@ -137,18 +113,19 @@ def main() -> int:
     args = parser.parse_args()
 
     # (a) Treehouse direct
-    print("=== Treehouse direct (8 codes) ===")
+    print("=== Treehouse direct ===")
     cohorts_direct = [
         TreehouseCohort(
-            cancer_code=code,
-            disease_label=label,
+            cancer_code=c.code,
+            disease_label=c.disease_label,
             extra_notes=(
-                f"All Treehouse samples labelled disease == '{label}'. "
+                f"All Treehouse samples labelled disease == '{c.disease_label}'. "
                 "Mostly Treehouse-internal + publicly-available "
                 "non-TCGA repositories."
             ),
+            cache_stem=c.stem,
         )
-        for code, label in TREEHOUSE_DIRECT
+        for c in cohorts_for_group("sarc_rare_direct")
     ]
     run_sweep(
         RELEASE_TREEHOUSE,
@@ -175,11 +152,12 @@ def main() -> int:
     histology = pd.read_csv(histology_cache)
 
     cohorts_tcga = []
-    for code, primary_diagnosis, disease_label in TCGA_SARC_OVERLAYS:
+    for c in cohorts_for_group("sarc_rare_overlay"):
+        primary_diagnosis = c.selection.split(":", 1)[1]
         cohorts_tcga.append(
             TreehouseCohort(
-                cancer_code=code,
-                disease_label=disease_label,
+                cancer_code=c.code,
+                disease_label=c.disease_label,
                 sample_predicate=_build_histology_predicate(
                     histology, primary_diagnosis,
                 ),
@@ -188,7 +166,7 @@ def main() -> int:
                     f"'{primary_diagnosis}'. Routed out of the "
                     "TCGA-SARC project via GDC histology lookup."
                 ),
-                cache_stem=f"tcga_sarc_{code.removeprefix('SARC_').lower()}",
+                cache_stem=c.stem,
             )
         )
     run_sweep(

--- a/scripts/sweep_treehouse_polya_cohorts.py
+++ b/scripts/sweep_treehouse_polya_cohorts.py
@@ -16,6 +16,7 @@ from pirlygenes.builders.treehouse import (
     TreehouseRelease,
     run_sweep,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -35,22 +36,12 @@ RELEASE = TreehouseRelease(
     pipeline_prefix="treehouse_polya_25_01_log2tpm_to_tpm",
 )
 
+# Cohort definitions come from the single registry in pirlygenes.cohorts
+# (group "polya_pediatric") — not enumerated here, so the read accessors and
+# this build sweep can't drift. Whole-disease-label cohorts (no predicate).
 COHORTS = [
-    TreehouseCohort("ATRT", "atypical teratoid/rhabdoid tumor"),
-    TreehouseCohort("SARC_EWS", "Ewing sarcoma"),
-    TreehouseCohort("HEPB", "hepatoblastoma"),
-    TreehouseCohort("MBL", "medulloblastoma"),
-    TreehouseCohort("NUTM", "NUT midline carcinoma"),
-    TreehouseCohort("SARC_OS", "osteosarcoma"),
-    TreehouseCohort("SARC_RMS_ARMS", "alveolar rhabdomyosarcoma"),
-    TreehouseCohort("SARC_RMS_ERMS", "embryonal rhabdomyosarcoma"),
-    TreehouseCohort("SARC_RMS_PRMS", "pleomorphic rhabdomyosarcoma"),
-    TreehouseCohort("SARC_RMS_SSRMS", "spindle cell/sclerosing rhabdomyosarcoma"),
-    TreehouseCohort("SARC_LMS", "leiomyosarcoma"),
-    TreehouseCohort("SARC_LPS_UNSPEC", "liposarcoma"),
-    TreehouseCohort("SARC_MYXFIB", "myxofibrosarcoma"),
-    TreehouseCohort("SARC_SYN", "synovial sarcoma"),
-    TreehouseCohort("SARC_UPS", "undifferentiated pleomorphic sarcoma"),
+    TreehouseCohort(c.code, c.disease_label, cache_stem=c.stem)
+    for c in cohorts_for_group("polya_pediatric")
 ]
 
 

--- a/scripts/sweep_treehouse_ribod_cohorts.py
+++ b/scripts/sweep_treehouse_ribod_cohorts.py
@@ -19,6 +19,7 @@ from pirlygenes.builders.treehouse import (
     TreehouseRelease,
     run_sweep,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -38,9 +39,11 @@ RELEASE = TreehouseRelease(
     pipeline_prefix="treehouse_ribod_25_01_log2tpm_to_tpm",
 )
 
+# Cohort definitions come from the single registry in pirlygenes.cohorts
+# (group "ribod"); not enumerated here.
 COHORTS = [
-    TreehouseCohort("SARC_CHOR", "chordoma"),
-    TreehouseCohort("RB", "retinoblastoma"),
+    TreehouseCohort(c.code, c.disease_label, cache_stem=c.stem)
+    for c in cohorts_for_group("ribod")
 ]
 
 

--- a/scripts/sweep_treehouse_sarc_subtypes.py
+++ b/scripts/sweep_treehouse_sarc_subtypes.py
@@ -38,11 +38,17 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_case_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
 RELEASE_DIR = CACHE_ROOT / "treehouse-polya-25-01"
+
+# Cohort definitions (code, stem, disease_label, selection) come from the
+# single registry in pirlygenes.cohorts (group "sarc_subtypes").
+_SUBTYPES = {c.code: c for c in cohorts_for_group("sarc_subtypes")}
 
 # Two distinct source_cohort tags = two distinct shards.
 RELEASE_TREEHOUSE = TreehouseRelease(
@@ -103,21 +109,12 @@ def _fetch_sarc_histology(cache_path: Path) -> pd.DataFrame:
     return df
 
 
-def _build_wdlps_predicate(histology: pd.DataFrame):
-    wdlps_cases = set(
-        histology.loc[
-            histology["primary_diagnosis"].eq("Liposarcoma, well differentiated"),
-            "submitter_id",
-        ].astype(str)
-    )
-
-    def _pred(row: dict) -> bool:
-        dsid = str(row.get("th_dataset_id", ""))
-        if not dsid.startswith("TCGA"):
-            return False
-        case_id = "-".join(dsid.split("-")[:3])
-        return case_id in wdlps_cases
-    return _pred
+def _build_histology_predicate(histology: pd.DataFrame, primary_diagnosis: str):
+    cases = histology.loc[
+        histology["primary_diagnosis"].eq(primary_diagnosis),
+        "submitter_id",
+    ].astype(str)
+    return tcga_case_predicate(cases)
 
 
 def main() -> int:
@@ -132,18 +129,20 @@ def main() -> int:
     args = parser.parse_args()
 
     # --- GIST: non-TCGA Treehouse samples under disease label ---
+    gist = _SUBTYPES["SARC_GIST"]
     print("=== SARC_GIST: Treehouse direct (n=19) ===")
     run_sweep(
         RELEASE_TREEHOUSE,
         [
             TreehouseCohort(
-                cancer_code="SARC_GIST",
-                disease_label="gastrointestinal stromal tumor",
+                cancer_code=gist.code,
+                disease_label=gist.disease_label,
                 extra_notes=(
                     "All 19 GIST samples in Treehouse 25.01 PolyA. "
                     "Not from TCGA-SARC (TCGA-SARC excluded GIST); "
                     "Treehouse-internal + publicly-available repositories."
                 ),
+                cache_stem=gist.stem,
             ),
         ],
         summary_output=args.summary_output,
@@ -152,25 +151,26 @@ def main() -> int:
     )
 
     # --- WDLPS: TCGA-SARC histology overlay ---
+    wdlps = _SUBTYPES["SARC_WDLPS"]
+    primary_diagnosis = wdlps.selection.split(":", 1)[1]
     print()
     print("=== SARC_WDLPS: TCGA-SARC histology overlay (n=5) ===")
     histology_cache = RELEASE_DIR / "derived" / "tcga_sarc_histology.csv"
     histology = _fetch_sarc_histology(histology_cache)
-    pred = _build_wdlps_predicate(histology)
+    pred = _build_histology_predicate(histology, primary_diagnosis)
     run_sweep(
         RELEASE_TCGA,
         [
             TreehouseCohort(
-                cancer_code="SARC_WDLPS",
-                disease_label="liposarcoma",
+                cancer_code=wdlps.code,
+                disease_label=wdlps.disease_label,
                 sample_predicate=pred,
                 extra_notes=(
-                    "TCGA-SARC histology = 'Liposarcoma, well "
-                    "differentiated' (n=5). Routed out of the "
-                    "TCGA-SARC project via GDC primary_diagnosis "
-                    "lookup on the case submitter_id."
+                    f"TCGA-SARC histology = '{primary_diagnosis}' (n=5). "
+                    "Routed out of the TCGA-SARC project via GDC "
+                    "primary_diagnosis lookup on the case submitter_id."
                 ),
-                cache_stem="tcga_sarc_wdlps",
+                cache_stem=wdlps.stem,
             ),
         ],
         summary_output=args.summary_output,

--- a/scripts/sweep_treehouse_tcga_brca_pam50.py
+++ b/scripts/sweep_treehouse_tcga_brca_pam50.py
@@ -41,7 +41,9 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_case_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -63,13 +65,8 @@ RELEASE = TreehouseRelease(
 )
 
 
-PAM50_TO_REGISTRY = {
-    "BRCA_Basal": "BRCA_Basal",
-    "BRCA_Her2": "BRCA_HER2",
-    "BRCA_LumA": "BRCA_LumA",
-    "BRCA_LumB": "BRCA_LumB",
-    "BRCA_Normal": "BRCA_Normal",
-}
+# Cohort definitions (code, stem, selection="pam50:<cBioPortal label>") come
+# from the single registry in pirlygenes.cohorts (group "tcga_brca_pam50").
 
 
 def _fetch_cbioportal_pam50(cache_path: Path) -> pd.DataFrame:
@@ -89,16 +86,6 @@ def _fetch_cbioportal_pam50(cache_path: Path) -> pd.DataFrame:
     return df
 
 
-def _build_pam50_predicate(cases_for_subtype: set[str]):
-    def _pred(row: dict) -> bool:
-        dsid = str(row.get("th_dataset_id", ""))
-        if not dsid.startswith("TCGA"):
-            return False
-        case_id = "-".join(dsid.split("-")[:3])
-        return case_id in cases_for_subtype
-    return _pred
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--ensembl-release", default=112, type=int)
@@ -116,18 +103,19 @@ def main() -> int:
     print(f"loaded cBioPortal PAM50 calls: {counts}")
 
     cohorts = []
-    for pam50_label, registry_code in PAM50_TO_REGISTRY.items():
+    for c in cohorts_for_group("tcga_brca_pam50"):
+        pam50_label = c.selection.split(":", 1)[1]
         cases = set(
             pam50.loc[pam50["pam50"] == pam50_label, "patientId"].astype(str)
         )
         if not cases:
-            print(f"  skipping {registry_code}: no cases")
+            print(f"  skipping {c.code}: no cases")
             continue
         cohorts.append(
             TreehouseCohort(
-                cancer_code=registry_code,
-                disease_label="breast invasive carcinoma",
-                sample_predicate=_build_pam50_predicate(cases),
+                cancer_code=c.code,
+                disease_label=c.disease_label,
+                sample_predicate=tcga_case_predicate(cases),
                 extra_notes=(
                     f"PAM50 subtype = '{pam50_label}' per cBioPortal "
                     "brca_tcga_pan_can_atlas_2018 (Hoadley 2018 "
@@ -136,7 +124,7 @@ def main() -> int:
                     "submitter_id is classified as this PAM50 subtype "
                     "in the cBioPortal study."
                 ),
-                cache_stem=f"tcga_brca_{pam50_label.replace('BRCA_', '').lower()}",
+                cache_stem=c.stem,
             )
         )
 

--- a/scripts/sweep_treehouse_tcga_cohorts.py
+++ b/scripts/sweep_treehouse_tcga_cohorts.py
@@ -28,7 +28,9 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_only_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -54,66 +56,25 @@ RELEASE = TreehouseRelease(
 )
 
 
-def _is_tcga(row: dict) -> bool:
-    return str(row.get("th_dataset_id", "")).startswith("TCGA")
-
-
-# (cancer_code, Treehouse disease label). One row per direct TCGA
-# project mapping. GBM/LGG and SARC sub-histology splits are deferred.
-TCGA_MAPPING: list[tuple[str, str]] = [
-    ("ACC", "adrenocortical carcinoma"),
-    ("BLCA", "bladder urothelial carcinoma"),
-    ("BRCA", "breast invasive carcinoma"),
-    ("CESC", "cervical & endocervical cancer"),
-    ("CHOL", "cholangiocarcinoma"),
-    ("COAD", "colon adenocarcinoma"),
-    ("DLBC", "diffuse large B-cell lymphoma"),
-    ("ESCA", "esophageal carcinoma"),
-    ("HNSC", "head & neck squamous cell carcinoma"),
-    ("KICH", "kidney chromophobe"),
-    ("KIRC", "kidney clear cell carcinoma"),
-    ("KIRP", "kidney papillary cell carcinoma"),
-    ("LAML", "acute myeloid leukemia"),
-    ("LIHC", "hepatocellular carcinoma"),
-    ("LUAD", "lung adenocarcinoma"),
-    ("LUSC", "lung squamous cell carcinoma"),
-    ("MESO", "mesothelioma"),
-    ("OV", "ovarian serous cystadenocarcinoma"),
-    ("PAAD", "pancreatic adenocarcinoma"),
-    ("PCPG", "pheochromocytoma & paraganglioma"),
-    ("PRAD", "prostate adenocarcinoma"),
-    ("READ", "rectum adenocarcinoma"),
-    # No bare "SARC" cohort: the TCGA-SARC leiomyosarcoma samples it used to
-    # capture are already in SARC_LMS (the Treehouse "leiomyosarcoma" atom keeps
-    # TCGA + non-TCGA samples), and the other TCGA-SARC histologies are likewise
-    # already in their SARC_UPS / SARC_MYXFIB / SARC_SYN / SARC_MPNST atoms. So
-    # "SARC" was a redundant leiomyosarcoma slice; the bare SARC code is now the
-    # computed pan-sarcoma grand union (cancer-cohort-aggregates.csv).
-    ("SKCM", "skin cutaneous melanoma"),
-    ("STAD", "stomach adenocarcinoma"),
-    ("TGCT", "testicular germ cell tumor"),
-    ("THCA", "thyroid carcinoma"),
-    ("THYM", "thymoma"),
-    ("UCEC", "uterine corpus endometrioid carcinoma"),
-    ("UCS", "uterine carcinosarcoma"),
-    ("UVM", "uveal melanoma"),
-]
-
-
+# (cancer_code, stem, disease_label) come from the single registry in
+# pirlygenes.cohorts (group "tcga_direct"); GBM/LGG (glioma split) and the
+# SARC sub-histologies live under their own groups. The bare "SARC" code is
+# the computed pan-sarcoma grand union (cancer-cohort-aggregates.csv), not a
+# concrete per-sample cohort, so it is intentionally absent.
 COHORTS = [
     TreehouseCohort(
-        cancer_code=code,
-        disease_label=label,
-        sample_predicate=_is_tcga,
+        cancer_code=c.code,
+        disease_label=c.disease_label,
+        sample_predicate=tcga_only_predicate(),
         extra_notes=(
             "TCGA subset only: filtered via "
             "`th_dataset_id.startswith('TCGA')` against Treehouse's "
             "compendium-wide disease label. Treehouse-internal "
             "samples with the same disease are excluded from this row."
         ),
-        cache_stem=f"tcga_{code.lower()}",
+        cache_stem=c.stem,
     )
-    for code, label in TCGA_MAPPING
+    for c in cohorts_for_group("tcga_direct")
 ]
 
 

--- a/scripts/sweep_treehouse_tcga_glioma_split.py
+++ b/scripts/sweep_treehouse_tcga_glioma_split.py
@@ -28,7 +28,9 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_case_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -84,14 +86,10 @@ def _fetch_case_to_project_map(cache_path: Path) -> pd.DataFrame:
     return df
 
 
-def _build_predicate(project_id: str, case_to_project: dict[str, str]):
-    def _pred(row: dict) -> bool:
-        dsid = str(row.get("th_dataset_id", ""))
-        if not dsid.startswith("TCGA"):
-            return False
-        case_id = "-".join(dsid.split("-")[:3])
-        return case_to_project.get(case_id) == project_id
-    return _pred
+def _project_predicate(project_id: str, case_to_project: dict[str, str]):
+    """Predicate for the TCGA samples whose case maps to ``project_id``."""
+    cases = {cid for cid, proj in case_to_project.items() if proj == project_id}
+    return tcga_case_predicate(cases)
 
 
 def main() -> int:
@@ -114,30 +112,24 @@ def main() -> int:
         f"{(case_map_df['project_id']=='TCGA-LGG').sum()} LGG"
     )
 
-    cohorts = [
-        TreehouseCohort(
-            cancer_code="GBM",
-            disease_label="glioma",
-            sample_predicate=_build_predicate("TCGA-GBM", case_to_project),
-            extra_notes=(
-                "TCGA-GBM split from Treehouse's compendium-wide 'glioma' "
-                "bucket via GDC case→project lookup on the TCGA submitter "
-                "ID prefix."
-            ),
-            cache_stem="tcga_gbm",
-        ),
-        TreehouseCohort(
-            cancer_code="LGG",
-            disease_label="glioma",
-            sample_predicate=_build_predicate("TCGA-LGG", case_to_project),
-            extra_notes=(
-                "TCGA-LGG split from Treehouse's compendium-wide 'glioma' "
-                "bucket via GDC case→project lookup on the TCGA submitter "
-                "ID prefix."
-            ),
-            cache_stem="tcga_lgg",
-        ),
-    ]
+    # Cohort definitions (code, stem, selection="gdc_project:TCGA-*") come from
+    # the single registry in pirlygenes.cohorts (group "tcga_glioma").
+    cohorts = []
+    for c in cohorts_for_group("tcga_glioma"):
+        project_id = c.selection.split(":", 1)[1]
+        cohorts.append(
+            TreehouseCohort(
+                cancer_code=c.code,
+                disease_label=c.disease_label,
+                sample_predicate=_project_predicate(project_id, case_to_project),
+                extra_notes=(
+                    f"{project_id} split from Treehouse's compendium-wide "
+                    "'glioma' bucket via GDC case→project lookup on the TCGA "
+                    "submitter ID prefix."
+                ),
+                cache_stem=c.stem,
+            )
+        )
 
     run_sweep(
         RELEASE,

--- a/scripts/sweep_treehouse_tcga_hnsc_hpv.py
+++ b/scripts/sweep_treehouse_tcga_hnsc_hpv.py
@@ -25,7 +25,9 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_case_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -47,10 +49,8 @@ RELEASE = TreehouseRelease(
 )
 
 
-HPV_TO_REGISTRY = {
-    "HNSC_HPV+": "HNSC_HPVpos",
-    "HNSC_HPV-": "HNSC_HPVneg",
-}
+# Cohort definitions (code, stem, selection="hpv:<cBioPortal label>") come from
+# the single registry in pirlygenes.cohorts (group "tcga_hnsc_hpv").
 
 
 def _fetch_cbioportal_hpv(cache_path: Path) -> pd.DataFrame:
@@ -70,16 +70,6 @@ def _fetch_cbioportal_hpv(cache_path: Path) -> pd.DataFrame:
     return df
 
 
-def _build_predicate(cases_for_subtype: set[str]):
-    def _pred(row: dict) -> bool:
-        dsid = str(row.get("th_dataset_id", ""))
-        if not dsid.startswith("TCGA"):
-            return False
-        case_id = "-".join(dsid.split("-")[:3])
-        return case_id in cases_for_subtype
-    return _pred
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--ensembl-release", default=112, type=int)
@@ -96,15 +86,16 @@ def main() -> int:
     print(f"loaded HPV calls: {hpv['hpv_subtype'].value_counts().to_dict()}")
 
     cohorts = []
-    for hpv_label, registry_code in HPV_TO_REGISTRY.items():
+    for c in cohorts_for_group("tcga_hnsc_hpv"):
+        hpv_label = c.selection.split(":", 1)[1]
         cases = set(
             hpv.loc[hpv["hpv_subtype"] == hpv_label, "patientId"].astype(str)
         )
         cohorts.append(
             TreehouseCohort(
-                cancer_code=registry_code,
-                disease_label="head & neck squamous cell carcinoma",
-                sample_predicate=_build_predicate(cases),
+                cancer_code=c.code,
+                disease_label=c.disease_label,
+                sample_predicate=tcga_case_predicate(cases),
                 extra_notes=(
                     f"HPV subtype = '{hpv_label}' per cBioPortal "
                     "hnsc_tcga_pan_can_atlas_2018 (Cao 2016 "
@@ -113,7 +104,7 @@ def main() -> int:
                     "submitter_id is classified as this HPV subtype "
                     "in the cBioPortal study."
                 ),
-                cache_stem=f"tcga_hnsc_{'hpv_pos' if hpv_label.endswith('+') else 'hpv_neg'}",
+                cache_stem=c.stem,
             )
         )
 

--- a/scripts/sweep_treehouse_tcga_luad_mutations.py
+++ b/scripts/sweep_treehouse_tcga_luad_mutations.py
@@ -34,7 +34,9 @@ from pirlygenes.builders.treehouse import (
     TreehouseCohort,
     TreehouseRelease,
     run_sweep,
+    tcga_case_predicate,
 )
+from pirlygenes.cohorts import cohorts_for_group
 
 
 CACHE_ROOT = Path.home() / ".cache" / "pirlygenes" / "expression"
@@ -99,26 +101,17 @@ def _cases_with_any_mutation(mut: pd.DataFrame, genes: list[str]) -> set[str]:
     return set(case_ids)
 
 
-def _build_predicate(cases: set[str]):
-    def _pred(row: dict) -> bool:
-        dsid = str(row.get("th_dataset_id", ""))
-        if not dsid.startswith("TCGA"):
-            return False
-        case_id = "-".join(dsid.split("-")[:3])
-        return case_id in cases
-    return _pred
-
-
-SUBTYPES = [
-    ("LUAD_EGFR", ["EGFR"], "EGFR-mutant: any cBioPortal-called EGFR coding mutation"),
-    ("LUAD_KRAS", ["KRAS"], "KRAS-mutant: any cBioPortal-called KRAS coding mutation"),
-    (
-        "LUAD_STK11",
-        ["STK11", "KEAP1"],
+# Cohort definitions (code, stem, selection="mutation:<gene[,gene]>") come from
+# the single registry in pirlygenes.cohorts (group "tcga_luad_mut"). Notes are
+# build-specific prose, kept here keyed by code.
+_NOTE_BY_CODE = {
+    "LUAD_EGFR": "EGFR-mutant: any cBioPortal-called EGFR coding mutation",
+    "LUAD_KRAS": "KRAS-mutant: any cBioPortal-called KRAS coding mutation",
+    "LUAD_STK11": (
         "STK11/KEAP1-mutant: any cBioPortal-called STK11 OR KEAP1 coding "
-        "mutation (canonical K/L axis; immune-cold subset).",
+        "mutation (canonical K/L axis; immune-cold subset)."
     ),
-]
+}
 
 
 def main() -> int:
@@ -138,18 +131,19 @@ def main() -> int:
     print(f"cBioPortal LUAD mutation counts: {counts_by_gene}")
 
     cohorts = []
-    for cancer_code, genes, note in SUBTYPES:
+    for c in cohorts_for_group("tcga_luad_mut"):
+        genes = c.selection.split(":", 1)[1].split(",")
         cases = _cases_with_any_mutation(mut, genes)
         if not cases:
-            print(f"skipping {cancer_code}: no cases")
+            print(f"skipping {c.code}: no cases")
             continue
         cohorts.append(
             TreehouseCohort(
-                cancer_code=cancer_code,
-                disease_label="lung adenocarcinoma",
-                sample_predicate=_build_predicate(cases),
-                extra_notes=note,
-                cache_stem=f"tcga_luad_{cancer_code.removeprefix('LUAD_').lower()}",
+                cancer_code=c.code,
+                disease_label=c.disease_label,
+                sample_predicate=tcga_case_predicate(cases),
+                extra_notes=_NOTE_BY_CODE[c.code],
+                cache_stem=c.stem,
             )
         )
 

--- a/tests/test_cohorts_registry.py
+++ b/tests/test_cohorts_registry.py
@@ -4,9 +4,21 @@ cohorts.py is the single source of truth for which per-sample expression sources
 exist and which cohorts they hold (explicit map for treehouse-polya; code==stem
 discovery from the cached derived parquets elsewhere)."""
 
+import importlib.util
+from pathlib import Path
+
 import pandas as pd
 
 from pirlygenes import cohorts
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load_script(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def test_per_sample_sources_complete():
@@ -48,3 +60,86 @@ def test_discovery_source_uses_stem_equals_code(tmp_path, monkeypatch):
 
 def test_unknown_source_empty():
     assert cohorts.cohorts_for_source("nope") == {}
+
+
+# --- the single declarative registry of every Treehouse per-sample cohort -----
+
+def test_registry_has_no_duplicate_codes():
+    codes = [c.code for c in cohorts._PER_SAMPLE_COHORTS]
+    assert len(codes) == len(set(codes)), "duplicate cohort code in registry"
+
+
+def test_registry_covers_the_expected_cohort_set():
+    """Lock the exact (code -> stem) set per source so any add/rename/restem is
+    a deliberate, reviewed registry edit (the read path and the sweeps both read
+    this — neither enumerates cohorts independently)."""
+    polya = {c.code: c.stem for c in cohorts._PER_SAMPLE_COHORTS
+             if c.source_id == "treehouse-polya-25-01"}
+    # 26 polya-direct (stem==code) + 30 tcga-direct + 2 glioma + 13 molecular/
+    # histology splits = 71.
+    assert len(polya) == 71
+    # spot-check each stem rule
+    assert polya["ATRT"] == "ATRT"                  # pediatric direct
+    assert polya["NPC"] == "NPC"                    # rare-subtype direct
+    assert polya["SARC_GIST"] == "SARC_GIST"        # treehouse-direct GIST
+    assert polya["PRAD"] == "tcga_prad"             # tcga direct
+    assert polya["GBM"] == "tcga_gbm"               # glioma split
+    assert polya["BRCA_LumA"] == "tcga_brca_luma"   # pam50
+    assert polya["HNSC_HPVpos"] == "tcga_hnsc_hpv_pos"  # hpv
+    assert polya["LUAD_STK11"] == "tcga_luad_stk11"     # mutation
+    assert polya["SARC_WDLPS"] == "tcga_sarc_wdlps"     # histology overlay
+    ribod = {c.code: c.stem for c in cohorts._PER_SAMPLE_COHORTS
+             if c.source_id == "treehouse-ribod-25-01"}
+    assert ribod == {"SARC_CHOR": "SARC_CHOR", "RB": "RB"}
+
+
+def test_neuroendocrine_cohorts_declared_for_all_ne_sources():
+    """The NE per-sample cohorts are declared in the registry (not only
+    discovered from disk), so cohorts.py can enumerate every per-sample cohort
+    without the cache present."""
+    by_source = {sid: set(cohorts.cohorts_for_source(sid)) for sid in
+                 ("gse118014-pannet", "sclc-ucologne-2015", "drmetrics-lnen-2020")}
+    assert by_source == {
+        "gse118014-pannet": {"NET_PANCREAS"},
+        "sclc-ucologne-2015": {"SCLC"},
+        "drmetrics-lnen-2020": {"NET_LUNG", "NEC_LUNG_LARGECELL"}}
+    # NE stems are code==stem
+    for sid in by_source:
+        for c in cohorts.cohorts_for_source(sid).values():
+            assert c.stem == c.code
+
+
+def test_groups_partition_the_registry():
+    """Every cohort belongs to exactly one build group; the groups together
+    cover the whole registry (no orphan rows a sweep would never build)."""
+    by_group = {}
+    for c in cohorts._PER_SAMPLE_COHORTS:
+        by_group.setdefault(c.group, []).append(c.code)
+    assert sum(len(v) for v in by_group.values()) == len(cohorts._PER_SAMPLE_COHORTS)
+    assert set(by_group) == {
+        "polya_pediatric", "sarc_rare_direct", "sarc_subtypes",
+        "sarc_rare_overlay", "tcga_direct", "tcga_glioma",
+        "tcga_brca_pam50", "tcga_hnsc_hpv", "tcga_luad_mut", "ribod",
+        "neuroendocrine"}
+
+
+def test_cohorts_for_group_filters_by_group():
+    pam50 = cohorts.cohorts_for_group("tcga_brca_pam50")
+    assert {c.code for c in pam50} == {
+        "BRCA_Basal", "BRCA_HER2", "BRCA_LumA", "BRCA_LumB", "BRCA_Normal"}
+    assert all(c.selection.startswith("pam50:") for c in pam50)
+    assert cohorts.cohorts_for_group("not-a-group") == []
+
+
+def test_static_sweeps_consume_the_registry():
+    """The build sweeps build their cohort list FROM the registry (not an inline
+    copy) — so the two can't drift. Verified for the three network-free sweeps
+    whose COHORTS are built at import time."""
+    for script, group in [
+            ("sweep_treehouse_polya_cohorts", "polya_pediatric"),
+            ("sweep_treehouse_ribod_cohorts", "ribod"),
+            ("sweep_treehouse_tcga_cohorts", "tcga_direct")]:
+        mod = _load_script(script)
+        built = {c.cancer_code: c.effective_cache_stem for c in mod.COHORTS}
+        expected = {c.code: c.stem for c in cohorts.cohorts_for_group(group)}
+        assert built == expected, (script, built, expected)


### PR DESCRIPTION
## What

The per-sample cohort list was enumerated **twice** — in `cohorts.py` (read path) and across 10 build scripts (build path) — and could drift. This hoists all of it into **one declarative registry in `pirlygenes.cohorts`** that both the read accessors and the build sweeps consume.

### `cohorts.py`
- `Cohort` gains build-time fields (`group`, `disease_label`, `selection`) with a declarative `selection` grammar (`tcga` / `gdc_project:` / `pam50:` / `hpv:` / `mutation:` / `histology:`) the sweeps turn into sample predicates.
- One registry of **all 77 per-sample cohorts**: 71 treehouse-polya + 2 treehouse-ribod + **4 neuroendocrine** (NET_PANCREAS, SCLC, NET_LUNG, NEC_LUNG_LARGECELL). Replaces the split `_TH_DIRECT/_TH_TCGA/_TH_DERIVED` lists; **read path is byte-identical** (verified against the old maps).
- New `cohorts_for_group()`; explicit map per registered source, disk discovery kept as a fallback for unregistered sources.

### `builders/treehouse.py`
- The TCGA case-membership predicate (copy-pasted in 5 sweeps) is centralized as `tcga_only_predicate` / `tcga_case_predicate`.

### Build scripts (10)
- The 9 `sweep_treehouse_*` / `sweep_sarc_rare` scripts + `build_ne_per_sample_parquets` now derive their cohort list from the registry via `cohorts_for_group()` / `cohorts_for_source()` instead of enumerating inline.

### Why this scope
Treehouse was the genuine duplication (read + 10 build scripts). The NE sources weren't duplicated (the read path discovered them from disk) but were undeclared, so they're now in the registry too. Summary-only reference cohorts (BL/TARGET/MMRF/CLL/microarray/NE-summaries) are a separate axis (per-gene-per-cohort summaries, not per-sample) and out of scope here.

## Verification
Read path byte-identical; every script constructs identical `(code, stem, disease_label, predicate, notes)`; new tests lock the cohort set, group partition, NE declaration, and that the static sweeps build from the registry. No shipped data change → `DATA_VERSION` unchanged; `__version__` → 5.21.31. Full gate green (**487 passed**).
