### PR TITLE
Curate anti-PD-1 ORR by cancer type (+ 9mer-payload plot variants)

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -534,14 +534,26 @@ def main():
     payload_fn = _mean_specific_9mer_payload(weights)
 
     def _emit_load_metrics(thr, cutoffs=None):
-        _metric_vs_tmb(mat, cohorts, thr, _mean_ctas_per_sample,
-                       "mean # CTAs expressed per sample", "cta_mean_count_vs_tmb",
-                       pctile_cutoffs=cutoffs, exclude=frozenset({"HEPB"}),
-                       slug_suffix="_noHEPB")
-        _metric_vs_tmb(mat, cohorts, thr, payload_fn,
-                       "mean CTA-specific 9mers per sample", "cta_9mer_payload_vs_tmb",
-                       pctile_cutoffs=cutoffs, exclude=frozenset({"HEPB"}),
-                       slug_suffix="_noHEPB")
+        # Same variant matrix as the coverage-vs-TMB plot (_cta_vs_tmb): base
+        # (all cohorts incl. HEPB), no-HEPB (drops the TMB~0.02 outlier), and
+        # no-HEPB subtypes-only (drop a parent category when its subtypes are
+        # also plotted) — for BOTH load metrics: mean #CTAs/sample and mean
+        # CTA-specific-9mer payload/sample.
+        for value_fn, ylabel, slug in (
+            (_mean_ctas_per_sample, "mean # CTAs expressed per sample",
+             "cta_mean_count_vs_tmb"),
+            (payload_fn, "mean CTA-specific 9mers per sample",
+             "cta_9mer_payload_vs_tmb"),
+        ):
+            _metric_vs_tmb(mat, cohorts, thr, value_fn, ylabel, slug,
+                           pctile_cutoffs=cutoffs)
+            _metric_vs_tmb(mat, cohorts, thr, value_fn, ylabel, slug,
+                           pctile_cutoffs=cutoffs, exclude=frozenset({"HEPB"}),
+                           slug_suffix="_noHEPB")
+            _metric_vs_tmb(mat, cohorts, thr, value_fn, ylabel, slug,
+                           pctile_cutoffs=cutoffs, exclude=frozenset({"HEPB"}),
+                           slug_suffix="_noHEPB_subtypesonly",
+                           drop_covered_parents=True)
 
     _emit_load_metrics(tpm_thr)
 
@@ -983,7 +995,8 @@ def _cohort_on_matrix(mat, cols, thr, pctile_cutoffs):
 
 
 def _metric_vs_tmb(mat, cohorts, thr, value_fn, ylabel, slug, *,
-                   pctile_cutoffs=None, exclude=frozenset(), slug_suffix=""):
+                   pctile_cutoffs=None, exclude=frozenset(), slug_suffix="",
+                   drop_covered_parents=False):
     """Generic scatter of a per-cohort per-sample CTA metric vs median TMB
     (log-x), styled like :func:`_cta_vs_tmb` but with a free (auto) y-axis and
     no sweet-spot band. ``value_fn(mat, cols, thr, pctile_cutoffs) -> float`` is
@@ -1017,6 +1030,8 @@ def _metric_vs_tmb(mat, cohorts, thr, value_fn, ylabel, slug, *,
         if tmb is None:
             continue
         pts.append((code, len(cols), value_fn(mat, cols, thr, pctile_cutoffs), tmb))
+    if drop_covered_parents:
+        pts = _drop_covered_parents(pts, _parent_code_map())
     if not pts:
         print("      no cohorts with metric + TMB; skip", flush=True)
         return

--- a/pirlygenes/data/cancer-apd1-response.csv
+++ b/pirlygenes/data/cancer-apd1-response.csv
@@ -1,0 +1,24 @@
+cancer_code,apd1_orr_pct,drug,trial,setting,pmid_doi,confidence,notes
+SKCM,33,pembrolizumab,KEYNOTE-006,advanced; <=1 prior tx; all-comers,PMID:25891173,high,ORR ~33% (Q2W/Q3W pooled) vs ipilimumab 12%
+LUAD,45,pembrolizumab,KEYNOTE-024,first-line; PD-L1 TPS>=50% selected,PMID:27718847,high,PD-L1>=50% selected; all-comers/low-PD-L1 ~18% (KEYNOTE-042 PMID:30955977)
+LUSC,45,pembrolizumab,KEYNOTE-024,first-line; PD-L1 TPS>=50% selected,PMID:27718847,medium,NSCLC pooled in KN-024; squamous subset similar to adeno
+LUAD_STK11,10,pembrolizumab,KEYNOTE-042 subgroup,STK11/KEAP1-mutant immune-cold subset,PMID:30955977,low,Approximate; STK11/KEAP1-mutant LUAD is immune-cold with markedly lower aPD1 benefit (reported mainly as PFS/OS HRs)
+HNSC,19,pembrolizumab,KEYNOTE-048,first-line R/M; CPS>=1; monotherapy arm,PMID:33052747,high,CPS>=20 ~23%; total population ~17%; HPV+/HPV- differential not cleanly established in KN-048
+KIRC,25,nivolumab,CheckMate-025,pretreated (post-VEGF TKI); all-comers,PMID:26406148,high,vs everolimus 5%
+BLCA,24,pembrolizumab,KEYNOTE-052,first-line cisplatin-ineligible; all-comers,PMID:32552471,high,CheckMate-275 pretreated ~20%
+COAD,5,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; only the ~13% MSI-H/dMMR respond (MSI-H ~45%; MSS ~0%)
+READ,5,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; MSI-H ~45% and MSS ~0%
+STAD,12,pembrolizumab,KEYNOTE-059,third-line; all-comers,PMID:29260193,medium,CPS>=1 ~16%; monotherapy indication later withdrawn
+LIHC,17,nivolumab,CheckMate-040,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion
+ESCA,18,nivolumab,ATTRACTION-3,pretreated; esophageal SCC,PMID:31582355,medium,nivo ~19%; KEYNOTE-181 ESCC subgroup ~17%
+CESC,15,pembrolizumab,KEYNOTE-158,pretreated; PD-L1+ (CPS>=1) selected,PMID:30943124,high,All responders were PD-L1+; all-comer ~12%
+HL,71,nivolumab,CheckMate-205,relapsed/refractory post-ASCT,PMID:29584546,high,Very high responder; KEYNOTE-087 pembro ~69%
+NEC_MERKEL,56,pembrolizumab,KEYNOTE-017,first-line advanced; all-comers,PMID:30726175,high,Very high responder; CR ~24%
+BRCA_Basal,5,pembrolizumab,KEYNOTE-086,pretreated metastatic TNBC; all-comers,PMID:30475950,medium,Cohort A (pretreated) ~5%; PD-L1+ untreated cohort B ~21%
+UCEC,8,pembrolizumab,KEYNOTE-158,all-comers (response is MMR-dependent),PMID:34990208,medium,dMMR/MSI-H ~50% vs pMMR ~6% (KN-158); all-comer is a weighted blend
+SCLC,13,nivolumab,CheckMate-032,pretreated; all-comers,PMID:27269732,medium,~10-19%; nivo mono ~10%; KEYNOTE-028 PD-L1-selected was higher (~33%) but not representative
+MESO,10,pembrolizumab,KEYNOTE-158,pretreated; all-comers,PMID:33125908,low,Reported ~8-20% across studies
+NPC,25,pembrolizumab,KEYNOTE-028,pretreated; PD-L1+ selected,PMID:28837405,medium,KN-028 NPC cohort ~26%
+PRAD,4,pembrolizumab,KEYNOTE-199,pretreated mCRPC,PMID:31774688,high,Near-zero anchor; ~5% PD-L1+ / ~3% PD-L1-
+PAAD,1,pembrolizumab,pooled/basket,pretreated; MSS,,low,Near-zero anchor (~0-3%); no single clean monotherapy trial; rare dMMR/MSI-H PDAC responds (~37%) but is a tiny subset
+GBM,8,nivolumab,CheckMate-143,recurrent; all-comers,PMID:32437507,high,Near-zero anchor; vs bevacizumab 23%

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -2114,6 +2114,52 @@ def cancer_tmb(cancer_type=None, *, inherit=True):
     return None
 
 
+def cancer_apd1_response_df():
+    """Return the curated ``cancer-apd1-response.csv`` reference: representative
+    objective response rate (ORR, %) to anti-PD-1 **monotherapy**
+    (pembrolizumab / nivolumab) per cancer-type code, with the drug, pivotal
+    trial, treatment setting, a published source PMID/DOI, and a confidence
+    flag.
+
+    Intended as a per-cancer-type plotting axis (e.g. TMB vs aPD1 ORR, CTA
+    burden vs aPD1 ORR). Values are representative anchors, not exact
+    reproducible constants — they shift with data cutoff, line of therapy, and
+    biomarker selection (PD-L1 / MSI / MMR); the ``setting`` and ``notes``
+    columns record that context. Several cancers are strongly biomarker-
+    dependent (COAD/READ MSI-H ~45% vs MSS ~0%; UCEC dMMR ~50% vs pMMR ~6%) —
+    the row carries the all-comer blend and the split is noted."""
+    return get_data("cancer-apd1-response")
+
+
+def cancer_apd1_response(cancer_type=None, *, inherit=True):
+    """Anti-PD-1 monotherapy ORR (%) for one cancer type, or the whole
+    ``{code: orr_pct}`` map. ``cancer_type`` is resolved through
+    :func:`resolve_cancer_type`; with ``inherit`` (default) a code with no
+    curated row of its own inherits its nearest ancestor's value via the
+    registry ``parent_code`` chain (so ``SCLC_ASCL1`` -> ``SCLC``,
+    ``LUAD_KRAS`` -> ``LUAD``). Returns ``None`` if neither the code nor any
+    ancestor has a value. Mirrors :func:`cancer_tmb`."""
+    df = cancer_apd1_response_df()
+    vals = df.dropna(subset=["apd1_orr_pct"])
+    mapping = dict(zip(vals["cancer_code"].astype(str),
+                       vals["apd1_orr_pct"].astype(float)))
+    if cancer_type is None:
+        return mapping
+    code = resolve_cancer_type(cancer_type)
+    if code in mapping or not inherit:
+        return mapping.get(code)
+    reg = cancer_type_registry().set_index("code")
+    cur, seen = code, set()
+    while cur and cur not in seen:
+        seen.add(cur)
+        if cur in mapping:
+            return mapping[cur]
+        if cur not in reg.index:
+            break
+        cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
+    return None
+
+
 def cancer_fusions_df():
     """Return the curated ``cancer-fusions.csv`` reference: characteristic gene
     fusions / oncogenic translocations per cancer-type code.

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.4"
+__version__ = "5.22.5"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cancer_apd1_response.py
+++ b/tests/test_cancer_apd1_response.py
@@ -1,0 +1,73 @@
+"""Tests for the curated anti-PD-1 monotherapy ORR reference (cancer-apd1-response.csv)."""
+
+import math
+
+from pirlygenes.gene_sets_cancer import (
+    cancer_apd1_response,
+    cancer_apd1_response_df,
+    resolve_cancer_type,
+)
+
+_EXPECTED_COLS = [
+    "cancer_code",
+    "apd1_orr_pct",
+    "drug",
+    "trial",
+    "setting",
+    "pmid_doi",
+    "confidence",
+    "notes",
+]
+
+
+def test_schema_and_unique_codes():
+    df = cancer_apd1_response_df()
+    assert list(df.columns) == _EXPECTED_COLS
+    codes = df["cancer_code"].astype(str)
+    assert codes.is_unique
+    for code in codes:                      # every code must be a real registry code
+        assert resolve_cancer_type(code) is not None
+
+
+def test_values_are_response_rates():
+    df = cancer_apd1_response_df()
+    vals = df.dropna(subset=["apd1_orr_pct"])["apd1_orr_pct"].astype(float)
+    assert (vals >= 0).all() and (vals <= 100).all()
+    # Hodgkin / Merkel are the high responders; the immune-cold anchors are low.
+    m = cancer_apd1_response()
+    assert m["HL"] > 50 and m["NEC_MERKEL"] > 40
+    assert m["GBM"] < 15 and m["PRAD"] < 15
+
+
+def test_drug_is_an_antiPD1_monotherapy():
+    df = cancer_apd1_response_df()
+    assert set(df["drug"]).issubset({"pembrolizumab", "nivolumab"})
+
+
+def test_every_value_is_cited_or_flagged():
+    """A value with confidence high/medium carries a source PMID/DOI; the only
+    citation-light rows are explicitly low-confidence anchors."""
+    df = cancer_apd1_response_df()
+    for row in df.itertuples():
+        assert row.confidence in {"high", "medium", "low"}
+        has_pmid = isinstance(row.pmid_doi, str) and row.pmid_doi.strip().startswith(
+            ("PMID", "DOI", "10.")
+        )
+        if row.confidence in {"high", "medium"}:
+            assert has_pmid, f"{row.cancer_code}: {row.confidence} row needs a PMID/DOI"
+
+
+def test_accessor_resolves_aliases_and_map():
+    assert cancer_apd1_response("melanoma") == cancer_apd1_response("SKCM")
+    m = cancer_apd1_response()
+    assert isinstance(m, dict) and "SKCM" in m and "NEC_MERKEL" in m
+
+
+def test_subtype_inherits_parent_orr():
+    # subtypes with no curated row inherit the parent (SCLC_ASCL1 -> SCLC,
+    # LUAD_KRAS -> LUAD); the STK11 immune-cold subtype gets its own lower row.
+    assert cancer_apd1_response("SCLC_ASCL1") == cancer_apd1_response("SCLC")
+    assert cancer_apd1_response("LUAD_KRAS") == cancer_apd1_response("LUAD")
+    assert cancer_apd1_response("LUAD_STK11") < cancer_apd1_response("LUAD")
+    # strict (no inherit) returns None for an uncurated subtype
+    assert cancer_apd1_response("SCLC_ASCL1", inherit=False) is None


### PR DESCRIPTION
Adds cancer-apd1-response.csv (23 cancers, cited) + cancer_apd1_response accessor (parent-inherit) for TMB-vs-aPD1 / CTA-burden-vs-aPD1 plotting axes. Fills the 9mer-payload-vs-TMB plot's variant matrix (base / _noHEPB / _noHEPB_subtypesonly) to match the coverage plots. Wheel-only; DATA_VERSION unchanged. Gate green (494 passed).