### PR TITLE
CTA plot output improvements: per-plot folders + log-y 9mer variants

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -57,6 +57,17 @@ THRESHOLDS = [25, 50, 100, 200]
 PERCENTILES = [80, 90, 95]
 
 
+def _out_path(group: str, name: str) -> Path:
+    """``outputs/<group>/<name>.png``, creating ``<group>/``.
+
+    Plot families that differ only by threshold / percentile / focus cohort /
+    x-axis (``t25``, ``t50``, ``p90``, ``GBM_t25`` …) live together in a folder
+    named for what the plot shows, instead of a flat soup of suffixed filenames."""
+    d = OUT / group
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{name}.png"
+
+
 from dataclasses import dataclass
 
 
@@ -734,7 +745,7 @@ def _stacked_coverage_bars(mat, cohorts, ensg_to_sym, thr, pctile_cutoffs=None,
     fig.text(0.99, 0.005, f"{len(rows)} per-sample cohorts (others summary-only)",
              ha="right", fontsize=6, color="gray")
     fig.tight_layout()
-    fig.savefig(OUT / f"cta_stacked_coverage_{thr.slug}.png", dpi=150)
+    fig.savefig(_out_path("cta_stacked_coverage", thr.slug), dpi=150)
     plt.close(fig)
     print(f"      {len(rows)} cohorts -> stacked coverage bar", flush=True)
 
@@ -975,8 +986,8 @@ def _cta_vs_x(mat, cohorts, ensg_to_sym, thr, pctile_cutoffs=None,
                  f"({thr.xlabel}, n={len(pts)} cohorts{ex_note}{sub_note})",
                  fontsize=10)
     fig.tight_layout()
-    fig.savefig(OUT / f"cta_coverage_vs_{xaxis.short}_{thr.slug}{slug_suffix}.png",
-                dpi=150)
+    fig.savefig(_out_path(f"cta_coverage_vs_{xaxis.short}",
+                          f"{thr.slug}{slug_suffix}"), dpi=150)
     plt.close(fig)
     print(f"      {len(pts)} cohorts plotted{ex_note}, "
           f"{len(missing)} dropped (no {xaxis.short})", flush=True)
@@ -1117,7 +1128,7 @@ def _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base, *,
                  f"({thr.xlabel}, n={len(pts)} cohorts{ex_note})", fontsize=10)
     fig.tight_layout()
     slug = f"{slug_base}_vs_{xaxis.short}"
-    fig.savefig(OUT / f"{slug}_{thr.slug}{slug_suffix}.png", dpi=150)
+    fig.savefig(_out_path(slug, f"{thr.slug}{slug_suffix}"), dpi=150)
     plt.close(fig)
     print(f"      {slug}: {len(pts)} cohorts plotted{ex_note}", flush=True)
 
@@ -1199,7 +1210,7 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
     ax.set_title(f"# patients expressing each CTA (> {threshold} TPM)", fontsize=9)
     fig.colorbar(im, ax=ax, shrink=0.5, label="patients")
     fig.tight_layout()
-    fig.savefig(OUT / f"cta_patient_count_heatmap_t{threshold}.png", dpi=150)
+    fig.savefig(_out_path("cta_patient_count_heatmap", f"t{threshold}"), dpi=150)
     plt.close(fig)
 
     # also a %-of-cohort version (breadth, normalized for cohort size)
@@ -1216,7 +1227,7 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
     ax.set_title(f"% of cohort expressing each CTA (> {threshold} TPM)", fontsize=9)
     fig.colorbar(im, ax=ax, shrink=0.5, label="% patients")
     fig.tight_layout()
-    fig.savefig(OUT / f"cta_patient_pct_heatmap_t{threshold}.png", dpi=150)
+    fig.savefig(_out_path("cta_patient_pct_heatmap", f"t{threshold}"), dpi=150)
     plt.close(fig)
 
     # ---- (3) sorted %-expressing bar for the focus cohort ----
@@ -1233,7 +1244,7 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
         for y, (p, k) in enumerate(zip(fc[pcol], fc[tcol])):
             ax.text(p, y, f" {k}", va="center", fontsize=6)
         fig.tight_layout()
-        fig.savefig(OUT / f"cta_pct_bar_{focus}_t{threshold}.png", dpi=150)
+        fig.savefig(_out_path("cta_pct_bar", f"{focus}_t{threshold}"), dpi=150)
         plt.close(fig)
 
     # ---- (4) co-occurrence-aware coverage curves: one overlaid, multi-colour
@@ -1265,7 +1276,7 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
     ax.legend(fontsize=6, ncol=3, loc="lower right")
     ax.grid(alpha=0.3)
     fig.tight_layout()
-    fig.savefig(OUT / f"cta_coverage_curves_t{threshold}.png", dpi=150)
+    fig.savefig(_out_path("cta_coverage_curves", f"t{threshold}"), dpi=150)
     plt.close(fig)
 
     # focus-cohort coverage with the CTA names annotated at each step
@@ -1285,7 +1296,7 @@ def _plots(mat, cohorts, counts, ensg_to_sym, threshold, focus):
         ax.set_xlim(0, min(30, len(cum) + 1))
         ax.grid(alpha=0.3)
         fig.tight_layout()
-        fig.savefig(OUT / f"cta_coverage_{focus}_t{threshold}.png", dpi=150)
+        fig.savefig(_out_path("cta_coverage_curves", f"{focus}_t{threshold}"), dpi=150)
         plt.close(fig)
 
 

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -579,6 +579,13 @@ def main():
         _metric_vs_x(mat, cohorts, thr, payload_fn,
                        "mean CTA-specific 9mers per sample", "cta_9mer_payload",
                        pctile_cutoffs=cutoffs, xaxis=_apd1_axis())
+        # Log-scaled-y companions of the 9mer-payload plots (vs TMB and vs aPD-1):
+        # the payload spans ~90x (PAAD ~15 → SKCM ~1300), so a log y separates the
+        # low-payload cohorts that bunch against the axis on the linear version.
+        for xa in (None, _apd1_axis()):   # None -> default TMB axis
+            _metric_vs_x(mat, cohorts, thr, payload_fn,
+                           "mean CTA-specific 9mers per sample", "cta_9mer_payload",
+                           pctile_cutoffs=cutoffs, xaxis=xa, log_y=True)
 
     _emit_load_metrics(tpm_thr)
 
@@ -1062,13 +1069,17 @@ def _cohort_on_matrix(mat, cols, thr, pctile_cutoffs):
 
 def _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base, *,
                    pctile_cutoffs=None, exclude=frozenset(), slug_suffix="",
-                   drop_covered_parents=False, xaxis=None):
+                   drop_covered_parents=False, xaxis=None, log_y=False):
     """Generic scatter of a per-cohort per-sample CTA metric vs an x-axis metric
     (``xaxis``, default median TMB log-x; pass :func:`_apd1_axis` for anti-PD-1
     ORR), styled like :func:`_cta_vs_x` but with a free (auto) y-axis and no
     sweet-spot band. ``value_fn(mat, cols, thr, pctile_cutoffs) -> float`` is the
-    cohort's metric (e.g. mean CTAs/sample, mean CTA-specific-9mer payload). The
-    figure is written to ``{slug_base}_vs_{xaxis.short}_{thr.slug}{suffix}.png``."""
+    cohort's metric (e.g. mean CTAs/sample, mean CTA-specific-9mer payload).
+
+    ``log_y=True`` plots the y-axis on a log scale (useful when the metric spans
+    orders of magnitude, e.g. CTA-specific-9mer payload runs ~15→1300) and adds a
+    ``_logy`` filename suffix. The figure is written to
+    ``{slug_base}_vs_{xaxis.short}/{thr.slug}{suffix}[_logy].png``."""
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
@@ -1101,7 +1112,12 @@ def _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base, *,
     if xaxis.log:
         ax.set_xscale("log")
     ax.set_xlim(*_xlim(xs, xaxis))
-    ax.set_ylim(0, max(ys) * 1.08)
+    if log_y:
+        ax.set_yscale("log")
+        pos = [y for y in ys if y > 0]
+        ax.set_ylim((min(pos) * 0.7) if pos else 1.0, max(ys) * 1.5)
+    else:
+        ax.set_ylim(0, max(ys) * 1.08)
     ax.scatter(xs, ys, s=34, c=[_LINEAGE_COLORS[g] for g in groups],
                alpha=0.9, edgecolor="white", linewidth=0.4, zorder=3)
     ax.set_xlabel(xaxis.label)
@@ -1124,11 +1140,14 @@ def _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base, *,
     ax.legend(handles=handles, loc="center left", bbox_to_anchor=(1.01, 0.5),
               fontsize=7, title="lineage", frameon=False)
     ex_note = f"; excludes {', '.join(sorted(exclude))}" if exclude else ""
+    log_note = "; log y" if log_y else ""
     ax.set_title(f"{ylabel} vs {xaxis.title} by cancer type "
-                 f"({thr.xlabel}, n={len(pts)} cohorts{ex_note})", fontsize=10)
+                 f"({thr.xlabel}, n={len(pts)} cohorts{ex_note}{log_note})",
+                 fontsize=10)
     fig.tight_layout()
     slug = f"{slug_base}_vs_{xaxis.short}"
-    fig.savefig(_out_path(slug, f"{thr.slug}{slug_suffix}"), dpi=150)
+    name = f"{thr.slug}{slug_suffix}{'_logy' if log_y else ''}"
+    fig.savefig(_out_path(slug, name), dpi=150)
     plt.close(fig)
     print(f"      {slug}: {len(pts)} cohorts plotted{ex_note}", flush=True)
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.6"
+__version__ = "5.22.7"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
## Summary

Two related CTA-plot output improvements (`analyses/cta_patient_counts.py`), no analysis-logic change.

### 1. Per-plot folders
`_out_path(group, name)` → `outputs/<group>/<name>.png` (auto-mkdir). Plot-variant families (threshold / percentile / focus cohort / x-axis) now live in a folder named for what the plot shows, instead of a flat suffixed soup:

| before (flat) | after (foldered) |
|---|---|
| `cta_coverage_vs_tmb_t25.png`, `..._t25_noHEPB.png`, … | `cta_coverage_vs_tmb/{t25,t25_noHEPB,…}.png` |
| `cta_coverage_vs_apd1_t25.png` | `cta_coverage_vs_apd1/t25.png` |
| `cta_9mer_payload_vs_{tmb,apd1}_*.png` | `cta_9mer_payload_vs_{tmb,apd1}/*.png` |
| `cta_coverage_curves_t25.png`, `cta_coverage_GBM_t25.png` | `cta_coverage_curves/{t25,GBM_t25}.png` |
| `cta_patient_{count,pct}_heatmap_t25.png` | `cta_patient_{count,pct}_heatmap/t25.png` |
| `cta_pct_bar_<COHORT>_t25.png` | `cta_pct_bar/<COHORT>_t25.png` |
| `cta_stacked_coverage_t25.png` | `cta_stacked_coverage/t25.png` |

Per-cohort coverage already used `cta_coverage/<slug>/`. One-off plots (the two `apd1_response_plots.py` figures) stay flat — folders are only for variant *families*.

### 2. Log-scaled-y 9mer-payload plots
`_metric_vs_x` gains `log_y=True` (log y-scale + `_logy` suffix + "log y" title note). The CTA-specific-9mer payload spans ~90x (PAAD ~15 → SKCM ~1300, TGCT ~2800), so a linear y bunches low-payload cohorts against the axis. Emits `cta_9mer_payload_vs_{tmb,apd1}/{thr}_logy.png` (base variant, both axes).

## Test plan
- [x] Re-rendered `python analyses/cta_patient_counts.py --no-percentiles`; confirmed each family lands in its folder and the `_logy` 9mer plots generate (TMB n=56, aPD1 n=18) and visually separate the low-payload cohorts.

Split out of #347 (NUT/MSI/aPD1) as plotting-only work.
