### PR TITLE
Add cta_paralog_symbols (CTA alias -> full paralog group)

### DIFF
--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import threading
 import warnings
+from functools import lru_cache
 
 from .load_dataset import get_data
 
@@ -1687,6 +1688,46 @@ from tsarina.partition import (  # noqa: E402,F401
     CTA_partition_gene_ids,
     CTA_partition_gene_names,
 )
+
+
+@lru_cache(maxsize=1)
+def _cta_protein_group_index():
+    """``({protein_group: [member_symbol, ...]}, {member_symbol: protein_group})``
+    over ``cta-protein-groups`` — the curated identical / near-identical CTA
+    paralog families (e.g. NY-ESO-1 = CTAG1A + CTAG1B). Members are sorted."""
+    g = get_data("cta-protein-groups")
+    by_group: dict[str, list[str]] = {}
+    member_to_group: dict[str, str] = {}
+    for grp, sub in g.groupby("protein_group"):
+        members = sorted({str(m) for m in sub["member_symbol"]})
+        by_group[str(grp)] = members
+        for m in members:
+            member_to_group[m] = str(grp)
+    return by_group, member_to_group
+
+
+def cta_paralog_symbols(name: str) -> list[str]:
+    """Every CTA gene symbol encoding the same antigen as ``name`` (its protein
+    group), including ``name`` itself.
+
+    Where :func:`cta_symbol_for_alias` (tsarina) returns the single *canonical*
+    symbol for an alias (``"NY-ESO-1" -> "CTAG1B"``), this returns the whole
+    interchangeable set from ``cta-protein-groups``:
+    ``"NY-ESO-1" -> ["CTAG1A", "CTAG1B"]``, ``"XAGE1" -> ["XAGE1A", "XAGE1B"]``,
+    ``"MAGEA3" -> ["MAGEA3", "MAGEA6"]``. A CTA with no paralog group resolves to
+    just its own official symbol; an input that is not a recognized CTA returns
+    ``[]``. Accepts aliases, official symbols, or protein-group names.
+    """
+    if not name:
+        return []
+    by_group, member_to_group = _cta_protein_group_index()
+    sym = cta_symbol_for_alias(name)
+    key = sym or str(name).strip()
+    if key in member_to_group:
+        return list(by_group[member_to_group[key]])
+    if key in by_group:  # a protein-group name with no member alias
+        return list(by_group[key])
+    return [sym] if sym else []
 
 
 def CTA_evidence():

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -173,6 +173,7 @@ def _clear_caches():
     ``get_data``; not part of the public surface.
     """
     CANCER_TYPE_NAMES.clear_cache()
+    _cta_protein_group_index.cache_clear()
 
 
 def resolve_cancer_type(cancer_type, *, strict=True):

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.8"
+__version__ = "5.22.9"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -386,3 +386,29 @@ def test_bispecific_antibody_target_gene_ids_name_is_consistent():
 
     assert hasattr(gsc, "bispecific_antibody_target_gene_ids")
     assert not hasattr(gsc, "bispecific_antibody_targets_gene_ids")
+
+
+def test_cta_paralog_symbols_expands_alias_to_protein_group():
+    """cta_paralog_symbols returns the whole interchangeable CTA family that
+    cta_symbol_for_alias collapses to one canonical symbol."""
+    from pirlygenes.gene_sets_cancer import cta_paralog_symbols
+
+    # alias, official symbol, and the second paralog all map to the full group
+    assert cta_paralog_symbols("NY-ESO-1") == ["CTAG1A", "CTAG1B"]
+    assert cta_paralog_symbols("CTAG1B") == ["CTAG1A", "CTAG1B"]
+    assert cta_paralog_symbols("CTAG1A") == ["CTAG1A", "CTAG1B"]
+    assert cta_paralog_symbols("XAGE1") == ["XAGE1A", "XAGE1B"]
+    assert set(cta_paralog_symbols("MAGEA3")) == {"MAGEA3", "MAGEA6"}
+    # non-CTA / unknown -> empty
+    assert cta_paralog_symbols("not-a-gene") == []
+    assert cta_paralog_symbols("") == []
+
+
+def test_cta_paralog_symbols_singleton_returns_self():
+    """A CTA with no paralog group resolves to just its own official symbol."""
+    from pirlygenes.gene_sets_cancer import cta_paralog_symbols, CTA_gene_names
+    from pirlygenes.load_dataset import get_data
+
+    grouped = set(get_data("cta-protein-groups")["member_symbol"].astype(str))
+    singleton = next(c for c in CTA_gene_names() if c not in grouped)
+    assert cta_paralog_symbols(singleton) == [singleton]


### PR DESCRIPTION
## Summary

Adds **`pirlygenes.gene_sets_cancer.cta_paralog_symbols(name)`** — the paralog-group-aware companion to tsarina's `cta_symbol_for_alias`.

`cta_symbol_for_alias` resolves an alias to the single *canonical* symbol (`"NY-ESO-1" → "CTAG1B"`). But several CTAs are encoded by ≥2 near-identical paralogous genes, so that single symbol silently drops the others. `cta_paralog_symbols` returns the whole interchangeable family from `cta-protein-groups`:

| input | `cta_symbol_for_alias` | `cta_paralog_symbols` |
|---|---|---|
| `NY-ESO-1` | `CTAG1B` | `["CTAG1A", "CTAG1B"]` |
| `XAGE1` | `XAGE1A` | `["XAGE1A", "XAGE1B"]` |
| `MAGEA3` | `MAGEA3` | `["MAGEA3", "MAGEA6"]` |
| `CTAG1B` (member) | `CTAG1B` | `["CTAG1A", "CTAG1B"]` |
| a CTA with no paralog group | itself | `[itself]` |
| non-CTA / unknown | `None` | `[]` |

Accepts aliases, official symbols, or protein-group names. The group index is `lru_cache`d. There are **23 such multi-member groups** (NY-ESO-1, XAGE1, MAGEA3, the GAGE/CT45A/CT47A/TSPY families, …).

Per request, the helper lives **in pirlygenes** — `cta_symbol_for_alias` in tsarina is left untouched; this composes it with the already-bundled `cta-protein-groups`.

Code-only release **5.22.8 → 5.22.9** (`DATA_VERSION` unchanged).

## Test plan
- [x] `./test.sh` — new tests assert alias/member/group-name expansion, singleton-returns-self, and non-CTA → `[]` (25 pass in the file); `./lint.sh` clean.
