### PR TITLE
CTA plots: timestamped per-run output dir + --out-dir + tqdm -> 5.22.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,5 +171,8 @@ cython_debug/
 # Built data-bundle artifacts (uploaded to GitHub Releases, never committed)
 pirlygenes-data-v*.tar.gz
 
-# Generated analysis plots (regenerable; CSV/md outputs are tracked)
+# Generated analysis plots (regenerable; CSV/md outputs are tracked).
+# PNGs at any depth, plus the per-run timestamped plot folders (run_YYYYMMDD-…).
 analyses/outputs/*.png
+analyses/outputs/**/*.png
+analyses/outputs/run_*/

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -461,29 +461,33 @@ def main():
     ap.add_argument("--no-percentiles", action="store_true",
                     help="skip the within-sample percentile-rank threshold plots")
     ap.add_argument("--out-dir", type=Path, default=None,
-                    help="base output directory (default: analyses/outputs). "
-                         "Caches and summary tables live directly here.")
+                    help="directory for the PNG plots (default: analyses/outputs). "
+                         "Only the plots move here — the caches "
+                         "(_per_sample_pctile_cutoffs.parquet, cta_specific_9mers.csv) "
+                         "and summary tables always stay in analyses/outputs, so a "
+                         "new --out-dir never forces a recompute.")
     ap.add_argument("--run-name", default=None,
-                    help="name of the per-run plot subfolder under the base "
+                    help="name of the per-run plot subfolder under the plot dir "
                          "(default: a timestamp, run_YYYYMMDD-HHMMSS)")
     ap.add_argument("--no-timestamp", action="store_true",
-                    help="write plots straight into the base dir (no per-run "
+                    help="write plots straight into the plot dir (no per-run "
                          "subfolder) — flat layout, mixes with prior runs")
     args = ap.parse_args()
 
-    global OUT, FIGDIR
-    if args.out_dir is not None:
-        OUT = args.out_dir.resolve()
+    # OUT is the FIXED stable base (caches + tracked summary tables) — never moved
+    # by --out-dir, so reruns reuse the cached cutoffs/9mers. Only the plots
+    # (FIGDIR) are redirectable, into a per-run subfolder so a fresh run never
+    # overwrites/mixes with an older one.
+    global FIGDIR
     OUT.mkdir(parents=True, exist_ok=True)
-    # Plots go to a per-run subfolder so a fresh run never overwrites/mixes with
-    # an older one; caches + summary tables stay in the stable base (OUT).
+    fig_base = args.out_dir.resolve() if args.out_dir is not None else OUT
     if args.no_timestamp:
-        FIGDIR = OUT
+        FIGDIR = fig_base
     else:
         run = args.run_name or f"run_{datetime.now().strftime('%Y%m%d-%H%M%S')}"
-        FIGDIR = OUT / run
+        FIGDIR = fig_base / run
     FIGDIR.mkdir(parents=True, exist_ok=True)
-    print(f"[0/5] base={OUT}\n      plots -> {FIGDIR}", flush=True)
+    print(f"[0/5] caches+tables -> {OUT}\n      plots -> {FIGDIR}", flush=True)
 
     # Authoritative ENSG->Symbol straight from the CTA evidence table (tsarina),
     # so every CTA in the set gets a symbol — including ones absent from the

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -32,6 +32,7 @@ import json
 import re
 import subprocess
 import sys
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple
@@ -52,20 +53,37 @@ CACHE = Path.home() / ".cache" / "pirlygenes" / "expression" / "treehouse-polya-
 TPM_TSV = CACHE / "Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv"
 CLINICAL = CACHE / "clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv"
 GLIOMA_MAP = CACHE / "derived" / "tcga_glioma_case_to_project.csv"
+# OUT is the *stable* base: caches (``_per_sample_pctile_cutoffs.parquet``,
+# ``cta_specific_9mers.csv``) and the tracked summary tables (``cta_*.csv/.md``)
+# live here and are reused/overwritten in place across runs. FIGDIR is where the
+# PNG plots go — by default a timestamped run subfolder so a fresh run never
+# mixes with an older one. Both are (re)assigned in main() from CLI args.
 OUT = Path(__file__).resolve().parent / "outputs"
+FIGDIR = OUT
 THRESHOLDS = [25, 50, 100, 200]
 PERCENTILES = [80, 90, 95]
 
 
 def _out_path(group: str, name: str) -> Path:
-    """``outputs/<group>/<name>.png``, creating ``<group>/``.
+    """``<FIGDIR>/<group>/<name>.png``, creating ``<group>/``.
 
     Plot families that differ only by threshold / percentile / focus cohort /
     x-axis (``t25``, ``t50``, ``p90``, ``GBM_t25`` …) live together in a folder
-    named for what the plot shows, instead of a flat soup of suffixed filenames."""
-    d = OUT / group
+    named for what the plot shows, instead of a flat soup of suffixed filenames.
+    FIGDIR is the (optionally timestamped) per-run plot destination."""
+    d = FIGDIR / group
     d.mkdir(parents=True, exist_ok=True)
     return d / f"{name}.png"
+
+
+def _tqdm(iterable, desc, **kw):
+    """tqdm progress bar with a graceful no-op fallback if tqdm isn't installed.
+    ``desc`` labels the category currently being rendered."""
+    try:
+        from tqdm import tqdm
+    except ImportError:
+        return iterable
+    return tqdm(iterable, desc=desc, leave=False, **kw)
 
 
 from dataclasses import dataclass
@@ -442,8 +460,30 @@ def main():
                     help="cohort for the %%-bar and coverage plots")
     ap.add_argument("--no-percentiles", action="store_true",
                     help="skip the within-sample percentile-rank threshold plots")
+    ap.add_argument("--out-dir", type=Path, default=None,
+                    help="base output directory (default: analyses/outputs). "
+                         "Caches and summary tables live directly here.")
+    ap.add_argument("--run-name", default=None,
+                    help="name of the per-run plot subfolder under the base "
+                         "(default: a timestamp, run_YYYYMMDD-HHMMSS)")
+    ap.add_argument("--no-timestamp", action="store_true",
+                    help="write plots straight into the base dir (no per-run "
+                         "subfolder) — flat layout, mixes with prior runs")
     args = ap.parse_args()
+
+    global OUT, FIGDIR
+    if args.out_dir is not None:
+        OUT = args.out_dir.resolve()
     OUT.mkdir(parents=True, exist_ok=True)
+    # Plots go to a per-run subfolder so a fresh run never overwrites/mixes with
+    # an older one; caches + summary tables stay in the stable base (OUT).
+    if args.no_timestamp:
+        FIGDIR = OUT
+    else:
+        run = args.run_name or f"run_{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        FIGDIR = OUT / run
+    FIGDIR.mkdir(parents=True, exist_ok=True)
+    print(f"[0/5] base={OUT}\n      plots -> {FIGDIR}", flush=True)
 
     # Authoritative ENSG->Symbol straight from the CTA evidence table (tsarina),
     # so every CTA in the set gets a symbol — including ones absent from the
@@ -576,15 +616,13 @@ def main():
     if not args.no_percentiles and args.threshold == THRESHOLDS[0]:
         print(f"[+] within-sample percentile thresholds {PERCENTILES}", flush=True)
         cutoffs = per_sample_percentile_cutoffs()
-        for p in PERCENTILES:
+        for p in _tqdm(PERCENTILES, "percentile thresholds"):
             pthr = Threshold("pctile", p)
-            print(f"    p{p}: coverage curves + stacked bars + scatters",
-                  flush=True)
             _coverage_every_cohort(mat, cohorts, ensg_to_sym, pthr, cutoffs)
             _stacked_coverage_bars(mat, cohorts, ensg_to_sym, pthr, cutoffs)
             _emit_coverage(mat, cohorts, ensg_to_sym, pthr, cutoffs)
             _emit_load_metrics(pthr, cutoffs)
-    print(f"done -> {OUT}", flush=True)
+    print(f"done -> plots in {FIGDIR}", flush=True)
 
 
 # CTA family prefixes, longest/most-specific first so e.g. MAGEA wins over a
@@ -1197,10 +1235,10 @@ def _coverage_every_cohort(mat, cohorts, ensg_to_sym, thr, pctile_cutoffs=None):
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
-    sub = OUT / "cta_coverage" / thr.slug
+    sub = FIGDIR / "cta_coverage" / thr.slug
     sub.mkdir(parents=True, exist_ok=True)
     n_written = 0
-    for code in sorted(cohorts):
+    for code in _tqdm(sorted(cohorts), f"coverage curves {thr.slug}"):
         order, cum, n = greedy_coverage(mat, cohorts[code], thr, pctile_cutoffs)
         if not cum:
             continue

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.17"
+__version__ = "5.22.18"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Makes the CTA cohort-plot command nice to run repeatedly without mixing old and
new plots.

## Changes
- **Per-run timestamped plot dir.** Plots now write to
  `outputs/run_<YYYYMMDD-HHMMSS>/<group>/…` (new `FIGDIR`) instead of overwriting
  flat folders, so a fresh run never mixes with an older one.
- **Stable caches/tables.** The percentile-cutoff parquet, the 9mer cache, and
  the tracked summary tables (`cta_*.csv/.md`) stay in the **base** dir (`OUT`) —
  reruns don't recompute and the data tables keep versioning cleanly.
- **Optional dest + naming.** `--out-dir BASE`, `--run-name NAME`,
  `--no-timestamp` (flat layout, prior behavior).
- **tqdm progress per category** (per-cohort coverage curves, percentile sweep)
  with a graceful no-op fallback if tqdm is absent.
- **.gitignore**: ignore PNGs at any depth + `run_*/` folders (CSV/md stay tracked).

## Layout after a run
```
analyses/outputs/
  cta_patient_counts.csv, cta_*_q1/q3/median.csv, cta_specific_9mers.csv  (stable, tracked/cache)
  run_20260609-143051/
    cta_coverage_vs_{tmb,apd1,incidence}/  cta_mean_count_vs_*/  cta_9mer_payload_vs_*/
    cta_coverage/  cta_*_heatmap/  cta_pct_bar/  …
```

Plot-script only; DATA_VERSION unchanged (5.22.6).