### PR TITLE
analyses: all plot scripts use shared per-run layout (run_<ts>/ + _cache) -> 5.22.20

### DIFF
--- a/analyses/_run_layout.py
+++ b/analyses/_run_layout.py
@@ -1,0 +1,58 @@
+"""Shared per-run output layout for the analyses/ plot scripts.
+
+A run writes its plots + tables into a timestamped ``run_<YYYYMMDD-HHMMSS>/``
+subfolder under the base ``outputs/`` dir, so a fresh run never overwrites or
+mixes with an older one. Reusable caches go to a stable, gitignored
+``outputs/_cache/``. This mirrors the layout in ``cta_patient_counts.py`` so
+every analyses script behaves the same way.
+
+Usage::
+
+    ap = argparse.ArgumentParser()
+    add_layout_args(ap)
+    args = ap.parse_args()
+    CACHE, FIGDIR = resolve_dirs(args, Path(__file__).resolve().parent / "outputs")
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+
+def add_layout_args(ap) -> None:
+    ap.add_argument("--out-dir", type=Path, default=None,
+                    help="directory for plots/tables (default: analyses/outputs). "
+                         "Only outputs move here; the _cache/ stays at the base.")
+    ap.add_argument("--run-name", default=None,
+                    help="per-run subfolder name (default: run_YYYYMMDD-HHMMSS)")
+    ap.add_argument("--no-timestamp", action="store_true",
+                    help="write straight into the output dir (no per-run subfolder)")
+
+
+def resolve_dirs(args, base: Path):
+    """Return ``(CACHE, FIGDIR)``. CACHE = ``base/_cache`` (always stable, so
+    reruns reuse caches even with ``--out-dir``); FIGDIR = the per-run snapshot
+    dir for this run's plots + tables, redirectable via ``--out-dir``."""
+    base = Path(base)
+    base.mkdir(parents=True, exist_ok=True)
+    cache = base / "_cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    fig_base = base if getattr(args, "out_dir", None) is None else args.out_dir.resolve()
+    if getattr(args, "no_timestamp", False):
+        figdir = fig_base
+    else:
+        run = (getattr(args, "run_name", None)
+               or f"run_{datetime.now().strftime('%Y%m%d-%H%M%S')}")
+        figdir = fig_base / run
+    figdir.mkdir(parents=True, exist_ok=True)
+    return cache, figdir
+
+
+def latest_run_dir(base, must_contain="cta_patient_counts.csv"):
+    """Newest ``run_<ts>/`` under ``base`` that contains ``must_contain`` (run
+    folders sort chronologically by their timestamp name). Returns ``None`` if
+    none exist — for scripts that consume another script's per-run output."""
+    base = Path(base)
+    runs = sorted(d for d in base.glob("run_*")
+                  if d.is_dir() and (d / must_contain).exists())
+    return runs[-1] if runs else None

--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -19,6 +19,7 @@ Run:  python analyses/apd1_response_plots.py
 """
 from __future__ import annotations
 
+import argparse
 from functools import lru_cache
 from pathlib import Path
 
@@ -27,8 +28,10 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 
 from pirlygenes import gene_sets_cancer as gsc  # noqa: E402
+from _run_layout import add_layout_args, resolve_dirs  # noqa: E402
 
 OUT = Path(__file__).resolve().parent / "outputs"
+FIGDIR = OUT   # per-run output dir; set in main() via _run_layout
 
 # Documented aPD1-differential subtype pairs (immune-hot vs immune-cold).
 _PAIRS = [("COAD_MSI", "COAD_MSS"), ("READ_MSI", "READ_MSS")]
@@ -71,7 +74,7 @@ def _plot_tmb_vs_apd1(orr, tmb, colors):
     ax.grid(alpha=0.3, which="both")
     ax.set_ylim(-3, (max(orr.values()) * 1.08) if orr else 1.0)
     fig.tight_layout()
-    fig.savefig(OUT / "apd1_vs_tmb.png", dpi=150)
+    fig.savefig(FIGDIR / "apd1_vs_tmb.png", dpi=150)
     plt.close(fig)
     return len(pts)
 
@@ -89,19 +92,23 @@ def _plot_orr_bars(orr, colors):
     ax.set_title("Anti-PD-1 response rate by cancer type (curated)")
     ax.grid(axis="x", alpha=0.3)
     fig.tight_layout()
-    fig.savefig(OUT / "apd1_orr_bars.png", dpi=150)
+    fig.savefig(FIGDIR / "apd1_orr_bars.png", dpi=150)
     plt.close(fig)
 
 
 def main() -> int:
-    OUT.mkdir(parents=True, exist_ok=True)
+    global FIGDIR
+    ap = argparse.ArgumentParser()
+    add_layout_args(ap)
+    args = ap.parse_args()
+    _, FIGDIR = resolve_dirs(args, OUT)
     orr = gsc.cancer_apd1_response()           # {code: ORR%}
     tmb = {c: gsc.cancer_tmb(c) for c in orr if gsc.cancer_tmb(c) is not None}
     colors = _color_map(orr)
     n = _plot_tmb_vs_apd1(orr, tmb, colors)
     _plot_orr_bars(orr, colors)
     print(f"wrote apd1_vs_tmb.png ({n} cancers with TMB+ORR) and "
-          f"apd1_orr_bars.png ({len(orr)} cancers) -> {OUT}", flush=True)
+          f"apd1_orr_bars.png ({len(orr)} cancers) -> {FIGDIR}", flush=True)
     return 0
 
 

--- a/analyses/cta_addressable_burden.py
+++ b/analyses/cta_addressable_burden.py
@@ -17,15 +17,21 @@ Run:  python analyses/cta_addressable_burden.py
 """
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from pirlygenes import gene_sets_cancer as gsc
+from _run_layout import latest_run_dir
 
 OUT = Path(__file__).resolve().parent / "outputs"
+# Set in main() to the run_<ts>/ that holds cta_patient_counts' tables; this
+# script both reads those tables and writes its plots into that same run dir.
 COUNTS = OUT / "cta_patient_counts.csv"
+UNION = OUT / "cta_union_counts.csv"
+FIGDIR = OUT
 TPM_THRESHOLDS = [25, 50, 100]
 PERCENTILES = [80, 90, 95]
 TOPN = 40
@@ -141,7 +147,7 @@ def _union_addressable(threshold, burden_metric, cat_n, drop_mage=False):
     """Burden-weighted fraction of patients expressing >=1 CTA protein over the
     threshold (the whole-panel union — 'All CTAs'). Each patient is counted once
     however many CTAs they express. With drop_mage, uses the MAGE-excluded union."""
-    u = pd.read_csv(OUT / "cta_union_counts.csv")
+    u = pd.read_csv(UNION)
     u = u[~u.cancer_code.isin(_REDUNDANT)].copy()
     u["category"] = [gsc.burden_category(c) for c in u.cancer_code]
     u = u[u.category.notna()]
@@ -203,7 +209,7 @@ def _render(drop_mage, suffix, title_tag):
                     f"categories = {ceiling:.0f}% of {blabel} (uncovered types not scored)",
                     transform=ax.transAxes, ha="right", fontsize=6, color="gray")
             fig.tight_layout()
-            fig.savefig(OUT / f"cta_addressable_{mkey}_{t.slug}{suffix}.png", dpi=150)
+            fig.savefig(FIGDIR / f"cta_addressable_{mkey}_{t.slug}{suffix}.png", dpi=150)
             plt.close(fig)
             print(f"  {mkey} {t.slug}{suffix}: top CTA {per.iloc[0].Symbol} "
                   f"({per.iloc[0].addressable:.1f}% of {blabel}); ceiling {ceiling:.0f}%",
@@ -250,17 +256,33 @@ def _burden_category_plot():
     ax.legend(loc="lower right", fontsize=8)
     ax.grid(axis="x", alpha=0.3)
     fig.tight_layout()
-    fig.savefig(OUT / "cta_burden_categories.png", dpi=150)
+    fig.savefig(FIGDIR / "cta_burden_categories.png", dpi=150)
     plt.close(fig)
     print(f"  burden-category reference: {len(cats)} categories "
           f"({counts.cancer_code.nunique()} cohorts)", flush=True)
 
 
 def main():
+    global COUNTS, UNION, FIGDIR
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-dir", type=Path, default=None,
+                    help="run_<ts>/ holding cta_patient_counts.csv + "
+                         "cta_union_counts.csv (default: latest run under "
+                         "analyses/outputs). Plots are written into this dir.")
+    args = ap.parse_args()
+    run = args.run_dir or latest_run_dir(OUT)
+    if run is None:
+        raise SystemExit(
+            "no run_<ts>/ with cta_patient_counts.csv found — run "
+            "cta_patient_counts.py first (or pass --run-dir).")
+    COUNTS = run / "cta_patient_counts.csv"
+    UNION = run / "cta_union_counts.csv"
+    FIGDIR = run
+    print(f"reading tables + writing plots in {FIGDIR}", flush=True)
     _render(drop_mage=False, suffix="", title_tag="")
     _render(drop_mage=True, suffix="_noMAGE", title_tag=" (excl. MAGE-A/B/C)")
     _burden_category_plot()
-    print(f"done -> 24 addressability plots + 1 burden-category plot in {OUT}",
+    print(f"done -> 24 addressability plots + 1 burden-category plot in {FIGDIR}",
           flush=True)
 
 

--- a/analyses/cta_covering_set.py
+++ b/analyses/cta_covering_set.py
@@ -20,6 +20,7 @@ Outputs a markdown report + a coverage-curve PNG to analyses/outputs/.
 """
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import matplotlib
@@ -31,6 +32,7 @@ import matplotlib.pyplot as plt
 import pirlygenes.expression.accessors as accessors
 import pirlygenes.gene_sets_cancer as gsc
 from cta_expression_heatmaps import _representative_source
+from _run_layout import add_layout_args, resolve_dirs
 
 ACTIONABLE_TPM = 30.0     # "actionable" target threshold (per user intuition)
 SECONDARY_TPM = 10.0      # also report coverage at a looser bar
@@ -159,7 +161,10 @@ def _section(mat: pd.DataFrame, stat_label: str, codes, type_w, pat_w) -> list[s
 
 
 def main() -> None:
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    ap = argparse.ArgumentParser()
+    add_layout_args(ap)
+    args = ap.parse_args()
+    _, figdir = resolve_dirs(args, OUT_DIR)
     mats = cta_matrices()
     codes = list(next(iter(mats.values())).index)
     type_w = pd.Series(1.0, index=codes)              # each cancer type = 1
@@ -176,7 +181,7 @@ def main() -> None:
     ]
     for stat_label, mat in mats.items():
         lines += _section(mat, stat_label, codes, type_w, pat_w)
-    (OUT_DIR / "cta_covering_set.md").write_text("\n".join(lines) + "\n", "utf-8")
+    (figdir / "cta_covering_set.md").write_text("\n".join(lines) + "\n", "utf-8")
 
     # coverage curve: median vs q3, patient-weighted
     fig, ax = plt.subplots(figsize=(9, 6))
@@ -194,9 +199,9 @@ def main() -> None:
     ax.legend(title="actionable if TPM> bar at:")
     ax.grid(True, alpha=0.3)
     fig.tight_layout()
-    fig.savefig(OUT_DIR / "cta_covering_set.png", dpi=150, bbox_inches="tight")
+    fig.savefig(figdir / "cta_covering_set.png", dpi=150, bbox_inches="tight")
     plt.close(fig)
-    print(f"wrote cta_covering_set.md + .png to {OUT_DIR}")
+    print(f"wrote cta_covering_set.md + .png to {figdir}")
 
 
 if __name__ == "__main__":

--- a/analyses/cta_expression_heatmaps.py
+++ b/analyses/cta_expression_heatmaps.py
@@ -16,6 +16,7 @@ high expression (# cohorts > HIGH_TPM), tie-broken by peak.
 """
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import matplotlib
@@ -28,6 +29,7 @@ import seaborn as sns
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, Normalize
 
 import pirlygenes.expression.accessors as accessors
+from _run_layout import add_layout_args, resolve_dirs
 import pirlygenes.gene_sets_cancer as gsc
 
 N_CANCER_TYPES = 30
@@ -37,6 +39,7 @@ MIN_DISPLAY_SAMPLES = 5  # but we only display a source with at least this many
 HIGH_TPM = 30.0   # "highly expressed" threshold for breadth metrics
 TPM_FLOOR = 0.01  # LogNorm needs strictly positive values
 OUT_DIR = Path(__file__).resolve().parent / "outputs"
+FIGDIR = OUT_DIR   # per-run output dir; set in main() via _run_layout
 
 # (value column, file slug, axis label)
 STATS = [
@@ -271,7 +274,7 @@ def plot(mat, stat_label, metric_label, fname, *, log_scale=True) -> None:
     ax.tick_params(axis="x", labelsize=8, rotation=90)
     ax.tick_params(axis="y", labelsize=8, rotation=0)
     fig.tight_layout()
-    fig.savefig(OUT_DIR / fname, dpi=150, bbox_inches="tight")
+    fig.savefig(FIGDIR / fname, dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -316,7 +319,7 @@ def plot_coarse(mat, stat_label, metric_label, fname) -> None:
     ax.tick_params(axis="x", labelsize=8, rotation=90)
     ax.tick_params(axis="y", labelsize=8, rotation=0)
     fig.tight_layout()
-    fig.savefig(OUT_DIR / fname, dpi=150, bbox_inches="tight")
+    fig.savefig(FIGDIR / fname, dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -347,7 +350,11 @@ def write_summary_md(matrices: dict, path: Path) -> None:
 
 
 def main() -> None:
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    global FIGDIR
+    ap = argparse.ArgumentParser()
+    add_layout_args(ap)
+    args = ap.parse_args()
+    _, FIGDIR = resolve_dirs(args, OUT_DIR)
     print("loading cancer reference expression...")
     df = accessors.cancer_reference_expression()
 
@@ -368,12 +375,12 @@ def main() -> None:
                 plot_coarse(
                     mat, stat_label, metric_label, f"cta_{metric}_{slug}_coarse.png"
                 )
-            mat.to_csv(OUT_DIR / f"cta_{metric}_{slug}.csv", index_label="cohort")
+            mat.to_csv(FIGDIR / f"cta_{metric}_{slug}.csv", index_label="cohort")
         print(f"  wrote 7 PNGs + 3 CSVs for [{metric}]")
 
-    write_summary_md(matrices, OUT_DIR / "cta_expression_summary.md")
+    write_summary_md(matrices, FIGDIR / "cta_expression_summary.md")
     n_png = len(COHORT_METRICS) * (len(STATS) * 2 + 1)  # +1 actionable per metric
-    print(f"wrote {n_png} PNGs total to {OUT_DIR}")
+    print(f"wrote {n_png} PNGs total to {FIGDIR}")
 
 
 if __name__ == "__main__":

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.19"
+__version__ = "5.22.20"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Finishes the self-contained-run layout so **nothing lands at the `analyses/outputs/` base** — the four sibling scripts now match `cta_patient_counts.py` (5.22.18/19).

## Changes
- **New `analyses/_run_layout.py`** — shared `add_layout_args` + `resolve_dirs`
  (per-run `run_<ts>/` + stable gitignored `_cache/`) + `latest_run_dir`. One
  `--out-dir`/`--run-name`/`--no-timestamp` convention everywhere.
- **`cta_covering_set.py`, `cta_expression_heatmaps.py`, `apd1_response_plots.py`**
  — write their tables/plots into the per-run dir.
- **`cta_addressable_burden.py` — regression fix.** It read
  `cta_patient_counts.csv`/`cta_union_counts.csv` from the base, which 5.22.19
  moved into `run_<ts>/` (so it was broken). Now it resolves the run dir
  (`--run-dir`, default newest `latest_run_dir`) and reads + writes there.
  `_REDUNDANT` also drops the `SARC_RMS`/`SARC_LPS` joint cohorts so a burden
  category isn't double-counted.

## Usage
Pass the same `--run-name` to every script to collect a full analysis into one
self-contained run folder (verified: `cta_patient_counts` → `cta_addressable_burden`
→ `apd1_response` all land in `run_chain/`).

Plot-script only; DATA_VERSION unchanged (5.22.6). (Stale base leftovers +
`old-analyses/` are cleaned separately.)