### PR TITLE
UCEC molecular split on CTA plots + aPD-1 curation + fix CACHE collision -> 5.22.24

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -49,10 +49,13 @@ from pirlygenes.coverage import greedy_coverage as _pkg_greedy_coverage
 import sweep_treehouse_polya_cohorts as polya
 import sweep_treehouse_tcga_cohorts as tcga
 
-CACHE = Path.home() / ".cache" / "pirlygenes" / "expression" / "treehouse-polya-25-01"
-TPM_TSV = CACHE / "Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv"
-CLINICAL = CACHE / "clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv"
-GLIOMA_MAP = CACHE / "derived" / "tcga_glioma_case_to_project.csv"
+# Expression source cache (Treehouse compendium TPM + clinical + cBioPortal
+# derived maps). Distinct from the output CACHE below — keep the names separate
+# (a 5.22.18 collision silently broke _DERIVED_DIR / the cBioPortal splits).
+EXPR_CACHE = Path.home() / ".cache" / "pirlygenes" / "expression" / "treehouse-polya-25-01"
+TPM_TSV = EXPR_CACHE / "Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv"
+CLINICAL = EXPR_CACHE / "clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv"
+GLIOMA_MAP = EXPR_CACHE / "derived" / "tcga_glioma_case_to_project.csv"
 # Three roles, three locations:
 #  * OUT     — the stable base directory.
 #  * CACHE   — OUT/_cache: expensive, regenerable, reused across runs (percentile
@@ -245,7 +248,7 @@ def _glioma_split_cohorts() -> list[TreehouseCohort]:
     ]
 
 
-_DERIVED_DIR = CACHE / "derived"
+_DERIVED_DIR = EXPR_CACHE / "derived"
 
 
 def _tcga_case_subtype_cohorts(cache_csv, disease_label, key_col, code_col,
@@ -285,6 +288,10 @@ def _cbioportal_derived_cohorts() -> list[TreehouseCohort]:
             _DERIVED_DIR / "cbioportal_hnsc_hpv.csv",
             "head & neck squamous cell carcinoma", "patientId", "hpv_subtype",
             recode={"HNSC_HPV-": "HNSC_HPVneg", "HNSC_HPV+": "HNSC_HPVpos"})
+        + _tcga_case_subtype_cohorts(
+            _DERIVED_DIR / "cbioportal_ucec_subtype.csv",
+            "uterine corpus endometrioid carcinoma", "patientId", "ucec_subtype",
+            recode={"UCEC_CN_LOW": "UCEC_CNL", "UCEC_CN_HIGH": "UCEC_CNH"})
     )
 
 

--- a/pirlygenes/data/cancer-apd1-response.csv
+++ b/pirlygenes/data/cancer-apd1-response.csv
@@ -28,3 +28,10 @@ READ_MSS,0,pembrolizumab,KEYNOTE-016,MSS,PMID:26028255,high,Microsatellite-stabl
 UCEC_MSI,50,pembrolizumab,KEYNOTE-158,dMMR/MSI-H advanced EC,PMID:34990208,high,ORR 50% (95% CI 40-61); MSI-H/dMMR cohort n=94
 UCEC_CNL,6,pembrolizumab,KEYNOTE-158,pMMR/MSS NSMP,PMID:34990208,medium,non-MSI-H ORR ~7% (3-14); MSS NSMP arm
 UCEC_CNH,6,pembrolizumab,KEYNOTE-158,pMMR/MSS p53-abnormal,PMID:34990208,medium,non-MSI-H ORR ~7%; p53-abnormal most immune-cold
+OV,8,pembrolizumab,KEYNOTE-100,recurrent ovarian (all-comers),PMID:31218020,medium,pembro monotherapy ORR 8.0%
+HNSC_HPVpos,24,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV+,PMID:27646946,medium,HPV+ subgroup; pooled monotherapy HPV+ > HPV- (overall KN-012 ORR 18%)
+HNSC_HPVneg,16,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV-,PMID:27646946,medium,HPV- subgroup
+KIRP,25,pembrolizumab,KEYNOTE-427 cohort B,papillary RCC 1L,PMID:34272311,medium,papillary nccRCC ORR 25.4%
+KICH,10,pembrolizumab,KEYNOTE-427 cohort B,chromophobe RCC 1L,PMID:34272311,low,chromophobe ORR 9.5% (small n)
+CHOL,6,pembrolizumab,KEYNOTE-158,advanced biliary,PMID:32319072,medium,biliary ORR 5.8% (6/104)
+UVM,4,nivolumab,pooled uveal series,metastatic uveal melanoma,PMID:27533448,low,uveal anti-PD-1 monotherapy ORR ~3-6% (checkpoint-refractory)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.23"
+__version__ = "5.22.24"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/scripts/sweep_treehouse_tcga_ucec_subtype.py
+++ b/scripts/sweep_treehouse_tcga_ucec_subtype.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Generate the cached cBioPortal UCEC molecular-class map used by the CTA-plot
+UCEC subtype split (analyses/cta_patient_counts.py).
+
+Fetches the TCGA molecular class per TCGA-UCEC patient (POLE / MSI / CN_LOW /
+CN_HIGH) from cBioPortal study ``ucec_tcga_pan_can_atlas_2018`` (SUBTYPE
+attribute; the four TCGA endometrial classes, Kandoth 2013 PMID 23636398) and
+writes ``<treehouse cache>/derived/cbioportal_ucec_subtype.csv``
+(``patientId,ucec_subtype``).
+
+The plot's ``_cbioportal_derived_cohorts`` reads that map and splits the
+Treehouse TCGA-UCEC samples by case id — the same per-sample-reconstructable
+pattern as the BRCA PAM50 / HNSC HPV splits. (Building full reference-expression
+shards for the four subtypes is a separate, heavier step; this map is all the
+CTA plots need.)
+
+    python scripts/sweep_treehouse_tcga_ucec_subtype.py
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+
+import pandas as pd
+
+CACHE = (Path.home() / ".cache" / "pirlygenes" / "expression"
+         / "treehouse-polya-25-01" / "derived")
+CACHE_CSV = CACHE / "cbioportal_ucec_subtype.csv"
+URL = (
+    "https://www.cbioportal.org/api/studies/ucec_tcga_pan_can_atlas_2018"
+    "/clinical-data?clinicalDataType=PATIENT&attributeId=SUBTYPE"
+)
+
+
+def main() -> int:
+    with urllib.request.urlopen(URL, timeout=60) as r:
+        data = json.load(r)
+    df = pd.DataFrame(
+        [{"patientId": d["patientId"], "ucec_subtype": d["value"]} for d in data]
+    )
+    CACHE.mkdir(parents=True, exist_ok=True)
+    df.to_csv(CACHE_CSV, index=False)
+    print(f"wrote {CACHE_CSV} ({len(df)} patients): "
+          f"{df['ucec_subtype'].value_counts().to_dict()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Both follow-ups in one PR — plus a silent-regression fix found along the way.

## 1. Fix: `CACHE` name collision (regression since 5.22.18)
The 5.22.18 output-layout reorg reused the global name `CACHE` for the
analyses-output cache, **shadowing** the expression `CACHE` and pointing
`_DERIVED_DIR` at `analyses/outputs/_cache/derived`. That silently broke **every
cBioPortal-derived split** — BRCA PAM50 and HNSC HPV have been absent from the
plots since 5.22.18. Renamed the expression cache to `EXPR_CACHE`; the splits are
restored.

## 2. UCEC molecular split on the CTA-expression plots
Wires `UCEC_POLE/MSI/CNL/CNH` into `_cbioportal_derived_cohorts` via the
cBioPortal `ucec_tcga_pan_can_atlas_2018` SUBTYPE map — POLE 16 / MSI 41 / CNL 30
/ CNH 85 of our 181 TCGA-UCEC samples (all viable). Same per-sample-reconstructable
pattern as the HNSC HPV split; new `scripts/sweep_treehouse_tcga_ucec_subtype.py`
generates the cached map. Registry subtype codes already shipped (5.22.22).
(Bug en route: the Treehouse disease label is "endometri**oid**", not "endometrial".)

## 3. aPD-1 ORR curation (+7 cited monotherapy rows)
- `OV` 8 — KEYNOTE-100 (PMID 31218020)
- `HNSC_HPVpos` 24 / `HNSC_HPVneg` 16 — KEYNOTE-012 (PMID 27646946)
- `KIRP` 25 / `KICH` 10 — KEYNOTE-427 cohort B (PMID 34272311)
- `CHOL` 6 — KEYNOTE-158 biliary (PMID 32319072)
- `UVM` 4 — uveal anti-PD-1 monotherapy (PMID 27533448)

## Net
CTA-vs-aPD-1 plots go from ~17 to **27** expression∩aPD-1 cohorts — including the
clinically-meaningful **UCEC MSI-responder (50%) vs CNL/CNH-nonresponder (6%)**
split and **HNSC-by-HPV**. In-wheel data; DATA_VERSION unchanged (5.22.6).