### PR TITLE
CTA plots: total-CTA-TPM metric is now threshold-aware -> 5.22.26

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -643,6 +643,8 @@ def main():
              "cta_mean_count"),
             (load_fn, "mean CTA-specific 9mers per sample",
              "cta_9mer_load"),
+            (_mean_total_cta_tpm, "mean total CTA TPM per sample",
+             "cta_total_tpm"),
         ):
             for xa in _tqdm(_all_axes(), f"{slug_base} {thr.slug}"):
                 _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base,
@@ -650,7 +652,9 @@ def main():
                 _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base,
                                pctile_cutoffs=cutoffs, xaxis=xa,
                                slug_suffix="_collapsed", collapse_subtypes=True)
-                is_load = slug_base == "cta_9mer_load"
+                # log-scale metrics (9mer load, total CTA TPM) span orders of
+                # magnitude -> add a log-y companion.
+                is_load = slug_base in ("cta_9mer_load", "cta_total_tpm")
                 if xa.short == "tmb":
                     _metric_vs_x(mat, cohorts, thr, value_fn, ylabel, slug_base,
                                    pctile_cutoffs=cutoffs, xaxis=xa,
@@ -671,18 +675,6 @@ def main():
                                    pctile_cutoffs=cutoffs, xaxis=xa, log_y=True)
 
     _emit_load_metrics(tpm_thr)
-
-    # Total CTA transcriptional burden (mean per-sample sum of ALL CTA TPM) vs
-    # every axis, log-y. Threshold-independent (no on/off cutoff), so emitted
-    # once with the --no-timestamp-safe `t` slug rather than per threshold.
-    for xa in _tqdm(_all_axes(), "cta_total_tpm"):
-        _metric_vs_x(mat, cohorts, tpm_thr, _mean_total_cta_tpm,
-                       "mean total CTA TPM per sample", "cta_total_tpm",
-                       xaxis=xa, log_y=True)
-        if xa.short == "tmb":
-            _metric_vs_x(mat, cohorts, tpm_thr, _mean_total_cta_tpm,
-                           "mean total CTA TPM per sample", "cta_total_tpm",
-                           xaxis=xa, log_y=True, color_by=_apd1_axis())
 
     # Within-sample percentile-rank thresholds (after clean-TPM): a CTA is "on"
     # in a sample if its TPM is at/above that sample's Nth-percentile across all
@@ -1495,11 +1487,13 @@ def _mean_ctas_per_sample(mat, cols, thr, pctile_cutoffs):
 
 
 def _mean_total_cta_tpm(mat, cols, thr, pctile_cutoffs):
-    """Mean over patients of the summed TPM across ALL CTA proteins — the total
-    CTA transcriptional burden per sample (threshold-independent: no on/off
-    cutoff, every CTA's TPM is summed). Spans orders of magnitude, so plotted
-    log-y."""
-    return float(mat[cols].sum(axis=0).mean())
+    """Mean over patients of the summed TPM across the CTAs that are ON at the
+    threshold — the total CTA transcriptional burden per sample. Threshold-aware
+    like the other load metrics (so it gets t25/t50/p80/p90/p95 variants): only
+    CTAs above the cutoff contribute their TPM. Spans orders of magnitude, so
+    plotted log-y."""
+    on = _cohort_on_matrix(mat, cols, thr, pctile_cutoffs)
+    return float((mat[cols].to_numpy() * on).sum(axis=0).mean())
 
 
 def _mean_specific_9mer_load(weights):

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.25"
+__version__ = "5.22.26"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
The total-CTA-TPM burden metric was threshold-independent (summed all CTA TPM) — inconsistent with the other load metrics, so it had no t25/p95 variants. Now it sums only the TPM of CTAs **on at the threshold** (via `_cohort_on_matrix`), folded into the per-threshold `_emit_load_metrics` loop with a log-y companion (log-scale-metric flag generalized to {9mer_load, total_tpm}). So it now gets t25/t50/p80/p90/p95 like everything else. Plot-script only; DATA_VERSION unchanged.