### PR TITLE
Fix #379: phantom-collision rows in pan-cancer-expression (5.22.28)

### DIFF
--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.27"
+__version__ = "5.22.28"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_pan_cancer_expression_integrity.py
+++ b/tests/test_pan_cancer_expression_integrity.py
@@ -1,0 +1,45 @@
+"""Integrity guards for pan-cancer-expression.csv (issue #379).
+
+The HPA(nTPM) x TCGA(FPKM) merge can leave *phantom* rows: a gene under a
+recently-reassigned Ensembl ID that has no match in the older GDC/STAR TCGA
+annotation (all-FPKM-NaN), coexisting with the gene's canonical row that DOES
+carry TCGA data. In a symbol-keyed aggregation the NaN phantom can wipe out the
+canonical value (real + NaN -> NaN -> silently coerced to 0). These guards lock
+out that collision class.
+
+Note: a gene legitimately measured by HPA but absent from the TCGA annotation
+keeps NaN FPKM on purpose (missing != zero) -- we do NOT coerce those to 0. The
+invariant is only that no *canonical, TCGA-valued* gene is shadowed by an
+all-NaN duplicate under the same symbol.
+"""
+
+import pandas as pd
+
+from pirlygenes.load_dataset import get_data
+
+
+def _df():
+    return get_data("pan-cancer-expression.csv")
+
+
+def test_no_duplicate_ensembl_ids():
+    d = _df()
+    dups = d["Ensembl_Gene_ID"][d["Ensembl_Gene_ID"].duplicated()].tolist()
+    assert not dups, f"duplicate Ensembl IDs: {dups}"
+
+
+def test_no_phantom_symbol_collision():
+    """No symbol may have BOTH a TCGA-valued row and an all-TCGA-NaN duplicate
+    row (the #379 collision: the NaN row corrupts symbol-keyed aggregation)."""
+    d = _df()
+    fpkm = [c for c in d.columns if c.startswith("FPKM_")]
+    assert fpkm, "expected FPKM_<cohort> TCGA columns"
+    all_nan = d[fpkm].isna().all(axis=1)
+    valued_symbols = set(d.loc[~all_nan, "Symbol"].dropna())
+    offenders = sorted(
+        set(d.loc[all_nan, "Symbol"].dropna()) & valued_symbols
+    )
+    assert not offenders, (
+        "symbols with a canonical TCGA-valued row shadowed by an all-NaN "
+        f"duplicate (phantom collision): {offenders}"
+    )


### PR DESCRIPTION
Closes #379 (the collision-corruption half; see scope note).

## Problem
The HPA(nTPM)×TCGA(FPKM) merge left **phantom rows**: a gene under a recently-reassigned Ensembl ID with no match in the older GDC/STAR TCGA annotation (all-FPKM-NaN), coexisting with the gene's **canonical TCGA-valued row** under the same symbol. In symbol-keyed aggregation the NaN phantom wipes the canonical value (`real + NaN → NaN` → silently coerced to 0).

## Fix
- **Drop the 2 true collisions**: `PRODH ENSG00000277196`, `NOX5 ENSG00000290203`. Their canonical rows (`ENSG00000100033`/`ENSG00000255346`) retain full 33/33 TCGA + 50/50 HPA — nothing lost.
- **New guards** (`tests/test_pan_cancer_expression_integrity.py`): no duplicate Ensembl IDs; no symbol shadowed by an all-TCGA-NaN duplicate of a TCGA-valued canonical row.

## Scope note (why not "fill 0")
The other 24 all-NaN genes (SOD2, CTAGE8, H2BN1, …) have **no canonical TCGA row in the file** — the value was orphaned upstream and is unrecoverable from the bundled product. Per the project's **missing≠zero** principle they stay NaN (not_measurable), **not 0**. Full recovery requires re-running the HPA↔TCGA merge with an Ensembl-ID crosswalk (upstream build, not in this repo); the downstream silent-NaN→0 is a consumer-side fix (treat NaN as not_measurable). I'll leave #379 open for that upstream remerge.

512 tests pass; lint clean.