### PR TITLE
#366 (option C): all:-union heterogeneity contract + exclude_microarray_proxy (5.22.37)

### DIFF
--- a/pirlygenes/expression/accessors.py
+++ b/pirlygenes/expression/accessors.py
@@ -1010,8 +1010,28 @@ def cancer_reference_expression(
     *,
     format: str = "long",
     include_provenance: bool = True,
+    exclude_microarray_proxy: bool = False,
 ) -> pd.DataFrame:
     """Source-agnostic packaged tumor expression references.
+
+    Cross-cohort (``all:`` union) heterogeneity contract — IMPORTANT when a
+    computed-aggregate code (``SARC``, ``CRC``, …) expands to many member
+    cohorts:
+
+    - **Mixed assays/pipelines.** Members may originate as microarray, FPKM,
+      RPKM, or raw counts and are each converted to clean TPM **independently,
+      per cohort, at build time** (see the ``processing_pipeline`` column).
+      Microarray-proxy TPM (``*_microarray_tpm_proxy_*``) is NOT magnitude-
+      comparable across platforms (a smaller probe universe inflates per-gene
+      TPM); pass ``exclude_microarray_proxy=True`` to drop those members for a
+      pipeline-homogeneous, poolable view.
+    - **Different gene universes.** Members measure different gene sets (here
+      ~13k–61k genes); a gene absent from a member is ``not_measurable`` for
+      that cohort, **never 0**. Rows are returned **per-(gene, cancer_code,
+      source_cohort)** — the reference deliberately does NOT pre-pool the union
+      into one fabricated summary, so a consumer can pool correctly (per-gene
+      availability mask, ``n_samples`` weighting) instead of averaging
+      incomparable scales.
 
     This accessor is for non-TCGA references such as CLL-map, MMRF
     CoMMpass, TARGET, and future GEO cohorts. Values are TPM-scale
@@ -1068,6 +1088,11 @@ def cancer_reference_expression(
         wide_codes = available_codes
     if genes is not None:
         df = filter_to_genes(df, genes)
+    if exclude_microarray_proxy:
+        # drop cross-platform-incomparable microarray-proxy members so the
+        # remaining all:-union view is pipeline-homogeneous and poolable.
+        df = df[~df["processing_pipeline"].astype(str)
+                .str.contains("microarray_tpm_proxy", na=False)]
 
     base_cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "source_cohort"]
     provenance_cols = [

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.36"
+__version__ = "5.22.37"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_reference_union_heterogeneity.py
+++ b/tests/test_reference_union_heterogeneity.py
@@ -1,0 +1,33 @@
+"""The all:-union expression contract (#366): a computed-aggregate code expands
+to member cohorts with mixed assays/pipelines and different gene universes, so
+the reference must (a) preserve per-cohort provenance, (b) never pre-pool, and
+(c) offer a pipeline-homogeneous view via exclude_microarray_proxy."""
+
+from pirlygenes.expression.accessors import cancer_reference_expression
+
+
+def test_union_preserves_per_cohort_pipeline_provenance():
+    d = cancer_reference_expression(cancer_types="SARC", genes=["TP53"])
+    # union expands to many member atoms, each tagged with its own pipeline
+    assert d["cancer_code"].nunique() > 5
+    assert "processing_pipeline" in d.columns
+    assert d["processing_pipeline"].nunique() > 1  # heterogeneous pipelines
+
+
+def test_exclude_microarray_proxy_yields_homogeneous_view():
+    full = cancer_reference_expression(cancer_types="SARC", genes=["TP53"])
+    homo = cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"], exclude_microarray_proxy=True)
+    # the microarray-proxy members (cross-platform-incomparable TPM) are dropped
+    assert full["processing_pipeline"].str.contains("microarray", na=False).any()
+    assert not homo["processing_pipeline"].str.contains("microarray", na=False).any()
+    assert homo["cancer_code"].nunique() < full["cancer_code"].nunique()
+
+
+def test_absent_genes_are_absent_not_zero():
+    # a gene present in only some member cohorts returns rows only for those
+    # cohorts (not_measurable elsewhere), never fabricated 0 rows.
+    d = cancer_reference_expression(cancer_types="SARC", genes=["TP53"])
+    assert (d["expression"].fillna(0) >= 0).all()
+    # every returned row is a real measurement (has a source cohort)
+    assert d["source_cohort"].notna().all()


### PR DESCRIPTION
Implements the safe core of **option C** (bare code = `all:`-union default), addressing the cross-cohort heterogeneity caution.

**Verified already in place:** bare `SARC` resolves to the all-union (30 atoms incl Ewing/OS — *not* the TCGA adult-STS cohort), and `SARC_LPS` intermediate node exists. So pirlygenes already defaults to `all:`; the remaining miscall is trufflepig's reference choice.

**This PR makes the union safe + explicit:**
- `cancer_reference_expression` docstring documents the union contract: members are **mixed assays** (microarray/FPKM/RPKM/counts) each converted to clean TPM **per-cohort at build**; microarray-proxy TPM is **not cross-platform comparable**; members measure **different gene universes** (~13k–61k here) so an absent gene is **not_measurable, never 0**; rows are per-(gene,code,source) and the reference **never pre-pools**.
- New `exclude_microarray_proxy=True` drops the incomparable microarray-proxy members for a pipeline-homogeneous, poolable view.

**Remaining (kept open):** full `source:node` grammar selector + heterogeneity-safe pooling (per-gene availability mask, n-weighting) = the cross-cohort-mixing roadmap. +3 tests; 520 pass.