### PR TITLE
Fix #304: clean_tpm_v5 cap-only technical normalization (5.22.38)

### DIFF
--- a/pirlygenes/expression/normalize.py
+++ b/pirlygenes/expression/normalize.py
@@ -209,7 +209,9 @@ def _clean_tpm_normalize(
         "group_cols": resolved_group_cols,
         "censored_fill": censored_fill,
         "technical_fraction": (
-            technical_fraction if censored_fill == "fixed_fraction" else None
+            technical_fraction
+            if censored_fill in ("fixed_fraction", "fixed_fraction_cap")
+            else None
         ),
         "exclude_ribosomal_proteins": bool(exclude_ribosomal_proteins),
         "removed_technical_gene_count": int(removable.sum()),
@@ -726,23 +728,39 @@ def clean_tpm_matrix(values, removable=None, *, gene_table=None,
             clean.iloc[ci, :] = ref_row[ci][:, None]
         return clean.fillna(0.0)
 
-    if censored_fill == "fixed_fraction":
-        # Two-compartment: technical -> technical_fraction*1e6, biological ->
-        # the rest, each renormalized WITHIN its group (relative expression
-        # preserved). Removes the technical-fraction confound without erasing
-        # within-compartment signal; cohort-independent (no reference table).
+    if censored_fill in ("fixed_fraction", "fixed_fraction_cap"):
+        # Two-compartment technical/biological split. The technical block is
+        # mtDNA / rRNA-like / mt-pseudogene / polyA-bias lncRNA + ribosomal-
+        # protein mRNA & pseudogenes. Within each compartment relative
+        # expression is preserved; cohort-independent (no reference table).
+        #   "fixed_fraction"     (clean_tpm_v4): technical block FORCED to
+        #       technical_fraction of the 1e6 budget — inflates technical genes
+        #       UP when they're naturally below the target (#304).
+        #   "fixed_fraction_cap" (clean_tpm_v5, #304): technical block CAPPED at
+        #       technical_fraction — compressed when above, NEVER inflated above
+        #       its natural level (suppress-only). Below the cap, expression is
+        #       left as-is (renormalised to 1e6).
         if not 0.0 < technical_fraction < 1.0:
             raise ValueError("technical_fraction must be in (0, 1)")
         tech_budget = technical_fraction * 1_000_000.0
-        bio_budget = (1.0 - technical_fraction) * 1_000_000.0
         tech_sum = values.loc[rem].sum(axis=0)
         bio_sum = values.loc[~rem].sum(axis=0)
         tscale = pd.Series(0.0, index=values.columns, dtype=float)
-        tpos = tech_sum > 0
-        tscale.loc[tpos] = tech_budget / tech_sum.loc[tpos]
         bscale = pd.Series(0.0, index=values.columns, dtype=float)
-        bpos = bio_sum > 0
-        bscale.loc[bpos] = bio_budget / bio_sum.loc[bpos]
+        if censored_fill == "fixed_fraction":
+            bio_budget = (1.0 - technical_fraction) * 1_000_000.0
+            tpos = tech_sum > 0
+            tscale.loc[tpos] = tech_budget / tech_sum.loc[tpos]
+            bpos = bio_sum > 0
+            bscale.loc[bpos] = bio_budget / bio_sum.loc[bpos]
+        else:  # fixed_fraction_cap (v5): cap-only, never inflate
+            total = tech_sum + bio_sum
+            over = (tech_sum > tech_budget) & (bio_sum > 0)
+            tscale.loc[over] = tech_budget / tech_sum.loc[over]
+            bscale.loc[over] = (1_000_000.0 - tech_budget) / bio_sum.loc[over]
+            keep = ~over & (total > 0)
+            tscale.loc[keep] = 1_000_000.0 / total.loc[keep]
+            bscale.loc[keep] = 1_000_000.0 / total.loc[keep]
         clean = values.astype(float).copy()
         clean.loc[rem] = values.loc[rem].mul(tscale, axis=1)
         clean.loc[~rem] = values.loc[~rem].mul(bscale, axis=1)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.37"
+__version__ = "5.22.38"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_clean_tpm_v5_cap.py
+++ b/tests/test_clean_tpm_v5_cap.py
@@ -1,0 +1,38 @@
+"""clean_tpm_v5 cap-only technical normalization (#304).
+
+v4 (censored_fill='fixed_fraction') FORCES the technical block to 25%, inflating
+technical genes UP in technically-light cohorts (CD138-sorted MM, T_ALL). v5
+(censored_fill='fixed_fraction_cap') CAPS at 25% — compress when above, never
+inflate above the natural level.
+"""
+
+import pandas as pd
+
+from pirlygenes.expression.normalize import clean_tpm_matrix
+
+_IDX = ["MT-CO1", "MT-ND1", "GAPDH", "ACTB"]
+_REM = pd.Series([True, True, False, False], index=_IDX)
+# sample LIGHT: technical = 10% of budget; HEAVY: technical = 50%
+_VALS = pd.DataFrame(
+    {"LIGHT": [50000, 50000, 450000, 450000],
+     "HEAVY": [250000, 250000, 250000, 250000]}, index=_IDX)
+
+
+def _tech_frac(clean, col):
+    return clean[col].loc[["MT-CO1", "MT-ND1"]].sum() / 1_000_000.0
+
+
+def test_v4_forces_to_fraction_inflating_light():
+    c = clean_tpm_matrix(_VALS, removable=_REM, censored_fill="fixed_fraction")
+    assert abs(_tech_frac(c, "LIGHT") - 0.25) < 1e-6   # 10% -> 25% (inflated)
+    assert abs(_tech_frac(c, "HEAVY") - 0.25) < 1e-6
+
+
+def test_v5_caps_only_never_inflates():
+    c = clean_tpm_matrix(_VALS, removable=_REM,
+                         censored_fill="fixed_fraction_cap")
+    assert abs(_tech_frac(c, "LIGHT") - 0.10) < 1e-6   # stays 10% (not inflated)
+    assert abs(_tech_frac(c, "HEAVY") - 0.25) < 1e-6   # 50% capped to 25%
+    # each compartment renormalises to a full 1e6 budget
+    assert abs(c["LIGHT"].sum() - 1_000_000.0) < 1.0
+    assert abs(c["HEAVY"].sum() - 1_000_000.0) < 1.0


### PR DESCRIPTION
Adds **`censored_fill='fixed_fraction_cap'` (clean_tpm_v5)** — the cap-only semantics you chose (cap all technical, incl ribosomal, at 25%).

**The v4 bug:** `fixed_fraction` *forces* the technical block to exactly 25%, so in technically-light cohorts it scales technical genes **up** (CD138-sorted MM MT-CO1 5173→13804; T_ALL MALAT1 3790→7512) — the opposite of suppressing contamination.

**v5 (cap-only):** technical block is **capped** at `technical_fraction` — compressed when above, **never inflated** above its natural level; below the cap, the sample is renormalised to 1e6 unchanged. Validated: a 10%-technical sample **stays 10%** (v4 forced it to 25%); a 50%-technical sample caps to 25%.

v4 is **preserved** (matches the currently-shipped bundle); v5 is **opt-in** via the new `censored_fill` value, so nothing breaks.

**Remaining (DATA_VERSION, kept open):** rebuild the reference bundle with clean_tpm_v5 (flip the builders to `fixed_fraction_cap` + bump the pipeline tag) so the *shipped* reference reflects cap-only — needs the raw quantifications. +2 tests; 522 pass.