### PR TITLE
#304: document clean_tpm_v5 comparability trade-off (5.22.39)

### DIFF
--- a/pirlygenes/expression/normalize.py
+++ b/pirlygenes/expression/normalize.py
@@ -740,6 +740,19 @@ def clean_tpm_matrix(values, removable=None, *, gene_table=None,
         #       technical_fraction — compressed when above, NEVER inflated above
         #       its natural level (suppress-only). Below the cap, expression is
         #       left as-is (renormalised to 1e6).
+        #       CAVEAT: this is NOT a strict improvement on v4. Within a 1e6
+        #       budget "biology comparable across samples" and "technical block
+        #       untouched" are complementary. v4 fixes the BIOLOGICAL compartment
+        #       to a constant (1-fraction) budget, so biological clean-TPM is
+        #       cross-sample comparable and only the suppressed technical/QC
+        #       block (incl. MALAT1/NEAT1 nuclear-QC markers) is rescaled. v5
+        #       instead lets low-technical samples keep a LARGER biological
+        #       budget, so biological genes are inflated there (a 10%-technical
+        #       sample reads ~1.2x a 25%-technical one for the same true biology)
+        #       — it moves the distortion onto the biological comparison you
+        #       actually use. Prefer v4 for a cross-cohort biological reference;
+        #       use v5 only WITHIN a technically-uniform set, or read QC genes
+        #       from raw TPM instead.
         if not 0.0 < technical_fraction < 1.0:
             raise ValueError("technical_fraction must be in (0, 1)")
         tech_budget = technical_fraction * 1_000_000.0

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.38"
+__version__ = "5.22.39"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Follow-up to #304: the cap-only v5 is **not** a strict improvement on v4, so the docstring now says so.

Within a 1e6 budget, *biology comparable across samples* and *technical block untouched* are **complementary**. v4 fixes the **biological compartment** to a constant budget → biological clean-TPM is cross-sample comparable, and only the suppressed technical/QC block (incl. MALAT1/NEAT1, which are deliberately classified as nuclear-QC markers) gets rescaled. v5 lets low-technical samples keep a larger biological budget → biological genes inflated there (**~1.2× for the same true biology**), moving the distortion onto the comparison clean-TPM exists to provide.

**Decision: keep v4 as default; do NOT rebuild the bundle to v5.** v5 remains a documented opt-in for within-technically-uniform-set use; read QC genes from raw TPM instead. 522 tests pass.