### PR TITLE
#366: source:node selector (source_kind=) (5.22.41)

### DIFF
--- a/pirlygenes/expression/accessors.py
+++ b/pirlygenes/expression/accessors.py
@@ -1011,8 +1011,18 @@ def cancer_reference_expression(
     format: str = "long",
     include_provenance: bool = True,
     exclude_microarray_proxy: bool = False,
+    source_kind: Optional[str | Iterable[str]] = None,
 ) -> pd.DataFrame:
     """Source-agnostic packaged tumor expression references.
+
+    ``source_kind`` is the ``source:node`` cohort-grammar selector (#366): keep
+    only the union members whose source is of the given cohort kind(s) — one or
+    a list of ``cohort-registry`` ``kind`` values (``treehouse``, ``geo``,
+    ``target``, ``beataml``, ``cgci``, ``cllmap``, ``mmrf``, ``ucologne``,
+    ``unc``). ``None`` (default) = ``all:`` (every source). NOTE: ``tcga`` is not
+    yet a first-class kind — TCGA data ships inside the ``treehouse`` cohort
+    (``*_TCGA_SUBSET``); a literal ``tcga:`` selector needs the cohort-registry
+    TCGA break-out (the larger #366 evidence-axis work).
 
     Cross-cohort (``all:`` union) heterogeneity contract — IMPORTANT when a
     computed-aggregate code (``SARC``, ``CRC``, …) expands to many member
@@ -1093,6 +1103,13 @@ def cancer_reference_expression(
         # remaining all:-union view is pipeline-homogeneous and poolable.
         df = df[~df["processing_pipeline"].astype(str)
                 .str.contains("microarray_tpm_proxy", na=False)]
+    if source_kind is not None:
+        # source:node selector — keep only members of the given cohort kind(s).
+        kinds = {source_kind} if isinstance(source_kind, str) else set(source_kind)
+        cr = get_data("cohort-registry")
+        cohort_kind = dict(zip(cr["cohort_id"].astype(str),
+                               cr["kind"].astype(str)))
+        df = df[df["source_cohort"].astype(str).map(cohort_kind).isin(kinds)]
 
     base_cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "source_cohort"]
     provenance_cols = [

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.40"
+__version__ = "5.22.41"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_reference_union_heterogeneity.py
+++ b/tests/test_reference_union_heterogeneity.py
@@ -31,3 +31,20 @@ def test_absent_genes_are_absent_not_zero():
     assert (d["expression"].fillna(0) >= 0).all()
     # every returned row is a real measurement (has a source cohort)
     assert d["source_cohort"].notna().all()
+
+
+def test_source_kind_selector_filters_by_cohort_kind():
+    """#366 source:node selector — source_kind keeps only members of the given
+    cohort kind(s); None (default) is the full all:-union."""
+    allu = cancer_reference_expression(cancer_types="SARC", genes=["TP53"])
+    geo = cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"], source_kind="geo")
+    th = cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"], source_kind="treehouse")
+    assert geo["source_cohort"].nunique() < allu["source_cohort"].nunique()
+    assert geo["source_cohort"].str.startswith("GSE").all()        # geo only
+    assert th["source_cohort"].str.startswith("TREEHOUSE").all()   # treehouse only
+    # a list of kinds unions them
+    both = cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"], source_kind=["geo", "treehouse"])
+    assert both["source_cohort"].nunique() == allu["source_cohort"].nunique()


### PR DESCRIPTION
Adds the **`source:node` selector** from #366: `cancer_reference_expression(..., source_kind=...)` keeps only the `all:`-union members whose source is of the given cohort-registry `kind`(s) — `treehouse`/`geo`/`target`/`beataml`/`cgci`/`cllmap`/`mmrf`/`ucologne`/`unc`. `None` (default) = `all:`. Accepts a string or list.

E.g. `source_kind='geo'` → only the GEO members of `SARC`; `['geo','treehouse']` unions them.

**NOTE / remaining:** `tcga` is **not yet a first-class kind** — TCGA data ships *inside* the `treehouse` cohort (`*_TCGA_SUBSET`), so a literal `tcga:SARC` selector needs the cohort-registry to break TCGA out of treehouse (+ that's the larger #366 evidence-axis work, along with heterogeneity-safe pooling). +1 test; 523 pass.