### PR TITLE
Fix #359: split coarse 'cns' family into 6 sub-families (5.22.42)

### DIFF
--- a/pirlygenes/data/cancer-type-registry.csv
+++ b/pirlygenes/data/cancer-type-registry.csv
@@ -13,7 +13,7 @@ CRC,Colorectal Adenocarcinoma,carcinoma-gi,colorectum,solid_primary,,,computed,C
 COAD,Colon Adenocarcinoma,carcinoma-gi,colon,solid_primary,CRC,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,CMS1-4 molecular subtypes + MSI-H axis,False,False,,none,,none,
 DLBC,Diffuse Large B-cell Lymphoma,heme-bcell,lymph_node,heme_nodal,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,ABC vs GCB subtypes,False,False,,subset,EBV,subtype,IGH-BCL6; IGH-MYC; IGH-BCL2
 ESCA,Esophageal Carcinoma,carcinoma-gi,esophagus,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,Adenocarcinoma + squamous lumped — biologically distinct,False,False,,none,,none,
-GBM,Glioblastoma Multiforme,cns,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-wildtype per 2021 WHO; mes/classical/proneural subtypes,False,False,,none,,subtype,FGFR3-TACC3
+GBM,Glioblastoma Multiforme,cns-glial,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-wildtype per 2021 WHO; mes/classical/proneural subtypes,False,False,,none,,subtype,FGFR3-TACC3
 HNSC,Head and Neck Squamous Cell Carcinoma,carcinoma-head-neck,pharynx,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HPV+ vs HPV- — two distinct diseases,False,False,,none,,none,
 HNSC_HPVpos,HPV+ HNSC,carcinoma-head-neck,oropharynx,solid_primary,HNSC,,TCGA/HPV,TREEHOUSE_POLYA_25_01_TCGA_HNSC_HPV,PMID:25631445,Better prognosis; p16+; E6/E7-driven,False,False,,defining,HPV,none,
 HNSC_HPVneg,HPV- HNSC,carcinoma-head-neck,oral_cavity,solid_primary,HNSC,,TCGA/HPV,TREEHOUSE_POLYA_25_01_TCGA_HNSC_HPV,PMID:25631445,Smoking/alcohol; TP53-mutant,False,False,,none,,none,
@@ -25,7 +25,7 @@ LAML_APL,Acute Promyelocytic Leukemia,heme-myeloid,bone_marrow,heme_marrow,LAML,
 LAML_ELNfav,AML ELN2017 Favorable,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,NPM1+/FLT3- or CBF; chemo-sensitive,False,False,,none,,none,
 LAML_ELNint,AML ELN2017 Intermediate,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,Mixed; individualized therapy,False,False,,none,,none,
 LAML_ELNadv,AML ELN2017 Adverse,heme-myeloid,bone_marrow,heme_marrow,LAML,,BEATAML,BEATAML_OHSU_2022,PMID:36109543,TP53/complex karyo; transplant-first,False,False,,none,,none,
-LGG,Lower Grade Glioma,cns,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-mutant (per 2021 WHO); vorasidenib-eligible,False,False,,none,,subtype,KIAA1549-BRAF
+LGG,Lower Grade Glioma,cns-glial,cerebrum,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,IDH-mutant (per 2021 WHO); vorasidenib-eligible,False,False,,none,,subtype,KIAA1549-BRAF
 LIHC,Liver Hepatocellular Carcinoma,carcinoma-gi,liver,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,HBV/HCV/NASH etiologies,False,False,,subset,HBV;HCV,subtype,DNAJB1-PRKACA
 LUAD,Lung Adenocarcinoma,carcinoma-lung,lung,solid_primary,,,TCGA,TREEHOUSE_POLYA_25_01_TCGA_SUBSET,PMID:24071852,EGFR / KRAS / STK11-KEAP1 axes — therapy-gating,False,False,,none,,subtype,EML4-ALK; CD74-ROS1; EZR-ROS1; SLC34A2-ROS1; KIF5B-RET; CCDC6-RET; CD74-NRG1; SLC3A2-NRG1
 LUAD_EGFR,EGFR-mutant LUAD,carcinoma-lung,lung,solid_primary,LUAD,,TCGA/mut,TREEHOUSE_POLYA_25_01_TCGA_LUAD_MUT,PMID:25079552,Osimertinib-first; often never-smoker,False,False,,none,,none,
@@ -68,12 +68,12 @@ NBL_MYCNamp,Neuroblastoma MYCN-amplified,neuroendocrine,sympathetic_ganglia,prim
 NBL_MYCNnonamp,Neuroblastoma MYCN-non-amplified,neuroendocrine,sympathetic_ganglia,primary_neural_crest,NBL,,TARGET,TARGET_NBL_2018,PMID:30019323,Intermediate/low-risk; better prognosis,False,True,,none,,none,
 WILMS,Wilms Tumor / Nephroblastoma,embryonal,kidney,primary_embryonal,,,TARGET,TARGET_WT_2015,PMID:25622910,WT1/CTNNB1/AMER1; favorable vs anaplastic,False,True,,none,,none,
 RT,Rhabdoid Tumor,embryonal,kidney_cns_soft,primary_embryonal,,,TARGET,TARGET_RT_2017,PMID:29568089,SMARCB1 loss; malignant; CNS AT/RT subset,False,True,,none,,none,
-ATRT,Atypical Teratoid/Rhabdoid Tumor,cns,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCB1 loss; CNS-only rhabdoid,False,True,,none,,none,
-MBL,Medulloblastoma,cns,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SHH / WNT / Group 3 / Group 4 subgroups,False,True,,none,,none,
-MBL_WNT,Medulloblastoma WNT,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Excellent prognosis; CTNNB1,False,True,,none,,none,
-MBL_SHH,Medulloblastoma SHH,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,PTCH1/SMO; vismodegib-eligible,False,True,,none,,none,
-MBL_G3,Medulloblastoma Group 3,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,MYC-amp; worst prognosis,False,True,,none,,none,
-MBL_G4,Medulloblastoma Group 4,cns,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Most common; MYCN/CDK6,False,True,,none,,none,
+ATRT,Atypical Teratoid/Rhabdoid Tumor,cns-embryonal,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SMARCB1 loss; CNS-only rhabdoid,False,True,,none,,none,
+MBL,Medulloblastoma,cns-embryonal,cerebellum,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,SHH / WNT / Group 3 / Group 4 subgroups,False,True,,none,,none,
+MBL_WNT,Medulloblastoma WNT,cns-embryonal,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Excellent prognosis; CTNNB1,False,True,,none,,none,
+MBL_SHH,Medulloblastoma SHH,cns-embryonal,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,PTCH1/SMO; vismodegib-eligible,False,True,,none,,none,
+MBL_G3,Medulloblastoma Group 3,cns-embryonal,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,MYC-amp; worst prognosis,False,True,,none,,none,
+MBL_G4,Medulloblastoma Group 4,cns-embryonal,cerebellum,solid_primary,MBL,,Treehouse,TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS,PMID:35709076,Most common; MYCN/CDK6,False,True,,none,,none,
 RB,Retinoblastoma,embryonal,retina,solid_primary,,,Treehouse/RiboD,TREEHOUSE_RIBOD_25_01,,RB1 loss; pediatric eye,False,True,,none,,none,
 HEPB,Hepatoblastoma,embryonal,liver,solid_primary,,,Treehouse,TREEHOUSE_POLYA_25_01,,CTNNB1; pediatric liver,False,True,,none,,none,
 CLL,Chronic Lymphocytic Leukemia,heme-bcell,peripheral_blood,heme_blood,,,CLL-map,CLLMAP_2022,,IGHV mutation status; BTK/BCL2 inhibitors,False,False,,none,,none,
@@ -140,11 +140,11 @@ FTC,Fallopian Tube Carcinoma,carcinoma-gu,fallopian_tube,solid_primary,OV,,curat
 PPC,Primary Peritoneal Carcinoma,carcinoma-gu,peritoneum_serous,solid_primary,OV,,curated,LITERATURE_CURATED,,HGSC of peritoneal origin; pooled in TCGA-OV.,False,False,,none,,none,
 ANSC,Anal Squamous Cell Carcinoma,carcinoma-gi,anal_canal,solid_primary,,,curated,LITERATURE_CURATED,PMID:39024554,HPV-driven anal SCC; GSE253560 bulk RNA-seq (n=70) not yet built.,False,False,,defining,HPV,none,
 GBC,Gallbladder Carcinoma,carcinoma-gi,gallbladder,solid_primary,,,curated,LITERATURE_CURATED,PMID:33578820,Distinct from intrahepatic CHOL; ERBB2/TP53; DDBJ SAMD00254734-781 (n=36) not yet built.,False,False,,none,,none,
-EPN,Ependymoma,cns,ependyma,solid_primary,,,curated,LITERATURE_CURATED,PMID:25965575,Molecular groups (ZFTA/RELA-fusion supratentorial; PF-A/PF-B); OpenPBTA/CBTN + GSE64415 not yet built.,False,True,,none,,none,
-CRANIO,Craniopharyngioma,cns,sellar_suprasellar,solid_primary,,,curated,LITERATURE_CURATED,PMID:28859336,Adamantinomatous (CTNNB1) vs papillary (BRAF V600E); OpenPBTA/CBTN + GSE94349 not yet built.,False,True,,none,,none,
-DIPG,Diffuse Midline Glioma H3 K27-altered,cns,pons_midline,solid_primary,,,curated,LITERATURE_CURATED,PMID:29954445,H3 K27M (H3F3A/HIST1H3B); pediatric brainstem DMG; OpenPBTA/PNOC003 + GSE115397 not yet built.,False,True,,none,,none,
-MENINGIOMA,Meningioma,cns,meninges,solid_primary,,,curated,LITERATURE_CURATED,PMID:34185076,Anchors the MENINGIOMA family panel (SSTR2A+ ~95%/EMA+); NF2 / SMARCE1 / KLF4-TRAF7 molecular subtypes; not yet built.,False,False,,none,,none,
-CHOROID_PLEXUS,Choroid Plexus Tumor,cns,choroid_plexus,solid_primary,,,curated,LITERATURE_CURATED,PMID:34185076,Anchors the CHOROID_PLEXUS family panel (TTR+/KCNJ13+/AQP1+ epithelium); papilloma vs carcinoma; not yet built.,False,True,,none,,none,
+EPN,Ependymoma,cns-ependymal,ependyma,solid_primary,,,curated,LITERATURE_CURATED,PMID:25965575,Molecular groups (ZFTA/RELA-fusion supratentorial; PF-A/PF-B); OpenPBTA/CBTN + GSE64415 not yet built.,False,True,,none,,none,
+CRANIO,Craniopharyngioma,cns-sellar,sellar_suprasellar,solid_primary,,,curated,LITERATURE_CURATED,PMID:28859336,Adamantinomatous (CTNNB1) vs papillary (BRAF V600E); OpenPBTA/CBTN + GSE94349 not yet built.,False,True,,none,,none,
+DIPG,Diffuse Midline Glioma H3 K27-altered,cns-glial,pons_midline,solid_primary,,,curated,LITERATURE_CURATED,PMID:29954445,H3 K27M (H3F3A/HIST1H3B); pediatric brainstem DMG; OpenPBTA/PNOC003 + GSE115397 not yet built.,False,True,,none,,none,
+MENINGIOMA,Meningioma,cns-meningeal,meninges,solid_primary,,,curated,LITERATURE_CURATED,PMID:34185076,Anchors the MENINGIOMA family panel (SSTR2A+ ~95%/EMA+); NF2 / SMARCE1 / KLF4-TRAF7 molecular subtypes; not yet built.,False,False,,none,,none,
+CHOROID_PLEXUS,Choroid Plexus Tumor,cns-choroid,choroid_plexus,solid_primary,,,curated,LITERATURE_CURATED,PMID:34185076,Anchors the CHOROID_PLEXUS family panel (TTR+/KCNJ13+/AQP1+ epithelium); papilloma vs carcinoma; not yet built.,False,True,,none,,none,
 PITNET,Pituitary Neuroendocrine Tumor,endocrine,pituitary,solid_primary,,,curated,LITERATURE_CURATED,,PIT1/TPIT/SF1 transcription-factor lineages; hormone-secreting; GSE147786 not yet built.,False,False,,none,,none,
 ALCL,Anaplastic Large Cell Lymphoma,heme-tcell,lymph_node,heme_nodal,,,curated,LITERATURE_CURATED,PMID:8122112,"CD30+ T-cell lymphoma; ALK+ (NPM1-ALK, younger) vs ALK- subtypes; brentuximab vedotin (anti-CD30); ALK inhibitors for ALK+",,False,,none,,subtype,NPM1-ALK
 COAD_MSI,MSI-H Colon Adenocarcinoma,carcinoma-gi,colon,solid_primary,COAD,,TCGA/MSI,TREEHOUSE_POLYA_25_01_TCGA_COADREAD_MSI,PMID:26028255,MSI-H/dMMR; immune-hot; aPD1-responsive (~45% ORR); MSIsensor>=10,False,False,,none,,none,

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -391,7 +391,12 @@ _FAMILY_DISPLAY_NAMES = {
     "carcinoma-mesothelial": "Mesothelioma",
     "carcinoma-other": "Other carcinoma",
     "carcinoma-skin": "Non-melanoma skin carcinoma",
-    "cns": "CNS tumor",
+    "cns-glial": "Glial tumor",
+    "cns-embryonal": "Embryonal CNS tumor",
+    "cns-ependymal": "Ependymal tumor",
+    "cns-sellar": "Sellar tumor",
+    "cns-meningeal": "Meningeal tumor",
+    "cns-choroid": "Choroid plexus tumor",
     "embryonal": "Embryonal tumor",
     "endocrine": "Endocrine tumor",
     "germ-cell": "Germ cell tumor",
@@ -2567,7 +2572,11 @@ _HEME_TISSUE_BURDEN = {
 }
 # Last-resort family fallback when primary_tissue is blank/unmapped.
 _FAMILY_BURDEN = {
-    "sarcoma": "soft_tissue_sarcoma", "melanoma": "melanoma", "cns": "brain_cns",
+    "sarcoma": "soft_tissue_sarcoma", "melanoma": "melanoma",
+    # CNS family was split into finer sub-families (#359); all map to brain_cns.
+    "cns-glial": "brain_cns", "cns-embryonal": "brain_cns",
+    "cns-ependymal": "brain_cns", "cns-sellar": "brain_cns",
+    "cns-meningeal": "brain_cns", "cns-choroid": "brain_cns",
     "carcinoma-skin": "non_melanoma_skin",
 }
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.41"
+__version__ = "5.22.42"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cancer_type_registry.py
+++ b/tests/test_cancer_type_registry.py
@@ -228,17 +228,20 @@ def test_registry_includes_rare_entities():
 
 def test_cns_panel_anchor_codes_present_358():
     """#358: the MENINGIOMA and CHOROID_PLEXUS family panels added in #357 were
-    inert without a registry code to anchor them. Both codes now exist (family
-    'cns', curated/not-yet-built) and their code matches the panel Family name
-    so trufflepig can resolve a sample to the panel by name until the finer
-    'cns' family split lands (#359)."""
+    inert without a registry code to anchor them. Both codes now exist
+    (curated/not-yet-built) and their code matches the panel Family name so
+    trufflepig can resolve a sample to the panel by name. The coarse 'cns'
+    family was split into finer sub-families (#359), so these anchor under
+    cns-meningeal / cns-choroid."""
     from pirlygenes.gene_sets_cancer import cancer_family_panels
 
     df = cancer_type_registry().set_index("code")
     panels = cancer_family_panels()
+    _cns_subfamily = {"MENINGIOMA": "cns-meningeal",
+                      "CHOROID_PLEXUS": "cns-choroid"}
     for code in ("MENINGIOMA", "CHOROID_PLEXUS"):
         assert code in df.index, f"missing CNS anchor code: {code}"
-        assert df.loc[code, "family"] == "cns"
+        assert df.loc[code, "family"] == _cns_subfamily[code]
         # curated placeholder, not over-claiming a concrete built shard
         assert df.loc[code, "expression_source"] == "curated"
         # the registry code anchors the same-named family panel


### PR DESCRIPTION
Closes #359. The single `cns` family fanned 13 codes out to 4+ panels, forcing trufflepig into per-code overrides. Split it the way **heme** is split (1:1 family→panel):

| sub-family | codes |
|---|---|
| `cns-glial` | GBM, LGG, DIPG |
| `cns-embryonal` | ATRT, MBL, MBL_WNT/SHH/G3/G4 |
| `cns-ependymal` | EPN |
| `cns-sellar` | CRANIO |
| `cns-meningeal` | MENINGIOMA |
| `cns-choroid` | CHOROID_PLEXUS |

Plus family display names and a `burden_category` family-fallback for the `cns-*` values (MENINGIOMA/CHOROID_PLEXUS have unmapped tissues and relied on the old `cns→brain_cns` fallback). Now the trufflepig code→panel crosswalk is **data-driven with zero CNS overrides**, exactly like heme.

(The lower-priority `endocrine` split noted in #359 is left as a follow-up.) 523 tests pass.