### PR TITLE
#366: source_kind = processing source (no fake tcga kind) + source_cohort= (5.22.44)

### DIFF
--- a/pirlygenes/expression/accessors.py
+++ b/pirlygenes/expression/accessors.py
@@ -1012,17 +1012,23 @@ def cancer_reference_expression(
     include_provenance: bool = True,
     exclude_microarray_proxy: bool = False,
     source_kind: Optional[str | Iterable[str]] = None,
+    source_cohort: Optional[str | Iterable[str]] = None,
 ) -> pd.DataFrame:
     """Source-agnostic packaged tumor expression references.
 
     ``source_kind`` is the ``source:node`` cohort-grammar selector (#366): keep
-    only the union members whose source is of the given cohort kind(s) — one or
-    a list of ``cohort-registry`` ``kind`` values (``treehouse``, ``geo``,
-    ``target``, ``beataml``, ``cgci``, ``cllmap``, ``mmrf``, ``ucologne``,
-    ``unc``). ``None`` (default) = ``all:`` (every source). NOTE: ``tcga`` is not
-    yet a first-class kind — TCGA data ships inside the ``treehouse`` cohort
-    (``*_TCGA_SUBSET``); a literal ``tcga:`` selector needs the cohort-registry
-    TCGA break-out (the larger #366 evidence-axis work).
+    only the union members whose **processing source** is of the given kind(s) —
+    one or a list of ``cohort-registry`` ``kind`` values (``treehouse``,
+    ``geo``, ``target``, ``beataml``, ``cgci``, ``cllmap``, ``mmrf``,
+    ``ucologne``, ``unc``, ``curated``, ``computed``). ``None`` (default) =
+    ``all:`` (every source). The kind is the *processing* source, not the sample
+    origin — there is deliberately **no ``tcga`` kind**: our TCGA data is
+    Treehouse-reprocessed, so it selects under ``source_kind="treehouse"`` (a
+    ``tcga`` kind would falsely conflate it with GDC-pipeline TCGA, which the
+    package does not carry). For sample-origin / cohort-level precision (e.g.
+    just the Treehouse TCGA subset) use ``source_cohort=`` with the exact
+    ``cohort-registry`` cohort id(s), e.g.
+    ``source_cohort="TREEHOUSE_POLYA_25_01_TCGA_SUBSET"``.
 
     Cross-cohort (``all:`` union) heterogeneity contract — IMPORTANT when a
     computed-aggregate code (``SARC``, ``CRC``, …) expands to many member
@@ -1110,6 +1116,11 @@ def cancer_reference_expression(
         cohort_kind = dict(zip(cr["cohort_id"].astype(str),
                                cr["kind"].astype(str)))
         df = df[df["source_cohort"].astype(str).map(cohort_kind).isin(kinds)]
+    if source_cohort is not None:
+        # origin/cohort-level precision (e.g. the Treehouse TCGA subset).
+        cohorts = ({source_cohort} if isinstance(source_cohort, str)
+                   else set(source_cohort))
+        df = df[df["source_cohort"].astype(str).isin(cohorts)]
 
     base_cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "source_cohort"]
     provenance_cols = [

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.43"
+__version__ = "5.22.44"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_reference_union_heterogeneity.py
+++ b/tests/test_reference_union_heterogeneity.py
@@ -48,3 +48,18 @@ def test_source_kind_selector_filters_by_cohort_kind():
     both = cancer_reference_expression(
         cancer_types="SARC", genes=["TP53"], source_kind=["geo", "treehouse"])
     assert both["source_cohort"].nunique() == allu["source_cohort"].nunique()
+
+
+def test_tcga_selects_as_treehouse_not_a_fake_kind():
+    """TCGA is Treehouse-reprocessed, so it selects under source_kind='treehouse'
+    (the processing source) — there is no 'tcga' kind. source_cohort= gives the
+    finer origin-level precision (the specific Treehouse TCGA subset)."""
+    th = cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"], source_kind="treehouse")
+    assert any("TCGA" in s for s in th["source_cohort"].unique())  # TCGA in treehouse:
+    assert cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"], source_kind="tcga").empty  # no tcga kind
+    sub = cancer_reference_expression(
+        cancer_types="SARC", genes=["TP53"],
+        source_cohort="TREEHOUSE_POLYA_25_01_TCGA_SUBSET")
+    assert set(sub["source_cohort"].unique()) == {"TREEHOUSE_POLYA_25_01_TCGA_SUBSET"}


### PR DESCRIPTION
Per review feedback: the `*_TCGA_*` cohorts are **Treehouse-reprocessed** TCGA, not GDC. My earlier plan to reclassify them to `kind=tcga` was wrong — it would erase the Treehouse-processing provenance and **falsely conflate them with `gdc:`-pipeline TCGA** (which the package doesn't carry).

**Correct model:** `source_kind` is the **processing source** (`treehouse`/`geo`/`gdc`/`target`/…). TCGA-via-Treehouse selects under `source_kind='treehouse'`; there is deliberately **no `tcga` kind**.

For sample-origin / cohort-level precision (just the Treehouse TCGA subset), new **`source_cohort=`** filters by exact cohort id:
```python
cancer_reference_expression('BRCA', source_cohort='TREEHOUSE_POLYA_25_01_TCGA_SUBSET')
```
Docstring updated to state the processing-source-vs-origin model. +1 test; 524 pass.