### PR TITLE
PooledCohorts: heterogeneity-safe cross-cohort pooling primitive

### DIFF
--- a/pirlygenes/expression/stats.py
+++ b/pirlygenes/expression/stats.py
@@ -33,6 +33,7 @@ are the canonical column-name tuples for schema work.
 from __future__ import annotations
 
 import warnings
+from dataclasses import dataclass
 from typing import Iterable, Literal
 
 import numpy as np
@@ -216,6 +217,151 @@ def compute_count_columns(values: pd.DataFrame) -> dict[str, np.ndarray]:
         "n_samples": n_samples,
         "n_detected": n_detected,
     }
+
+
+# Availability-aware count columns for a *pooled* (cross-cohort) matrix, where
+# different source cohorts measured different gene sets. ``n_available`` is the
+# per-gene count that ``n_samples`` (cohort-wide constant) and ``n_detected``
+# (measured AND > 0) cannot express on their own.
+POOLED_COUNT_COLUMNS: tuple[str, ...] = ("n_samples", "n_available", "n_detected")
+
+
+@dataclass(frozen=True)
+class PooledCohorts:
+    """Heterogeneity-safe pool of ragged per-cohort sample matrices.
+
+    The single, centralized representation for cross-cohort mixing. ``values``
+    spans the **union** gene set x all pooled samples; ``measured`` is a
+    parallel boolean mask that is ``True`` exactly where the sample's source
+    cohort carries that gene in its panel.
+
+    Crucially the mask is built from per-cohort **row (gene) and column
+    (sample) membership**, NOT from ``values.notna()``. That keeps two cases
+    correct that a notna mask gets wrong:
+
+    - a *measured-but-zero* gene (value ``0.0``) is ``measured=True``;
+    - a *measured-but-dropout* gene (an intra-cohort ``NaN``) still counts in
+      that cohort's ``n_available`` denominator — the cohort measured it, this
+      sample just had no value — even though it's excluded from the reductions.
+
+    Not-measured cells are ``NaN`` in ``values`` and ``False`` in ``measured``
+    and are **never filled** (missing != zero). Every pooled operation routes
+    through this object (``analysis_matrix`` / :meth:`counts` / :meth:`stats` /
+    :meth:`summary`) so the availability semantics live in exactly one place.
+    """
+
+    values: pd.DataFrame
+    measured: pd.DataFrame
+
+    @classmethod
+    def from_cohorts(cls, matrices: Iterable[pd.DataFrame]) -> "PooledCohorts":
+        """Build the pool from ``(n_genes, n_samples)`` per-cohort matrices.
+
+        Each matrix's index is its **row mask** (the genes that cohort measures)
+        and its columns are its **column mask** (that cohort's samples); the
+        pooled measurement mask is the OR of each cohort's ``row x column``
+        block. Sample (column) labels must be globally unique across inputs —
+        prefix them by source cohort upstream if they collide.
+        """
+        mats = [m for m in matrices if m is not None and m.shape[1] > 0]
+        if not mats:
+            empty = pd.DataFrame()
+            return cls(empty, empty.copy())
+        values = pd.concat(mats, axis=1, join="outer")
+        # Each block is all-True over its cohort's genes x samples; after an
+        # outer join, a cell is present (True) iff some cohort covers it and NaN
+        # otherwise, so ``.notna()`` is exactly the membership mask (bool dtype,
+        # no fill/downcast).
+        blocks = [pd.DataFrame(True, index=m.index, columns=m.columns)
+                  for m in mats]
+        measured = (
+            pd.concat(blocks, axis=1, join="outer")
+            .reindex(index=values.index, columns=values.columns)
+            .notna()
+        )
+        return cls(values, measured)
+
+    @property
+    def analysis_matrix(self) -> pd.DataFrame:
+        """``values`` with every not-measured cell forced to ``NaN`` so every
+        reduction is taken only over the samples whose cohort measured the gene.
+        """
+        return self.values.where(self.measured)
+
+    def counts(self) -> dict[str, np.ndarray]:
+        """``{n_samples, n_available, n_detected}`` (see
+        :data:`POOLED_COUNT_COLUMNS`). ``n_available`` is the per-gene measured
+        (membership) count — the correct cross-cohort denominator; ``n_detected``
+        counts measured-and-``> 0`` only, never treating a not-measured cell as
+        a zero.
+        """
+        am = self.analysis_matrix
+        return {
+            "n_samples": np.full(self.values.shape[0], self.values.shape[1],
+                                 dtype=int),
+            "n_available": self.measured.sum(axis=1).to_numpy(),
+            "n_detected": ((am > 0) & self.measured).sum(axis=1).to_numpy(),
+        }
+
+    def stats(self, *, prefix: str = "TPM_") -> dict[str, np.ndarray]:
+        """The :func:`compute_cohort_stats` suite over the masked matrix.
+
+        Per-gene ``std`` is ``NaN`` where fewer than two samples measured the
+        gene.
+        """
+        return compute_cohort_stats(self.analysis_matrix, prefix=prefix)
+
+    def summary(self, *, prefix: str = "TPM_") -> dict[str, np.ndarray]:
+        """:meth:`stats` merged with :meth:`counts` — the full pooled summary."""
+        return {**self.stats(prefix=prefix), **self.counts()}
+
+
+def align_ragged_matrices(matrices: Iterable[pd.DataFrame]) -> pd.DataFrame:
+    """Outer-join ``(n_genes, n_samples)`` matrices on the gene-id index.
+
+    Thin convenience wrapper over :meth:`PooledCohorts.from_cohorts` returning
+    just the union value matrix (not-measured cells ``NaN``, never filled).
+    Prefer :class:`PooledCohorts` when you also need the measurement mask.
+    """
+    return PooledCohorts.from_cohorts(matrices).values
+
+
+def available_count_columns(values: pd.DataFrame) -> dict[str, np.ndarray]:
+    """Availability counts for a single matrix where ``NaN`` means not-measured.
+
+    Degenerate (single-panel) case of :meth:`PooledCohorts.counts`: with no
+    per-cohort blocks the only mask available is ``values.notna()``. Use
+    :class:`PooledCohorts` for a real cross-cohort pool, where membership and
+    notna can differ (measured-but-dropout cells).
+    """
+    measured = values.notna()
+    return {
+        "n_samples": np.full(values.shape[0], values.shape[1], dtype=int),
+        "n_available": measured.sum(axis=1).to_numpy(),
+        "n_detected": ((values > 0) & measured).sum(axis=1).to_numpy(),
+    }
+
+
+def pool_cohort_samples(
+    matrices: Iterable[pd.DataFrame],
+    *,
+    prefix: str = "TPM_",
+) -> tuple[pd.DataFrame, dict[str, np.ndarray]]:
+    """Heterogeneity-safe pool of ragged per-cohort sample matrices.
+
+    Functional front door to :class:`PooledCohorts`: a gene measured by one
+    cohort but not another is summarised over just the measuring cohort's
+    patients, with a per-gene ``n_available`` denominator — never imputed to
+    zero, never inner-joined down to the lowest-common gene set.
+
+    Returns ``(analysis_matrix, summary)`` where ``analysis_matrix`` is the
+    union matrix with not-measured cells ``NaN`` and ``summary`` merges the
+    ``compute_cohort_stats`` suite with the availability counts.
+    """
+    pool = PooledCohorts.from_cohorts(matrices)
+    if pool.values.empty:
+        return pool.values, {}
+    return pool.analysis_matrix, pool.summary(prefix=prefix)
 
 
 def assign_stats(

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.49"
+__version__ = "5.22.50"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_pool_cohort_samples.py
+++ b/tests/test_pool_cohort_samples.py
@@ -1,0 +1,139 @@
+"""Heterogeneity-safe cross-cohort pooling primitive (roadmap #366 remainder).
+
+Different source cohorts measure different gene sets; pooling them must compute
+each gene's stats over only the samples whose cohort measured it, with a
+per-gene ``n_available`` denominator — never inner-joining down to the common
+gene set and never imputing off-panel genes to zero (missing != zero).
+"""
+
+import numpy as np
+import pandas as pd
+
+from pirlygenes.expression.stats import (
+    PooledCohorts,
+    align_ragged_matrices,
+    available_count_columns,
+    pool_cohort_samples,
+)
+
+
+def _cohort_a():
+    # measures genes A, B, C across 3 samples
+    return pd.DataFrame(
+        {"a1": [10.0, 100.0, 0.0], "a2": [20.0, 200.0, 5.0], "a3": [30.0, 300.0, 0.0]},
+        index=["A", "B", "C"],
+    )
+
+
+def _cohort_b():
+    # measures genes A, D only (NOT B, C; measures D which A doesn't) across 2 samples
+    return pd.DataFrame(
+        {"b1": [40.0, 7.0], "b2": [50.0, 9.0]},
+        index=["A", "D"],
+    )
+
+
+def test_alignment_is_union_and_unmeasured_stays_nan():
+    aligned = align_ragged_matrices([_cohort_a(), _cohort_b()])
+    assert set(aligned.index) == {"A", "B", "C", "D"}  # union, not intersection
+    assert list(aligned.columns) == ["a1", "a2", "a3", "b1", "b2"]
+    # B/C measured only by cohort A -> NaN in cohort B's columns (never filled)
+    assert aligned.loc["B", ["b1", "b2"]].isna().all()
+    assert aligned.loc["C", ["b1", "b2"]].isna().all()
+    # D measured only by cohort B -> NaN in cohort A's columns
+    assert aligned.loc["D", ["a1", "a2", "a3"]].isna().all()
+    # A measured by both -> no NaN
+    assert aligned.loc["A"].notna().all()
+
+
+def test_per_gene_stats_use_only_measuring_samples():
+    _, stats = pool_cohort_samples([_cohort_a(), _cohort_b()])
+    med = pd.Series(stats["TPM_median"], index=["A", "B", "C", "D"])
+    # A pooled over all 5 samples {10,20,30,40,50} -> 30
+    assert med["A"] == 30.0
+    # B only cohort A's {100,200,300} -> 200 (NOT diluted by cohort-B zeros)
+    assert med["B"] == 200.0
+    # D only cohort B's {7,9} -> 8
+    assert med["D"] == 8.0
+
+
+def test_availability_aware_counts():
+    counts = available_count_columns(align_ragged_matrices([_cohort_a(), _cohort_b()]))
+    idx = ["A", "B", "C", "D"]
+    n_samples = pd.Series(counts["n_samples"], index=idx)
+    n_avail = pd.Series(counts["n_available"], index=idx)
+    n_det = pd.Series(counts["n_detected"], index=idx)
+    # n_samples is the pooled width (constant)
+    assert (n_samples == 5).all()
+    # n_available is per-gene measured count
+    assert n_avail["A"] == 5 and n_avail["B"] == 3 and n_avail["C"] == 3 and n_avail["D"] == 2
+    # n_detected counts measured AND >0: gene C has two zeros among 3 measured
+    assert n_det["C"] == 1
+    # a not-measured cell is never counted as a (zero) detection
+    assert n_det["B"] == 3 and n_det["D"] == 2
+
+
+def test_std_is_nan_for_single_sample_gene():
+    a = pd.DataFrame({"a1": [1.0]}, index=["A"])          # 1 sample
+    b = pd.DataFrame({"b1": [2.0], "b2": [4.0]}, index=["B"])  # 2 samples, different gene
+    _, stats = pool_cohort_samples([a, b])
+    std = pd.Series(stats["TPM_std"], index=["A", "B"])
+    assert np.isnan(std["A"])        # only 1 sample measured A -> undefined std
+    assert std["B"] == np.std([2.0, 4.0], ddof=1)
+
+
+def test_missing_is_not_zero():
+    """The whole point: a gene off one cohort's panel must not be pulled toward
+    zero by that cohort's samples (the outer-join-and-fill bug)."""
+    _, stats = pool_cohort_samples([_cohort_a(), _cohort_b()])
+    mean = pd.Series(stats["TPM_mean"], index=["A", "B", "C", "D"])
+    # B's mean over only cohort A = (100+200+300)/3 = 200; a fill-zero pool over
+    # all 5 would give (100+200+300+0+0)/5 = 120 (the wrong, deflated answer).
+    assert mean["B"] == 200.0
+    assert mean["B"] != 120.0
+
+
+def test_empty_input():
+    aligned, stats = pool_cohort_samples([])
+    assert aligned.empty and stats == {}
+
+
+def test_mask_is_membership_not_notna_measured_but_zero():
+    """A measured-but-zero gene is measured=True (the mask comes from cohort
+    panel membership, not from the value being non-NaN/non-zero)."""
+    pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
+    # gene C measured by cohort A (values incl zeros) -> measured in a-cols,
+    # not measured in b-cols
+    assert pool.measured.loc["C", ["a1", "a2", "a3"]].all()
+    assert not pool.measured.loc["C", ["b1", "b2"]].any()
+    # the zeros are measured, so they ARE in n_available
+    counts = pool.counts()
+    n_avail = pd.Series(counts["n_available"], index=pool.values.index)
+    assert n_avail["C"] == 3            # all three A samples measured C
+    n_det = pd.Series(counts["n_detected"], index=pool.values.index)
+    assert n_det["C"] == 1              # only one of them had C > 0
+
+
+def test_mask_membership_vs_notna_on_dropout():
+    """A measured-but-dropout cell (intra-cohort NaN) still counts in
+    n_available (the cohort measured the gene) but is excluded from the stat.
+    A notna-based mask would wrongly drop it from the denominator."""
+    # cohort measures gene G in 3 samples but sample s2 dropped out (NaN)
+    coh = pd.DataFrame({"s1": [4.0], "s2": [np.nan], "s3": [8.0]}, index=["G"])
+    pool = PooledCohorts.from_cohorts([coh])
+    counts = pool.counts()
+    # membership mask -> all 3 measured this gene
+    assert int(counts["n_available"][0]) == 3
+    # but the median/mean skip the dropout NaN -> over {4, 8}
+    stats = pool.stats()
+    assert stats["TPM_median"][0] == 6.0
+    # contrast: the notna-based degenerate helper would only see 2 available
+    assert int(available_count_columns(pool.values)["n_available"][0]) == 2
+
+
+def test_centralized_helpers_agree_with_functional_frontdoor():
+    pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
+    am, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])
+    pd.testing.assert_frame_equal(am, pool.analysis_matrix)
+    for key, arr in pool.summary().items():
+        assert np.allclose(summary[key], arr, equal_nan=True)


### PR DESCRIPTION
First foundational piece of the cross-cohort-mixing roadmap (#366 remainder / task #12).

## Problem
Different source cohorts measure different gene sets. A correct pool must compute each gene's stats over **only the samples whose cohort measured it** — never inner-joining down to the common gene set, never imputing off-panel genes to zero (*missing ≠ zero*). The bundle currently sidesteps this with richest-source-wins on a single panel.

## What this adds
A single centralized representation — **`PooledCohorts`** in `expression/stats.py`:
- **`values`** — union-gene × all-sample matrix, `NaN` where not measured (never filled).
- **`measured`** — a parallel boolean mask built from per-cohort **row (gene) × column (sample) membership**, *not* from `values.notna()`. This keeps two cases correct that a notna mask gets wrong:
  - a *measured-but-zero* gene (value `0.0`) → `measured=True`;
  - a *measured-but-dropout* gene (intra-cohort `NaN`) → still counts in that cohort's `n_available` denominator, though excluded from the reductions.
- **Centralized helpers** so every pooled op routes through the mask:
  - `analysis_matrix` = `values.where(measured)`
  - `counts()` → `{n_samples, n_available, n_detected}` (per-gene `n_available` is the real cross-cohort denominator; `n_detected` never counts a not-measured cell as a zero)
  - `stats()` → the `compute_cohort_stats` suite, NaN-aware (per-gene `std` is `NaN` for singletons)
  - `summary()` → stats + counts

`align_ragged_matrices` / `available_count_columns` / `pool_cohort_samples` are thin wrappers (functional front door + maskless degenerate case). `POOLED_COUNT_COLUMNS` documents the schema.

## Scope
**Additive only** — no change to the build schema, `REFERENCE_COLUMNS`, or the shipped bundle. This directly closes the gaps the roadmap named (`compute_count_columns` had no per-gene `n_available`; nothing pooled ragged gene sets safely).

**Follow-ups** (not in this PR): wire `PooledCohorts` into the builder per-sample pool and the accessor's `all:`-union pooling mode; ragged-aware medoid (representatives) + percentile generation; then a bundle rebuild that persists `n_available`.

9 new tests cover union alignment, per-gene measuring subset, membership-vs-notna (measured-but-zero, measured-but-dropout), singleton-std NaN, and missing≠zero. 539 pass (`./test.sh`).