### PR TITLE
PooledCohorts: deterministic gene order + mask-as-authority

### DIFF
--- a/pirlygenes/expression/stats.py
+++ b/pirlygenes/expression/stats.py
@@ -260,14 +260,22 @@ class PooledCohorts:
         Each matrix's index is its **row mask** (the genes that cohort measures)
         and its columns are its **column mask** (that cohort's samples); the
         pooled measurement mask is the OR of each cohort's ``row x column``
-        block. Sample (column) labels must be globally unique across inputs —
-        prefix them by source cohort upstream if they collide.
+        block, with ``measured`` the single authority (a not-measured cell is
+        ``False`` here regardless of what ``values`` holds). Sample (column)
+        labels must be globally unique across inputs — prefix them by source
+        cohort upstream if they collide.
+
+        The union **gene rows are sorted canonically (lexical Ensembl id)** so
+        the pool is reproducible regardless of input cohort order — there is no
+        global gene order elsewhere (everything aligns by label), but a
+        deterministic order keeps any persisted pooled artifact diff-stable.
+        Sample **columns stay in input order** (grouped by cohort).
         """
         mats = [m for m in matrices if m is not None and m.shape[1] > 0]
         if not mats:
             empty = pd.DataFrame()
             return cls(empty, empty.copy())
-        values = pd.concat(mats, axis=1, join="outer")
+        values = pd.concat(mats, axis=1, join="outer").sort_index()
         # Each block is all-True over its cohort's genes x samples; after an
         # outer join, a cell is present (True) iff some cohort covers it and NaN
         # otherwise, so ``.notna()`` is exactly the membership mask (bool dtype,
@@ -283,8 +291,17 @@ class PooledCohorts:
 
     @property
     def analysis_matrix(self) -> pd.DataFrame:
-        """``values`` with every not-measured cell forced to ``NaN`` so every
-        reduction is taken only over the samples whose cohort measured the gene.
+        """``values`` projected through the (authoritative) ``measured`` mask:
+        every not-measured cell is forced to ``NaN`` so each **marginal** (per
+        gene, ``axis=1``) reduction is taken only over the samples whose cohort
+        measured the gene.
+
+        For the :meth:`from_cohorts` outer-join this equals ``values`` (already
+        ``NaN`` off-panel), but the projection is what makes correctness depend
+        on the mask rather than on how ``values`` was filled — essential if
+        ``values`` is ever a dense backing store. **Cross-sample / pairwise**
+        operations (distances, correlations) must consult ``measured`` directly
+        instead, since they need pairwise co-availability, not per-cell ``NaN``.
         """
         return self.values.where(self.measured)
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.50"
+__version__ = "5.22.51"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_pool_cohort_samples.py
+++ b/tests/test_pool_cohort_samples.py
@@ -131,6 +131,18 @@ def test_mask_membership_vs_notna_on_dropout():
     assert int(available_count_columns(pool.values)["n_available"][0]) == 2
 
 
+def test_gene_rows_are_canonically_sorted_and_order_independent():
+    """Union gene rows are sorted (lexical id) so the pool is reproducible
+    regardless of input cohort order; sample columns stay grouped by cohort."""
+    p_ab = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
+    p_ba = PooledCohorts.from_cohorts([_cohort_b(), _cohort_a()])
+    assert list(p_ab.values.index) == ["A", "B", "C", "D"]      # sorted union
+    assert list(p_ab.values.index) == list(p_ba.values.index)   # order-independent
+    # columns follow input order (grouped by cohort), not sorted
+    assert list(p_ab.values.columns) == ["a1", "a2", "a3", "b1", "b2"]
+    assert list(p_ba.values.columns) == ["b1", "b2", "a1", "a2", "a3"]
+
+
 def test_centralized_helpers_agree_with_functional_frontdoor():
     pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
     am, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])


### PR DESCRIPTION
Follow-up to #405, answering two design questions.

**1. `values.where(measured)` — keep it; mask is the authority.** It's a no-op for the `from_cohorts` outer-join (values is already `NaN` off-panel), but it's the canonical projection that makes correctness depend on the *mask* rather than on how `values` was filled — essential the moment `values` is a dense backing store (verified: a dense-backed pool gives the wrong median without it). Docstrings now state `measured` is authoritative, and that **cross-sample/pairwise** ops (distances, correlations) must use `measured` directly — per-cell `NaN` can't express pairwise co-availability.

**2. No global canonical ENSG row order exists or is needed** — every gene op aligns by *label* (`isin`/`merge`/`reindex`-by-label), so physical row order is incidental everywhere. But the pool's union row order was *input-order-dependent*, which would make a persisted pooled artifact's diffs non-reproducible. `from_cohorts` now sorts union **gene rows** canonically (lexical Ensembl id); **sample columns stay grouped by input cohort order**.

10 tests (added order-independence/determinism). 540 pass.