### PR TITLE
PooledCohorts: gene identity by id, never by position

### DIFF
--- a/pirlygenes/expression/stats.py
+++ b/pirlygenes/expression/stats.py
@@ -253,6 +253,17 @@ class PooledCohorts:
     values: pd.DataFrame
     measured: pd.DataFrame
 
+    def __post_init__(self) -> None:
+        # The mask can only be trusted if it shares the EXACT gene index and
+        # sample columns of values, by label. This forbids ever pairing a mask
+        # with a value matrix whose rows/cols are in a different order (the
+        # "matched by position, not id" bug the whole design exists to avoid).
+        if not self.values.index.equals(self.measured.index):
+            raise ValueError("values/measured gene index mismatch (must be "
+                             "identical and identically ordered, by id)")
+        if not self.values.columns.equals(self.measured.columns):
+            raise ValueError("values/measured sample columns mismatch")
+
     @classmethod
     def from_cohorts(cls, matrices: Iterable[pd.DataFrame]) -> "PooledCohorts":
         """Build the pool from ``(n_genes, n_samples)`` per-cohort matrices.
@@ -329,8 +340,31 @@ class PooledCohorts:
         return compute_cohort_stats(self.analysis_matrix, prefix=prefix)
 
     def summary(self, *, prefix: str = "TPM_") -> dict[str, np.ndarray]:
-        """:meth:`stats` merged with :meth:`counts` — the full pooled summary."""
+        """:meth:`stats` merged with :meth:`counts` as bare per-gene arrays.
+
+        Low-level surface, matching the :func:`compute_cohort_stats` /
+        :func:`assign_stats` convention. The arrays carry **no gene labels** —
+        ``array[i]`` corresponds to ``self.gene_index[i]`` *positionally*. Prefer
+        :meth:`summary_frame` whenever you don't already hold ``gene_index`` in
+        lockstep, so identity travels with the values (label-aligned, like the
+        rest of the package) instead of riding on row position.
+        """
         return {**self.stats(prefix=prefix), **self.counts()}
+
+    @property
+    def gene_index(self) -> pd.Index:
+        """The gene-id (Ensembl) index that every per-gene array aligns to."""
+        return self.values.index
+
+    def summary_frame(self, *, prefix: str = "TPM_") -> pd.DataFrame:
+        """:meth:`summary` as a **gene-indexed** DataFrame.
+
+        Each stat/count column is label-aligned to the Ensembl-id index, so
+        which row is which ENSG is explicit rather than a positional contract.
+        This is the safe public surface for pooled output (and what a future
+        bundle-persistence step should serialise).
+        """
+        return pd.DataFrame(self.summary(prefix=prefix), index=self.gene_index)
 
 
 def align_ragged_matrices(matrices: Iterable[pd.DataFrame]) -> pd.DataFrame:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.51"
+__version__ = "5.22.52"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_pool_cohort_samples.py
+++ b/tests/test_pool_cohort_samples.py
@@ -143,6 +143,49 @@ def test_gene_rows_are_canonically_sorted_and_order_independent():
     assert list(p_ba.values.columns) == ["b1", "b2", "a1", "a2", "a3"]
 
 
+def test_summary_frame_is_gene_indexed_not_positional():
+    """The safe public surface: identity travels with the values. Looking up a
+    gene's stats is by ENSG label, not by guessing its row position."""
+    pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
+    frame = pool.summary_frame()
+    # gene-indexed, aligned to the (sorted) union gene set
+    assert list(frame.index) == ["A", "B", "C", "D"]
+    assert frame.index.equals(pool.gene_index)
+    # label lookup gives the right gene's stats (B measured only by cohort A)
+    assert frame.loc["B", "TPM_median"] == 200.0
+    assert frame.loc["B", "n_available"] == 3
+    # every bare summary() array aligns positionally to gene_index
+    for key, arr in pool.summary().items():
+        assert np.allclose(frame[key].to_numpy(), arr, equal_nan=True)
+
+
+def test_genes_matched_by_id_never_by_position():
+    """Scramble each cohort's gene row order and the per-gene pooled stats are
+    unchanged — genes align by id label (concat/reindex), never by position."""
+    a, b = _cohort_a(), _cohort_b()
+    a_scrambled = a.loc[["C", "A", "B"]]            # reorder rows
+    b_scrambled = b.loc[["D", "A"]]
+    base = PooledCohorts.from_cohorts([a, b]).summary_frame()
+    scram = PooledCohorts.from_cohorts([a_scrambled, b_scrambled]).summary_frame()
+    pd.testing.assert_frame_equal(base, scram)      # identical, by id
+    # and the cohorts disagreeing on a SHARED gene's row position is harmless:
+    a2 = a.loc[["B", "C", "A"]]                      # A's gene A now last
+    b2 = b                                           # B's gene A still first
+    pooled = PooledCohorts.from_cohorts([a2, b2]).summary_frame()
+    # gene A pooled over all 5 samples {10,20,30(? no)...} -> same as base
+    assert pooled.loc["A", "TPM_median"] == base.loc["A", "TPM_median"]
+
+
+def test_mask_value_axis_mismatch_is_rejected():
+    """A hand-built pool whose mask doesn't share values' gene index/order is
+    rejected — you cannot accidentally pair a mask with mis-ordered values."""
+    import pytest
+    vals = pd.DataFrame({"s1": [1.0, 2.0]}, index=["A", "B"])
+    bad_mask = pd.DataFrame({"s1": [True, True]}, index=["B", "A"])  # reordered
+    with pytest.raises(ValueError, match="gene index mismatch"):
+        PooledCohorts(vals, bad_mask)
+
+
 def test_centralized_helpers_agree_with_functional_frontdoor():
     pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
     am, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])


### PR DESCRIPTION
Answers two follow-up questions: *how do you know which rows correspond to which ENSG?* and *make sure genes never get mixed up by order instead of id.*

- **`summary_frame()`** — the same stat/count suite as a **gene-indexed DataFrame**, so identity travels with the values (label lookup like the rest of the package). The bare-array `summary()`/`stats()`/`counts()` remain (matching the `compute_cohort_stats` convention) but are now documented as positionally aligned to the new `gene_index` property; `summary_frame` is the safe public surface.
- **`__post_init__` invariant** — `values` and `measured` must share the **exact gene index and sample columns, by label and order**, else `ValueError`. A mask can never be paired with a mis-ordered value matrix.
- The pooling already aligns by id (`concat`/`reindex` are label-based). Added a **scramble test** proving per-gene pooled stats are identical no matter what row order each cohort arrives in, and a test that an axis-mismatched hand-built pool is rejected.

3 new tests (13 in file). 543 pass.