### PR TITLE
PooledCohorts: gene-indexed everywhere (remove label-less surface)

### DIFF
--- a/pirlygenes/expression/stats.py
+++ b/pirlygenes/expression/stats.py
@@ -316,55 +316,49 @@ class PooledCohorts:
         """
         return self.values.where(self.measured)
 
-    def counts(self) -> dict[str, np.ndarray]:
-        """``{n_samples, n_available, n_detected}`` (see
+    @property
+    def gene_index(self) -> pd.Index:
+        """The authoritative gene-id (Ensembl) index every result is keyed by."""
+        return self.values.index
+
+    def counts(self) -> pd.DataFrame:
+        """Gene-indexed ``{n_samples, n_available, n_detected}`` (see
         :data:`POOLED_COUNT_COLUMNS`). ``n_available`` is the per-gene measured
         (membership) count — the correct cross-cohort denominator; ``n_detected``
         counts measured-and-``> 0`` only, never treating a not-measured cell as
         a zero.
         """
         am = self.analysis_matrix
-        return {
-            "n_samples": np.full(self.values.shape[0], self.values.shape[1],
-                                 dtype=int),
-            "n_available": self.measured.sum(axis=1).to_numpy(),
-            "n_detected": ((am > 0) & self.measured).sum(axis=1).to_numpy(),
-        }
+        return pd.DataFrame(
+            {
+                "n_samples": np.full(self.values.shape[0], self.values.shape[1],
+                                     dtype=int),
+                "n_available": self.measured.sum(axis=1).to_numpy(),
+                "n_detected": ((am > 0) & self.measured).sum(axis=1).to_numpy(),
+            },
+            index=self.gene_index,
+        )
 
-    def stats(self, *, prefix: str = "TPM_") -> dict[str, np.ndarray]:
-        """The :func:`compute_cohort_stats` suite over the masked matrix.
+    def stats(self, *, prefix: str = "TPM_") -> pd.DataFrame:
+        """The :func:`compute_cohort_stats` suite as a gene-indexed DataFrame.
 
         Per-gene ``std`` is ``NaN`` where fewer than two samples measured the
         gene.
         """
-        return compute_cohort_stats(self.analysis_matrix, prefix=prefix)
+        return pd.DataFrame(
+            compute_cohort_stats(self.analysis_matrix, prefix=prefix),
+            index=self.gene_index,
+        )
 
-    def summary(self, *, prefix: str = "TPM_") -> dict[str, np.ndarray]:
-        """:meth:`stats` merged with :meth:`counts` as bare per-gene arrays.
+    def summary(self, *, prefix: str = "TPM_") -> pd.DataFrame:
+        """:meth:`stats` + :meth:`counts` as one **gene-indexed** DataFrame.
 
-        Low-level surface, matching the :func:`compute_cohort_stats` /
-        :func:`assign_stats` convention. The arrays carry **no gene labels** —
-        ``array[i]`` corresponds to ``self.gene_index[i]`` *positionally*. Prefer
-        :meth:`summary_frame` whenever you don't already hold ``gene_index`` in
-        lockstep, so identity travels with the values (label-aligned, like the
-        rest of the package) instead of riding on row position.
+        The single output surface. Every column is label-aligned to
+        :attr:`gene_index`, so which row is which ENSG is explicit — there is no
+        bare, position-only array to mis-pair with a foreign gene list. This is
+        what a future bundle-persistence step should serialise.
         """
-        return {**self.stats(prefix=prefix), **self.counts()}
-
-    @property
-    def gene_index(self) -> pd.Index:
-        """The gene-id (Ensembl) index that every per-gene array aligns to."""
-        return self.values.index
-
-    def summary_frame(self, *, prefix: str = "TPM_") -> pd.DataFrame:
-        """:meth:`summary` as a **gene-indexed** DataFrame.
-
-        Each stat/count column is label-aligned to the Ensembl-id index, so
-        which row is which ENSG is explicit rather than a positional contract.
-        This is the safe public surface for pooled output (and what a future
-        bundle-persistence step should serialise).
-        """
-        return pd.DataFrame(self.summary(prefix=prefix), index=self.gene_index)
+        return pd.concat([self.stats(prefix=prefix), self.counts()], axis=1)
 
 
 def align_ragged_matrices(matrices: Iterable[pd.DataFrame]) -> pd.DataFrame:
@@ -397,7 +391,7 @@ def pool_cohort_samples(
     matrices: Iterable[pd.DataFrame],
     *,
     prefix: str = "TPM_",
-) -> tuple[pd.DataFrame, dict[str, np.ndarray]]:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Heterogeneity-safe pool of ragged per-cohort sample matrices.
 
     Functional front door to :class:`PooledCohorts`: a gene measured by one
@@ -405,13 +399,13 @@ def pool_cohort_samples(
     patients, with a per-gene ``n_available`` denominator — never imputed to
     zero, never inner-joined down to the lowest-common gene set.
 
-    Returns ``(analysis_matrix, summary)`` where ``analysis_matrix`` is the
-    union matrix with not-measured cells ``NaN`` and ``summary`` merges the
-    ``compute_cohort_stats`` suite with the availability counts.
+    Returns ``(analysis_matrix, summary)``, both **gene-indexed** DataFrames:
+    ``analysis_matrix`` is the union matrix with not-measured cells ``NaN`` and
+    ``summary`` is the per-gene stat + availability-count suite.
     """
     pool = PooledCohorts.from_cohorts(matrices)
     if pool.values.empty:
-        return pool.values, {}
+        return pool.values, pd.DataFrame()
     return pool.analysis_matrix, pool.summary(prefix=prefix)
 
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.52"
+__version__ = "5.22.53"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_pool_cohort_samples.py
+++ b/tests/test_pool_cohort_samples.py
@@ -4,10 +4,14 @@ Different source cohorts measure different gene sets; pooling them must compute
 each gene's stats over only the samples whose cohort measured it, with a
 per-gene ``n_available`` denominator — never inner-joining down to the common
 gene set and never imputing off-panel genes to zero (missing != zero).
+
+Every ``PooledCohorts`` result is a **gene-indexed** DataFrame, so gene identity
+is by id label, never by row position.
 """
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from pirlygenes.expression.stats import (
     PooledCohorts,
@@ -36,7 +40,6 @@ def _cohort_b():
 def test_alignment_is_union_and_unmeasured_stays_nan():
     aligned = align_ragged_matrices([_cohort_a(), _cohort_b()])
     assert set(aligned.index) == {"A", "B", "C", "D"}  # union, not intersection
-    assert list(aligned.columns) == ["a1", "a2", "a3", "b1", "b2"]
     # B/C measured only by cohort A -> NaN in cohort B's columns (never filled)
     assert aligned.loc["B", ["b1", "b2"]].isna().all()
     assert aligned.loc["C", ["b1", "b2"]].isna().all()
@@ -47,8 +50,8 @@ def test_alignment_is_union_and_unmeasured_stays_nan():
 
 
 def test_per_gene_stats_use_only_measuring_samples():
-    _, stats = pool_cohort_samples([_cohort_a(), _cohort_b()])
-    med = pd.Series(stats["TPM_median"], index=["A", "B", "C", "D"])
+    _, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])
+    med = summary["TPM_median"]  # gene-indexed Series
     # A pooled over all 5 samples {10,20,30,40,50} -> 30
     assert med["A"] == 30.0
     # B only cohort A's {100,200,300} -> 200 (NOT diluted by cohort-B zeros)
@@ -58,75 +61,66 @@ def test_per_gene_stats_use_only_measuring_samples():
 
 
 def test_availability_aware_counts():
-    counts = available_count_columns(align_ragged_matrices([_cohort_a(), _cohort_b()]))
-    idx = ["A", "B", "C", "D"]
-    n_samples = pd.Series(counts["n_samples"], index=idx)
-    n_avail = pd.Series(counts["n_available"], index=idx)
-    n_det = pd.Series(counts["n_detected"], index=idx)
+    counts = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()]).counts()
     # n_samples is the pooled width (constant)
-    assert (n_samples == 5).all()
+    assert (counts["n_samples"] == 5).all()
     # n_available is per-gene measured count
-    assert n_avail["A"] == 5 and n_avail["B"] == 3 and n_avail["C"] == 3 and n_avail["D"] == 2
+    assert counts.loc["A", "n_available"] == 5
+    assert counts.loc["B", "n_available"] == 3
+    assert counts.loc["C", "n_available"] == 3
+    assert counts.loc["D", "n_available"] == 2
     # n_detected counts measured AND >0: gene C has two zeros among 3 measured
-    assert n_det["C"] == 1
+    assert counts.loc["C", "n_detected"] == 1
     # a not-measured cell is never counted as a (zero) detection
-    assert n_det["B"] == 3 and n_det["D"] == 2
+    assert counts.loc["B", "n_detected"] == 3
+    assert counts.loc["D", "n_detected"] == 2
 
 
 def test_std_is_nan_for_single_sample_gene():
     a = pd.DataFrame({"a1": [1.0]}, index=["A"])          # 1 sample
     b = pd.DataFrame({"b1": [2.0], "b2": [4.0]}, index=["B"])  # 2 samples, different gene
-    _, stats = pool_cohort_samples([a, b])
-    std = pd.Series(stats["TPM_std"], index=["A", "B"])
-    assert np.isnan(std["A"])        # only 1 sample measured A -> undefined std
-    assert std["B"] == np.std([2.0, 4.0], ddof=1)
+    _, summary = pool_cohort_samples([a, b])
+    assert np.isnan(summary.loc["A", "TPM_std"])  # only 1 sample measured A
+    assert summary.loc["B", "TPM_std"] == np.std([2.0, 4.0], ddof=1)
 
 
 def test_missing_is_not_zero():
     """The whole point: a gene off one cohort's panel must not be pulled toward
     zero by that cohort's samples (the outer-join-and-fill bug)."""
-    _, stats = pool_cohort_samples([_cohort_a(), _cohort_b()])
-    mean = pd.Series(stats["TPM_mean"], index=["A", "B", "C", "D"])
+    _, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])
     # B's mean over only cohort A = (100+200+300)/3 = 200; a fill-zero pool over
     # all 5 would give (100+200+300+0+0)/5 = 120 (the wrong, deflated answer).
-    assert mean["B"] == 200.0
-    assert mean["B"] != 120.0
+    assert summary.loc["B", "TPM_mean"] == 200.0
+    assert summary.loc["B", "TPM_mean"] != 120.0
 
 
 def test_empty_input():
-    aligned, stats = pool_cohort_samples([])
-    assert aligned.empty and stats == {}
+    aligned, summary = pool_cohort_samples([])
+    assert aligned.empty and summary.empty
 
 
 def test_mask_is_membership_not_notna_measured_but_zero():
     """A measured-but-zero gene is measured=True (the mask comes from cohort
     panel membership, not from the value being non-NaN/non-zero)."""
     pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
-    # gene C measured by cohort A (values incl zeros) -> measured in a-cols,
-    # not measured in b-cols
+    # gene C measured by cohort A (values incl zeros), not by cohort B
     assert pool.measured.loc["C", ["a1", "a2", "a3"]].all()
     assert not pool.measured.loc["C", ["b1", "b2"]].any()
-    # the zeros are measured, so they ARE in n_available
     counts = pool.counts()
-    n_avail = pd.Series(counts["n_available"], index=pool.values.index)
-    assert n_avail["C"] == 3            # all three A samples measured C
-    n_det = pd.Series(counts["n_detected"], index=pool.values.index)
-    assert n_det["C"] == 1              # only one of them had C > 0
+    assert counts.loc["C", "n_available"] == 3   # all three A samples measured C
+    assert counts.loc["C", "n_detected"] == 1    # only one of them had C > 0
 
 
 def test_mask_membership_vs_notna_on_dropout():
     """A measured-but-dropout cell (intra-cohort NaN) still counts in
     n_available (the cohort measured the gene) but is excluded from the stat.
     A notna-based mask would wrongly drop it from the denominator."""
-    # cohort measures gene G in 3 samples but sample s2 dropped out (NaN)
     coh = pd.DataFrame({"s1": [4.0], "s2": [np.nan], "s3": [8.0]}, index=["G"])
     pool = PooledCohorts.from_cohorts([coh])
-    counts = pool.counts()
     # membership mask -> all 3 measured this gene
-    assert int(counts["n_available"][0]) == 3
+    assert pool.counts().loc["G", "n_available"] == 3
     # but the median/mean skip the dropout NaN -> over {4, 8}
-    stats = pool.stats()
-    assert stats["TPM_median"][0] == 6.0
+    assert pool.stats().loc["G", "TPM_median"] == 6.0
     # contrast: the notna-based degenerate helper would only see 2 available
     assert int(available_count_columns(pool.values)["n_available"][0]) == 2
 
@@ -143,20 +137,18 @@ def test_gene_rows_are_canonically_sorted_and_order_independent():
     assert list(p_ba.values.columns) == ["b1", "b2", "a1", "a2", "a3"]
 
 
-def test_summary_frame_is_gene_indexed_not_positional():
-    """The safe public surface: identity travels with the values. Looking up a
-    gene's stats is by ENSG label, not by guessing its row position."""
+def test_summary_is_gene_indexed_not_positional():
+    """The single output surface is gene-indexed: looking up a gene's stats is
+    by ENSG label, not by guessing its row position."""
     pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
-    frame = pool.summary_frame()
-    # gene-indexed, aligned to the (sorted) union gene set
-    assert list(frame.index) == ["A", "B", "C", "D"]
-    assert frame.index.equals(pool.gene_index)
+    summary = pool.summary()
+    assert list(summary.index) == ["A", "B", "C", "D"]
+    assert summary.index.equals(pool.gene_index)
     # label lookup gives the right gene's stats (B measured only by cohort A)
-    assert frame.loc["B", "TPM_median"] == 200.0
-    assert frame.loc["B", "n_available"] == 3
-    # every bare summary() array aligns positionally to gene_index
-    for key, arr in pool.summary().items():
-        assert np.allclose(frame[key].to_numpy(), arr, equal_nan=True)
+    assert summary.loc["B", "TPM_median"] == 200.0
+    assert summary.loc["B", "n_available"] == 3
+    # stats + counts are both present, all label-aligned
+    assert "TPM_p90" in summary.columns and "n_detected" in summary.columns
 
 
 def test_genes_matched_by_id_never_by_position():
@@ -165,30 +157,26 @@ def test_genes_matched_by_id_never_by_position():
     a, b = _cohort_a(), _cohort_b()
     a_scrambled = a.loc[["C", "A", "B"]]            # reorder rows
     b_scrambled = b.loc[["D", "A"]]
-    base = PooledCohorts.from_cohorts([a, b]).summary_frame()
-    scram = PooledCohorts.from_cohorts([a_scrambled, b_scrambled]).summary_frame()
+    base = PooledCohorts.from_cohorts([a, b]).summary()
+    scram = PooledCohorts.from_cohorts([a_scrambled, b_scrambled]).summary()
     pd.testing.assert_frame_equal(base, scram)      # identical, by id
-    # and the cohorts disagreeing on a SHARED gene's row position is harmless:
+    # cohorts disagreeing on a SHARED gene's row position is harmless too:
     a2 = a.loc[["B", "C", "A"]]                      # A's gene A now last
-    b2 = b                                           # B's gene A still first
-    pooled = PooledCohorts.from_cohorts([a2, b2]).summary_frame()
-    # gene A pooled over all 5 samples {10,20,30(? no)...} -> same as base
+    pooled = PooledCohorts.from_cohorts([a2, b]).summary()
     assert pooled.loc["A", "TPM_median"] == base.loc["A", "TPM_median"]
 
 
 def test_mask_value_axis_mismatch_is_rejected():
     """A hand-built pool whose mask doesn't share values' gene index/order is
     rejected — you cannot accidentally pair a mask with mis-ordered values."""
-    import pytest
     vals = pd.DataFrame({"s1": [1.0, 2.0]}, index=["A", "B"])
     bad_mask = pd.DataFrame({"s1": [True, True]}, index=["B", "A"])  # reordered
     with pytest.raises(ValueError, match="gene index mismatch"):
         PooledCohorts(vals, bad_mask)
 
 
-def test_centralized_helpers_agree_with_functional_frontdoor():
-    pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
+def test_functional_frontdoor_matches_class():
     am, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])
+    pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])
     pd.testing.assert_frame_equal(am, pool.analysis_matrix)
-    for key, arr in pool.summary().items():
-        assert np.allclose(summary[key], arr, equal_nan=True)
+    pd.testing.assert_frame_equal(summary, pool.summary())


### PR DESCRIPTION
Answers *is there a way to make this safe?* — the residual rule was 'bare-array `summary()` must be zipped against `gene_index`.' Now there is **no position-only output at all**:

- `counts()`, `stats()`, `summary()` all return **gene-indexed DataFrames** (were dicts of bare `np.ndarray`); `summary()` = stats + counts.
- dropped `summary_frame()` (folded into `summary()`); `gene_index` property kept.
- `pool_cohort_samples()` returns `(analysis_matrix, summary)` as two gene-indexed DataFrames.

Every per-gene result carries its Ensembl index, so identity is by **label**, never row position — it can't be mis-paired with a foreign gene list. `compute_cohort_stats` (the low-level builder primitive) is unchanged (still arrays); only the high-level `PooledCohorts` API is frames. 543 pass.