### PR TITLE
Fix #401: MENINGIOMA SSTR2 / 177Lu-DOTATATE empty treatment_path_tier

### DIFF
--- a/pirlygenes/data/cancer-key-genes.csv
+++ b/pirlygenes/data/cancer-key-genes.csv
@@ -847,6 +847,6 @@ ALCL,ALK-positive,ALK,target,crizotinib,ALK-inhibitor,phase_2,investigational_bi
 MENINGIOMA,,NF2,biomarker,,,,,,,,Most common driver (22q/NF2 loss); sporadic and NF2-syndrome meningiomas,
 MENINGIOMA,,SSTR2,biomarker,,,,,,,,Somatostatin receptor 2 — near-universal; basis of 68Ga-DOTATATE PET imaging,
 MENINGIOMA,,PGR,biomarker,,,,,,,,Progesterone receptor — expressed in most grade I; prognostic,
-MENINGIOMA,,SSTR2,target,177Lu-DOTATATE,radioligand,emerging,,,,progressive/refractory meningioma,SSTR2-directed peptide receptor radionuclide therapy — emerging for surgery/RT-refractory disease,
+MENINGIOMA,,SSTR2,target,177Lu-DOTATATE,radioligand,phase_2,investigational_biomarker_matched,later_line_or_investigational,confirm SSTR2 expression (DOTATATE-PET-avid),progressive/refractory meningioma,SSTR2-directed peptide receptor radionuclide therapy — investigational for surgery/RT-refractory disease,
 CHOROID_PLEXUS,,TP53,biomarker,,,,,,,,TP53 mutation — strong Li-Fraumeni association in choroid plexus carcinoma; prompts germline testing,
 CHOROID_PLEXUS,,TTR,biomarker,,,,,,,,Transthyretin — definitive choroid-plexus differentiation marker (diagnostic IHC),

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.53"
+__version__ = "5.22.54"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Closes #401. The only `phase=emerging` row in `cancer-key-genes.csv` had an empty `treatment_path_tier` (+ `line_of_therapy`, `eligibility_note`), breaking trufflepig's phase↔tier and structured-tier contracts.

177Lu-DOTATATE PRRT for meningioma is in phase-2 trials and selected by SSTR2 / 68Ga-DOTATATE-PET avidity:
- `phase`: `emerging` → `phase_2` (`emerging` was a one-off; `phase_2` is the real stage + a recognized vocabulary term)
- `treatment_path_tier`: `investigational_biomarker_matched`
- `line_of_therapy`: `later_line_or_investigational`
- `eligibility_note`: `confirm SSTR2 expression (DOTATATE-PET-avid)`

matching the other `investigational_biomarker_matched` rows (GBC/CRANIO/ALCL). Clears the trufflepig `('MENINGIOMA','SSTR2')` quarantine. 543 tests pass.