### PR TITLE
Heterogeneity-safe pooling: read-time accessor pool + per-cohort availability

### DIFF
--- a/pirlygenes/expression/accessors.py
+++ b/pirlygenes/expression/accessors.py
@@ -1003,6 +1003,45 @@ def heme_tumor_up_vs_matched_normal(cancer_code: str | None = None) -> pd.DataFr
     )
 
 
+def _pool_union_rows(long: pd.DataFrame, *,
+                     include_provenance: bool) -> pd.DataFrame:
+    """Collapse per-(gene, cancer_code, source_cohort) union rows to one
+    heterogeneity-safe pooled row per (gene, cancer_code, normalization).
+
+    Per-gene availability: only source-cohort rows with a non-NaN ``expression``
+    (a cohort that measured the gene) are pooled; the central value is
+    ``n_samples``-weighted and the pooled ``n_samples`` is the summed
+    measuring-cohort sample count. ``q1``/``q3`` -> ``NaN`` (quantiles aren't
+    recombinable from summaries). Vectorised (no per-group Python) so it is cheap
+    even on the full union.
+    """
+    keys = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "normalization"]
+    w = long["n_samples"].where(long["expression"].notna()) \
+        if "n_samples" in long.columns else long["expression"].notna().astype(float)
+    tmp = long.assign(_w=w, _wx=w * long["expression"])
+    agg_spec = {"_wx": ("_wx", "sum"), "_w": ("_w", "sum")}
+    if "n_detected" in long.columns:
+        # samples detecting the gene, summed over measuring cohorts
+        agg_spec["n_detected"] = ("n_detected", "sum")
+    g = tmp.groupby(keys, as_index=False, sort=False).agg(**agg_spec)
+    g["expression"] = g["_wx"] / g["_w"].replace(0, np.nan)
+    g["n_samples"] = g["_w"]
+    g["q1"] = np.nan
+    g["q3"] = np.nan
+    g["source_cohort"] = "POOLED"
+    out_cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "source_cohort"]
+    if include_provenance:
+        if "n_samples" in long.columns:
+            out_cols.append("n_samples")
+        if "n_detected" in g.columns:
+            out_cols.append("n_detected")
+        g["processing_pipeline"] = "pooled_n_weighted"
+        g["source_project"] = "pooled"
+        out_cols += ["source_project", "processing_pipeline"]
+    out_cols += ["normalization", "expression", "q1", "q3"]
+    return g[[c for c in out_cols if c in g.columns]]
+
+
 def cancer_reference_expression(
     cancer_types: Optional[str | Iterable[str]] = None,
     genes: Optional[Iterable[str]] = None,
@@ -1014,6 +1053,7 @@ def cancer_reference_expression(
     source_kind: Optional[str | Iterable[str]] = None,
     source_cohort: Optional[str | Iterable[str]] = None,
     collapse_protein_identical: bool = False,
+    pool: bool = False,
 ) -> pd.DataFrame:
     """Source-agnostic packaged tumor expression references.
 
@@ -1088,6 +1128,33 @@ def cancer_reference_expression(
         aren't under-counted. Off by default (preserves the per-locus rows and
         the shipped reference semantics). See
         :func:`pirlygenes.expression.protein_groups.collapse_protein_identical_loci_long`.
+    pool
+        When ``True``, collapse the ``all:``-union's per-(gene, cancer_code,
+        source_cohort) rows into **one heterogeneity-safe pooled row per (gene,
+        cancer_code)**. Each gene is pooled over **only the source cohorts that
+        measured it** (per-gene availability — a cohort missing the gene is
+        excluded, not treated as 0), with the per-cohort value **n_samples
+        -weighted**. ``source_cohort`` becomes ``"POOLED"`` and the pooled
+        ``n_samples`` is the summed sample count of the cohorts that measured the
+        gene.
+
+        Granularity caveat: at summary level per-gene availability is **binary at
+        cohort grain** — a cohort either carries the gene (a row) or not. The
+        reference ``n_samples`` is a cohort-wide constant, not per-gene, so the
+        pooled ``n_samples`` is "samples in cohorts that measured the gene", NOT
+        a dropout-aware per-(gene, sample) ``n_available`` (that requires the
+        per-sample matrices — :class:`pirlygenes.expression.stats.PooledCohorts`
+        at build time, where ``n_available`` is computed properly).
+
+        This is the read-time, summary-level analogue of ``PooledCohorts``. The
+        n-weighting is **exact for a mean** central value and an **approximation
+        for a median** (quantiles cannot be recombined from per-cohort summaries
+        — ``q1``/``q3`` are returned ``NaN``; for exact pooled quantiles use the
+        per-sample ``PooledCohorts`` path). Only ~7 codes are multi-source today,
+        so this is a no-op (one row in → one row out) for the rest. **Pool within
+        a pipeline-homogeneous set** — pooling absolute TPM across microarray
+        -proxy and RNA-seq members is not magnitude-comparable (pass
+        ``exclude_microarray_proxy=True`` first).
 
     Returns
     -------
@@ -1164,6 +1231,9 @@ def cancer_reference_expression(
             sum_cols=["expression", "q1", "q3"],
             max_cols=("n_detected",),
         )
+
+    if pool:
+        long = _pool_union_rows(long, include_provenance=include_provenance)
 
     if format == "long":
         return long

--- a/pirlygenes/expression/stats.py
+++ b/pirlygenes/expression/stats.py
@@ -33,8 +33,9 @@ are the canonical column-name tuples for schema work.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Iterable, Literal
+from typing import Iterable, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -248,16 +249,27 @@ class PooledCohorts:
     and are **never filled** (missing != zero). Every pooled operation routes
     through this object (``analysis_matrix`` / :meth:`counts` / :meth:`stats` /
     :meth:`summary`) so the availability semantics live in exactly one place.
+
+    When built from **labelled** cohorts (a ``{name: matrix}`` mapping), the
+    optional ``sample_cohort`` (sample-column -> cohort name) unlocks the
+    per-cohort availability accounting needed to pool correctly:
+    :attr:`cohort_measured` (``is_measured[gene, cohort]``),
+    :attr:`n_measured_genes` (per cohort), and :attr:`n_measured_samples`
+    (``[gene, cohort]`` observed-sample count — the weight for a per-gene mean).
     """
 
     values: pd.DataFrame
     measured: pd.DataFrame
+    sample_cohort: Optional[pd.Series] = None
 
     def __post_init__(self) -> None:
         # The mask can only be trusted if it shares the EXACT gene index and
         # sample columns of values, by label. This forbids ever pairing a mask
         # with a value matrix whose rows/cols are in a different order (the
         # "matched by position, not id" bug the whole design exists to avoid).
+        if (self.sample_cohort is not None and len(self.values.columns)
+                and not self.values.columns.equals(self.sample_cohort.index)):
+            raise ValueError("sample_cohort index must match values columns")
         if not self.values.index.equals(self.measured.index):
             raise ValueError("values/measured gene index mismatch (must be "
                              "identical and identically ordered, by id)")
@@ -265,8 +277,12 @@ class PooledCohorts:
             raise ValueError("values/measured sample columns mismatch")
 
     @classmethod
-    def from_cohorts(cls, matrices: Iterable[pd.DataFrame]) -> "PooledCohorts":
+    def from_cohorts(cls, matrices) -> "PooledCohorts":
         """Build the pool from ``(n_genes, n_samples)`` per-cohort matrices.
+
+        ``matrices`` is either an iterable of matrices (cohorts auto-labelled
+        ``cohort_0``, ``cohort_1``, …) or a ``{cohort_name: matrix}`` mapping
+        (labels preserved — pass this to use the per-cohort availability views).
 
         Each matrix's index is its **row mask** (the genes that cohort measures)
         and its columns are its **column mask** (that cohort's samples); the
@@ -282,10 +298,16 @@ class PooledCohorts:
         deterministic order keeps any persisted pooled artifact diff-stable.
         Sample **columns stay in input order** (grouped by cohort).
         """
-        mats = [m for m in matrices if m is not None and m.shape[1] > 0]
-        if not mats:
+        if isinstance(matrices, Mapping):
+            items = [(str(n), m) for n, m in matrices.items()
+                     if m is not None and m.shape[1] > 0]
+        else:
+            items = [(f"cohort_{i}", m) for i, m in enumerate(matrices)
+                     if m is not None and m.shape[1] > 0]
+        if not items:
             empty = pd.DataFrame()
-            return cls(empty, empty.copy())
+            return cls(empty, empty.copy(), None)
+        mats = [m for _, m in items]
         values = pd.concat(mats, axis=1, join="outer").sort_index()
         # Each block is all-True over its cohort's genes x samples; after an
         # outer join, a cell is present (True) iff some cohort covers it and NaN
@@ -298,7 +320,11 @@ class PooledCohorts:
             .reindex(index=values.index, columns=values.columns)
             .notna()
         )
-        return cls(values, measured)
+        sample_cohort = pd.Series(
+            {col: name for name, m in items for col in m.columns},
+        ).reindex(values.columns)
+        sample_cohort.name = "cohort"
+        return cls(values, measured, sample_cohort)
 
     @property
     def analysis_matrix(self) -> pd.DataFrame:
@@ -320,6 +346,35 @@ class PooledCohorts:
     def gene_index(self) -> pd.Index:
         """The authoritative gene-id (Ensembl) index every result is keyed by."""
         return self.values.index
+
+    def _require_cohorts(self) -> pd.Series:
+        if self.sample_cohort is None:
+            raise ValueError("per-cohort availability needs labelled cohorts — "
+                             "build with PooledCohorts.from_cohorts({name: matrix})")
+        return self.sample_cohort
+
+    @property
+    def cohort_measured(self) -> pd.DataFrame:
+        """``is_measured[gene, cohort]`` — gene x cohort bool, ``True`` where that
+        cohort's panel carries the gene (membership; independent of dropouts)."""
+        sc = self._require_cohorts()
+        return self.measured.T.groupby(sc, sort=False).any().T
+
+    @property
+    def n_measured_genes(self) -> pd.Series:
+        """``n_measured_genes[cohort]`` — how many genes each cohort measures."""
+        return self.cohort_measured.sum(axis=0)
+
+    @property
+    def n_measured_samples(self) -> pd.DataFrame:
+        """``n_measured_samples[gene, cohort]`` — the count of each cohort's
+        samples that **observed** the gene (non-``NaN`` after masking). This is
+        the correct per-cohort, per-gene weight for combining means: a cohort's
+        contribution to a gene's pooled mean is weighted by how many of its
+        samples actually carried a value for that gene (dropout-aware)."""
+        sc = self._require_cohorts()
+        observed = self.analysis_matrix.notna()
+        return observed.T.groupby(sc, sort=False).sum().T
 
     def counts(self) -> pd.DataFrame:
         """Gene-indexed ``{n_samples, n_available, n_detected}`` (see

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.57"
+__version__ = "5.22.58"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_pool_cohort_samples.py
+++ b/tests/test_pool_cohort_samples.py
@@ -175,6 +175,30 @@ def test_mask_value_axis_mismatch_is_rejected():
         PooledCohorts(vals, bad_mask)
 
 
+def test_per_cohort_availability_views():
+    """Labelled cohorts expose is_measured[gene,cohort], n_measured_genes, and
+    n_measured_samples (observed, dropout-aware) for correct per-gene weighting."""
+    A = pd.DataFrame({"a1": [10., 100., 0.], "a2": [20., np.nan, 5.],
+                      "a3": [30., 300., 0.]}, index=["A", "B", "C"])
+    B = pd.DataFrame({"b1": [40., 7.], "b2": [50., 9.]}, index=["A", "D"])
+    pool = PooledCohorts.from_cohorts({"cohortA": A, "cohortB": B})
+    cm = pool.cohort_measured
+    assert cm.loc["A", "cohortA"] and cm.loc["A", "cohortB"]        # in both
+    assert cm.loc["B", "cohortA"] and not cm.loc["B", "cohortB"]    # A only
+    assert cm.loc["D", "cohortB"] and not cm.loc["D", "cohortA"]    # B only
+    assert pool.n_measured_genes.to_dict() == {"cohortA": 3, "cohortB": 2}
+    nms = pool.n_measured_samples
+    assert nms.loc["A", "cohortA"] == 3 and nms.loc["A", "cohortB"] == 2
+    assert nms.loc["B", "cohortA"] == 2   # membership True but 1 sample dropped out
+    assert nms.loc["C", "cohortB"] == 0   # cohortB never measured C
+
+
+def test_per_cohort_views_require_labels():
+    pool = PooledCohorts.from_cohorts([_cohort_a()])   # iterable -> auto-labelled
+    assert pool.sample_cohort is not None               # auto-labelled cohort_0
+    assert list(pool.n_measured_genes.index) == ["cohort_0"]
+
+
 def test_functional_frontdoor_matches_class():
     am, summary = pool_cohort_samples([_cohort_a(), _cohort_b()])
     pool = PooledCohorts.from_cohorts([_cohort_a(), _cohort_b()])

--- a/tests/test_reference_union_heterogeneity.py
+++ b/tests/test_reference_union_heterogeneity.py
@@ -63,3 +63,41 @@ def test_tcga_selects_as_treehouse_not_a_fake_kind():
         cancer_types="SARC", genes=["TP53"],
         source_cohort="TREEHOUSE_POLYA_25_01_TCGA_SUBSET")
     assert set(sub["source_cohort"].unique()) == {"TREEHOUSE_POLYA_25_01_TCGA_SUBSET"}
+
+
+def test_pool_collapses_multisource_n_weighted_per_gene_availability():
+    """pool=True collapses a multi-source code's per-cohort rows into one
+    n-weighted pooled row per gene, pooling only the cohorts that measured the
+    gene (per-gene availability)."""
+    base = cancer_reference_expression(cancer_types="NUTM", normalize="tpm")
+    pooled = cancer_reference_expression(cancer_types="NUTM", normalize="tpm",
+                                         pool=True)
+    assert base["source_cohort"].nunique() > 1            # genuinely multi-source
+    assert pooled.groupby("Ensembl_Gene_ID").size().max() == 1   # one row per gene
+    assert (pooled["source_cohort"] == "POOLED").all()
+    assert pooled["q1"].isna().all() and pooled["q3"].isna().all()  # quantiles dropped
+
+    # a gene measured in BOTH cohorts: n_samples-weighted mean of per-cohort values
+    avail = base.dropna(subset=["expression"])
+    both = avail.groupby("Symbol")["source_cohort"].nunique()
+    sym = both[both == 2].index[0]
+    rows = base[base["Symbol"] == sym]
+    w = rows["n_samples"]
+    expect = (w * rows["expression"]).sum() / w.sum()
+    got = pooled.loc[pooled["Symbol"] == sym, "expression"].iloc[0]
+    assert abs(got - expect) < 1e-6
+    # pooled n_samples = summed sample count of the measuring cohorts
+    assert pooled.loc[pooled["Symbol"] == sym, "n_samples"].iloc[0] == w.sum()
+
+
+def test_pool_is_noop_for_single_source_code():
+    base = cancer_reference_expression(cancer_types="SKCM", normalize="tpm",
+                                       genes=["TP53", "MLANA"])
+    pooled = cancer_reference_expression(cancer_types="SKCM", normalize="tpm",
+                                         genes=["TP53", "MLANA"], pool=True)
+    # single source -> same gene count, values unchanged (just relabelled POOLED)
+    assert len(pooled) == base["Ensembl_Gene_ID"].nunique()
+    for sym in ["TP53", "MLANA"]:
+        b = base.loc[base["Symbol"] == sym, "expression"].iloc[0]
+        p = pooled.loc[pooled["Symbol"] == sym, "expression"].iloc[0]
+        assert abs(b - p) < 1e-6


### PR DESCRIPTION
Cross-cohort-mixing increment (#366 remainder / task #12) — wires the `PooledCohorts` primitive to real data and adds the availability accounting needed to pool correctly.

## 1. `cancer_reference_expression(pool=True)`
Collapses the `all:`-union's per-(gene, cancer_code, source_cohort) rows into **one heterogeneity-safe pooled row per (gene, cancer_code)**:
- each gene pools over **only the cohorts that measured it** (per-gene availability, missing≠0), **n_samples-weighted**;
- pooled `n_samples` = summed measuring-cohort samples; `source_cohort='POOLED'`;
- `q1`/`q3` → `NaN` (quantiles can't be recombined from summaries — exact pooled quantiles need the per-sample `PooledCohorts` path).

Vectorised; a no-op for the ~112 single-source codes. Documented honestly: n-weighting is **exact for a mean, approximate for a median**; pool within a pipeline-homogeneous set (`exclude_microarray_proxy=True` first); and — per the "is n_samples per-gene?" check — the reference `n_samples` is **cohort-wide, not per-gene**, so the pooled `n` is *"samples in cohorts that measured the gene"*, not a dropout-aware per-(gene,sample) `n_available`.

## 2. `PooledCohorts` per-cohort availability views
Now accepts labelled cohorts (`{name: matrix}`) and exposes exactly what was asked for:
- **`cohort_measured`** — `is_measured[gene, cohort]` (membership bool)
- **`n_measured_genes[cohort]`** — gene-universe size per cohort
- **`n_measured_samples[gene, cohort]`** — observed (non-NaN, **dropout-aware**) sample count per cohort per gene — the correct weight for per-gene means

Iterable input still works (auto-labelled `cohort_0`…); `sample_cohort` is a new optional field with axis-consistency validation. (Verified: a membership-True gene with one dropped sample shows `is_measured=True` but `n_measured_samples=2`.)

4 new tests; 556 pass. The exact per-sample build-time pool (persisting `n_available` to the bundle) + ragged medoid/percentile remain follow-ups.