### PR TITLE
Plotting sanity pass: honest in-sample labels + consistent composite z-scoring

### DIFF
--- a/analyses/apd1_causal_factors.py
+++ b/analyses/apd1_causal_factors.py
@@ -77,11 +77,16 @@ def main() -> int:
     F["CTA"] = cta_burden(mat)
     F["viral"] = [viral_score(c, reg) for c in mat.index]
     F["indel"] = [with_parent(indel, c, 0.0) for c in mat.index]
-    F["exclusion"] = mat[excl_genes].apply(_z).mean(axis=1)
-    F = F.dropna(subset=["logTMB", "CTA", "exclusion"])
+    # drop cohorts missing a required factor, then z-score BOTH composites over
+    # the SAME final modeled cohort set (so antigen and exclusion share a
+    # reference distribution; previously exclusion was z-scored pre-dropna).
+    has_excl = mat[excl_genes].notna().any(axis=1)
+    F = F.assign(_has_excl=has_excl).dropna(subset=["logTMB", "CTA"])
+    F = F[F["_has_excl"]].drop(columns="_has_excl")
     # The two conceptual axes the user wants kept distinct:
     #   ANTIGEN AVAILABILITY = TMB + CTA + viral + indel (anything to see?)
     #   IMMUNE EXCLUSION     = TGF-beta-response + Wnt  (will a T cell get in?)
+    F["exclusion"] = mat.loc[F.index, excl_genes].apply(_z).mean(axis=1)
     F["antigen"] = F[["logTMB", "CTA", "viral", "indel"]].apply(_z).mean(axis=1)
     print(f"cohorts modeled: {len(F)}\n")
 
@@ -149,8 +154,8 @@ def _plot(F, feats, betas, r2):
     colors = ["#2c7fb8" if b >= 0 else "#d95f0e" for b in betas]
     axA.barh(feats, betas, color=colors)
     axA.axvline(0, color="k", lw=0.8)
-    axA.set_title(f"Standardized drivers of aPD1 ORR\n(OLS R2={r2:.2f}, "
-                  f"n={len(F)})", fontsize=10)
+    axA.set_title(f"Standardized drivers of aPD1 ORR\n(in-sample OLS R2={r2:.2f}, "
+                  f"n={len(F)}; descriptive, no held-out)", fontsize=10)
     axA.set_xlabel("standardized beta (signed)")
     for i, b in enumerate(betas):
         axA.annotate(f"{b:+.2f}", (b, i), fontsize=8,

--- a/analyses/exclusion_vs_apd1.py
+++ b/analyses/exclusion_vs_apd1.py
@@ -314,7 +314,8 @@ def main() -> int:
     for ax, comp_s, title in [
         (axes[0], combined,
          f"curated TGF-beta-response + Wnt ({len(tgfb_response+wnt)} genes)"),
-        (axes[1], comp, f"greedy composite ({len(chosen)} genes)")]:
+        (axes[1], comp, f"greedy composite ({len(chosen)} genes) "
+         "— IN-SAMPLE OPTIMIZED, not predictive")]:
         ok = comp_s.notna()
         x, y = comp_s[ok], orr[ok]
         ax.scatter(x, y, s=28, alpha=0.8)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.58"
+__version__ = "5.22.59"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Sanity-checked every aPD1 plotting script and the plotting logic end-to-end (the requested review).

**No correctness bugs found** — axes, z-scaling (`ddof=0` throughout), `TwoSlopeNorm` centering, NaN-skipping composites, color maps, axis-group separators, and value sourcing (collapse-aware CTA burden, pooled-accessor-ready) all check out. The balance sheet correctly signs antigen +z / exclusion −z and drops circular signatures; the landscape heatmap shows circular signatures as context but excludes them from the model.

Two honesty/robustness fixes:
- **`exclusion_composite_vs_apd1`**: the right panel (greedy composite) is *in-sample optimized* — the greedy forward-selection maximizes that very Spearman on the same cohorts, so its rho (−0.71) is not comparable to the curated panel's (−0.43). Title now reads **'IN-SAMPLE OPTIMIZED, not predictive'** so the two panels aren't mistaken as a fair comparison.
- **`apd1_causal_factors`**: title flags the OLS R² as **in-sample** (no held-out); and the antigen + exclusion composites are now z-scored over the **same final modeled cohort set** (exclusion was previously z-scored pre-`dropna`). Drops 0 cohorts in practice → values unchanged, but removes a latent inconsistency.

Figures regenerated; canonical CSVs unchanged. 556 pass.

Scope note: reviewed the active aPD1 batch (`exclusion_vs_apd1`, `apd1_causal_factors`, `apd1_mechanism_screen`, `apd1_landscape`, `apd1_exclusion_scatters`). The legacy `cta_*` / `apd1_response_plots` scripts are a separate older family, out of scope here.