### PR TITLE
Plot fixes: CRC_MSI pooling + balance-sheet redesign + unified plot driver

### DIFF
--- a/analyses/apd1_landscape.py
+++ b/analyses/apd1_landscape.py
@@ -74,7 +74,7 @@ def _build():
     # curated expression signatures
     for cls, genes in curated_signatures().items():
         present = [g for g in genes if g in mat.columns]
-        if len(present) < 2:
+        if len(present) < 1:        # allow single-gene signatures (TGF-β = TGFB2)
             continue
         axis = SIGNATURE_META[cls][0]
         label = cls.replace("aPD1_", "").replace("exclusion_", "").replace(
@@ -129,29 +129,35 @@ def _balance_sheet(Z, orr, axes_of):
     # only causal antigen/exclusion factors (drop circular)
     feats = [c for c in Z.columns if axes_of[c] in ("antigen", "exclusion")]
     # signed contribution toward response: antigen as +z, exclusion as -z, so a
-    # rightward bar is always FAVOURABLE regardless of factor type.
+    # rightward bar is always FAVOURABLE regardless of factor type. Position
+    # carries the meaning; colour (colourblind-safe blue/orange, NOT red/green)
+    # just tags the factor type, and a dashed marker shows the NET balance.
     sign = {f: (1 if axes_of[f] == "antigen" else -1) for f in feats}
-    fig, axs = plt.subplots(2, 4, figsize=(17, 8), sharex=True)
+    ANTIGEN, EXCLUSION = "#2166ac", "#b35806"   # PuOr blue / orange (CB-safe)
+    fig, axs = plt.subplots(2, 4, figsize=(17, 8.4), sharex=True)
     for ax, code in zip(axs.flat, archetypes):
         contrib = (Z.loc[code, feats] * pd.Series(sign)).sort_values()
-        colors = ["#2ca02c" if axes_of[f] == "antigen" else "#d62728"
+        colors = [ANTIGEN if axes_of[f] == "antigen" else EXCLUSION
                   for f in contrib.index]
         ax.barh(range(len(contrib)), contrib.values, color=colors)
         ax.set_yticks(range(len(contrib)))
         ax.set_yticklabels(contrib.index, fontsize=6)
         ax.axvline(0, color="k", lw=0.7)
-        ax.set_title(f"{code}  (ORR {orr[code]:.0f}%)", fontsize=10)
+        net = float(contrib.sum())
+        ax.axvline(net, color="#222", lw=1.8, ls="--")   # NET balance marker
+        ax.set_title(f"{code}   ORR {orr[code]:.0f}%   net {net:+.1f}",
+                     fontsize=10)
         ax.tick_params(axis="x", labelsize=7)
     for ax in axs.flat[len(archetypes):]:
         ax.axis("off")
-    fig.suptitle("Causal balance sheet per cancer type  -  signed contribution "
-                 "toward response (right = favourable)\n"
-                 "green = antigen availability (TMB/indel/viral/CTA/MHC-I)   "
-                 "red = immune exclusion (TGF-beta/Wnt/angio/adenosine)",
-                 fontsize=12)
-    fig.supxlabel("contribution toward aPD-1 response  "
-                  "(z; antigen as +z, exclusion as -z)", fontsize=10)
-    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.suptitle("Causal balance sheet per cancer type — each factor's signed "
+                 "contribution toward anti-PD-1 response\n"
+                 "blue = antigen availability (TMB/indel/viral/CTA/MHC-I)    "
+                 "orange = immune exclusion (TGF-β/Wnt/angio/adenosine)    "
+                 "dashed = net", fontsize=12)
+    fig.supxlabel("←  less favourable        contribution toward aPD-1 response "
+                  "(z)        more favourable  →", fontsize=10)
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
     fig.savefig(OUT / "apd1_balance_sheet.png", dpi=130)
     plt.close(fig)
 

--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -34,7 +34,24 @@ OUT = Path(__file__).resolve().parent / "outputs"
 FIGDIR = OUT   # per-run output dir; set in main() via _run_layout
 
 # Documented aPD1-differential subtype pairs (immune-hot vs immune-cold).
-_PAIRS = [("COAD_MSI", "COAD_MSS"), ("READ_MSI", "READ_MSS")]
+_PAIRS = [("CRC_MSI", "CRC_MSS")]
+
+# Colorectal pooling: KEYNOTE-177 (and the MSS series) report *colorectal*, so
+# COAD_MSI+READ_MSI are one CRC_MSI point (identical ORR/TMB), not two — mirrors
+# the causal-factors plots' CRC pooling so every aPD1 plot agrees.
+_CRC_POOL = {"COAD_MSI": "CRC_MSI", "READ_MSI": "CRC_MSI",
+             "COAD_MSS": "CRC_MSS", "READ_MSS": "CRC_MSS",
+             "COAD": "CRC", "READ": "CRC"}
+
+
+def _pool_crc(d: dict) -> dict:
+    """Average the colorectal members into their CRC tier (the duplicated
+    COAD/READ values are identical, so the mean is just that value); every other
+    cancer code passes through unchanged."""
+    groups: dict[str, list] = {}
+    for code, val in d.items():
+        groups.setdefault(_CRC_POOL.get(code, code), []).append(val)
+    return {k: sum(v) / len(v) for k, v in groups.items()}
 
 
 @lru_cache(maxsize=1)
@@ -104,8 +121,11 @@ def main() -> int:
     add_layout_args(ap)
     args = ap.parse_args()
     _, FIGDIR = resolve_dirs(args, OUT)
-    orr = gsc.cancer_apd1_response()           # {code: ORR%}
-    tmb = {c: gsc.cancer_tmb(c) for c in orr if gsc.cancer_tmb(c) is not None}
+    orr_raw = gsc.cancer_apd1_response()       # {code: ORR%}
+    tmb_raw = {c: gsc.cancer_tmb(c) for c in orr_raw
+               if gsc.cancer_tmb(c) is not None}
+    orr = _pool_crc(orr_raw)                   # COAD/READ MSI+MSS -> CRC tiers
+    tmb = _pool_crc(tmb_raw)
     colors = _color_map(orr)
     n = _plot_tmb_vs_apd1(orr, tmb, colors)
     _plot_orr_bars(orr, colors)

--- a/analyses/regenerate_plots.py
+++ b/analyses/regenerate_plots.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Regenerate **all** analyses plots into ONE timestamped run dir, organised by
+plot family in subfolders:
+
+    analyses/outputs/run_<YYYYMMDD-HHMMSS>/
+        apd1_causal_model/          aggregate aPD1 causal-factor figures
+            cta_vs_apd1_by_exclusion/
+        apd1_response/              ORR bars, ORR-vs-TMB
+        cta_<metric>_vs_<axis>/     CTA burden vs TMB / aPD1 / incidence / mortality
+        cta_addressable/  cta_covering_set/  cta_expression_heatmaps/
+        ...
+
+This replaces the old per-script ``outputs/apd1_causal_factors/run_*`` layout
+(which buried five scripts' output under one script's name) — every family now
+lands in the same timestamped run dir.
+
+    python analyses/regenerate_plots.py
+
+Scripts that fail are reported but don't abort the batch.
+"""
+from __future__ import annotations
+
+import datetime
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+OUTPUTS = HERE / "outputs"
+
+# aPD1 causal-factor batch — driven by the APD1_RUN_DIR env var, all into one
+# subfolder of the run (they already group cta_vs_apd1_by_exclusion/ themselves).
+APD1_BATCH = ["exclusion_vs_apd1", "apd1_causal_factors", "apd1_mechanism_screen",
+              "apd1_landscape", "apd1_exclusion_scatters"]
+
+# argparse + _run_layout scripts. (script, extra_args, target):
+#   target "groups" -> writes its own family subdirs straight under the run dir
+#   target "<name>" -> a flat-writing script gets its own named subdir
+LAYOUT = [
+    ("cta_patient_counts", [], "groups"),
+    ("cta_addressable_burden", [], "cta_addressable"),
+    ("cta_covering_set", [], "cta_covering_set"),
+    ("cta_expression_heatmaps", [], "cta_expression_heatmaps"),
+    ("apd1_response_plots", [], "apd1_response"),
+]
+
+
+def _run(cmd, env=None):
+    return subprocess.run(cmd, cwd=HERE, env=env).returncode == 0
+
+
+def main() -> int:
+    ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    run = OUTPUTS / f"run_{ts}"
+    run.mkdir(parents=True, exist_ok=True)
+    ok, failed = [], []
+
+    print(f"regenerating all plots -> {run}\n")
+    env = {**os.environ, "APD1_RUN_DIR": str(run / "apd1_causal_model")}
+    for s in APD1_BATCH:
+        print(f"  apd1_causal_model: {s} ...", flush=True)
+        (ok if _run([sys.executable, f"{s}.py"], env=env) else failed).append(s)
+
+    for s, extra, target in LAYOUT:
+        print(f"  {target}: {s} ...", flush=True)
+        if target == "groups":          # writes its own group subdirs under run/
+            args = ["--out-dir", str(run), "--no-timestamp"]
+        else:                           # flat-writing -> its own named subdir
+            args = ["--out-dir", str(run), "--run-name", target]
+        (ok if _run([sys.executable, f"{s}.py", *args, *extra]) else failed).append(s)
+
+    pngs = sorted(run.rglob("*.png"))
+    print(f"\nrun -> {run}")
+    print(f"  {len(pngs)} PNGs across {len({p.parent for p in pngs})} subfolders")
+    print(f"  ok: {ok}")
+    if failed:
+        print(f"  FAILED: {failed}")
+    for d in sorted({p.parent.relative_to(run) for p in pngs}):
+        print(f"    {d}/")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.60"
+__version__ = "5.22.61"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Addresses the plot-review feedback.

- **CRC_MSI pooling** (`apd1_response_plots`): COAD/READ MSI+MSS pool to CRC_MSI/CRC_MSS — KEYNOTE-177 etc. report *colorectal*, so the identical COAD_MSI+READ_MSI become one point (matching the causal-factors plots). 36→33 cancers.
- **Balance-sheet redesign** (`apd1_landscape`): red/green → colourblind-safe **blue=antigen / orange=exclusion**; position carries favourability (`← less | more →`); added a dashed **net-score** marker + net in each title.
- **Show TGF-β**: the landscape/balance-sheet skipped signatures with <2 genes, silently dropping `TGFb_response` (=TGFB2). Now single-gene signatures are allowed, so TGF-β appears.
- **Unified plot driver** (`regenerate_plots.py`): one `outputs/run_<ts>/` with every family in its own subdir (`apd1_causal_model/`, `apd1_response/`, `cta_*_vs_tmb/` …), replacing the buried `outputs/apd1_causal_factors/` layout.

558 pass. Queued next (per discussion): cDNA-identity global proteoform collapse + CT47A override (drop ≥90%); CTA-burden = %patients ≥95th within-sample pctile with collapse-before-percentile + CRC pooling in the CTA coverage plots; curate sarcoma/NUTM/ATRT aPD1 ORR.