### PR TITLE
CTA coverage pipeline: cDNA-identical collapse (consistency with #417)

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -418,21 +418,26 @@ def _add_aggregate_cohorts(cohorts):
 
 
 def _merge_proteins(mat, ensg_to_sym):
-    """Collapse near-identical CTA paralogs (>=90% AA identity, + curated
-    NY-ESO-1 / XAGE1) into one protein per group, SUMMING per-sample TPM (total
-    expression of that protein — RNA-seq can't disambiguate identical paralogs,
-    and one TCR/antibody/vaccine addresses the group). Returns the merged matrix
-    indexed by protein name + an identity {name: name} display map."""
-    from pirlygenes.load_dataset import get_data
-    grp = get_data("cta-protein-groups")
-    group_of = dict(zip(grp["member_symbol"].astype(str),
-                        grp["protein_group"].astype(str)))
-    row_protein = [group_of.get(s, s)
-                   for s in (ensg_to_sym.get(e, e) for e in mat.index)]
-    merged = mat.groupby(pd.Index(row_protein, name="protein")).sum()
-    print(f"      merged {len(mat) - len(merged)} paralog rows into protein "
-          f"groups -> {len(merged)} proteins", flush=True)
-    return merged, {name: name for name in merged.index}
+    """Collapse **cDNA-identical** loci (byte-identical canonical CDS, + the
+    curated overrides such as CT47A) into one entry per group, SUMMING per-sample
+    TPM — the universal read-recovery collapse (a quantifier can't disambiguate
+    identical-CDS paralogs, so each is split and only the sum is reliable). This
+    is the SAME collapse the reference accessor uses (``collapse_cdna_identical``,
+    pirlygenes #417), so the per-sample and cohort-summary pipelines agree. NOT a
+    >=90% near-identical rollup — distinct proteins (MAGEA3 vs MAGEA6) stay
+    separate. Returns the merged matrix (canonical-Ensembl-indexed) + a
+    ``{ensg: symbol}`` display map."""
+    from pirlygenes.expression.protein_groups import (cdna_canonical_to_symbol,
+                                                      cdna_member_to_canonical)
+    m2c = cdna_member_to_canonical()
+    c2s = cdna_canonical_to_symbol()
+    row_canon = [m2c.get(str(e).split(".")[0], str(e).split(".")[0])
+                 for e in mat.index]
+    merged = mat.groupby(pd.Index(row_canon, name="gene")).sum()
+    print(f"      merged {len(mat) - len(merged)} cDNA-identical rows -> "
+          f"{len(merged)} genes", flush=True)
+    display = {e: c2s.get(e, ensg_to_sym.get(e, e)) for e in merged.index}
+    return merged, display
 
 
 def per_cohort_counts(mat, cohorts, ensg_to_sym, pctile_cutoffs=None):

--- a/pirlygenes/expression/protein_groups.py
+++ b/pirlygenes/expression/protein_groups.py
@@ -275,6 +275,19 @@ def fold_to_cdna_canonical_symbol(symbols) -> list[str]:
     return out
 
 
+def cdna_member_to_canonical() -> dict[str, str]:
+    """Public ``{member_ensg: canonical_ensg}`` for the cDNA-identical collapse
+    (+ curated overrides) — for consumers that collapse an ENSG-indexed matrix
+    directly (e.g. per-sample CTA matrices)."""
+    return dict(_cdna_member_to_canonical())
+
+
+def cdna_canonical_to_symbol() -> dict[str, str]:
+    """Public ``{canonical_ensg: canonical_symbol}`` companion to
+    :func:`cdna_member_to_canonical`."""
+    return dict(_cdna_canonical_to_symbol())
+
+
 def collapse_cdna_identical_loci_long(
     df: pd.DataFrame,
     *,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.62"
+__version__ = "5.22.63"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
First slice of #21. `cta_patient_counts._merge_proteins` collapsed CTA paralogs with the ≥90% `cta-protein-groups`; switched it to the **cDNA-identical (+override)** collapse so the per-sample coverage pipeline and the reference-summary pipeline use the *same* collapse (#417). cDNA-distinct paralogs (MAGEA3 vs MAGEA6) now stay separate here too; CT47A unifies via the override. Merged matrix keyed by canonical Ensembl id + real symbol. Public `cdna_member_to_canonical`/`cdna_canonical_to_symbol` accessors added.

Verified on a synthetic CTA matrix (6→4: NY-ESO→1, MAGEA3/6 separate, CT47A→1). 558 pass.

**Remaining #21** (the substantive per-sample-pipeline pieces): collapse the percentile-*reference* universe so XAGE1 isn't ranked against XAGE1A/B in the within-sample percentile; CRC_MSI/CRC_MSS pooling in the coverage cohorts (answers 'no CRC_MSI in the CTA-vs-TMB plot'); and making the aPD1 `cta_burden` the %-patients-≥95th-percentile metric.