### PR TITLE
CTA percentile universe: collapse cDNA-identical loci before ranking (#21.1)

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -166,27 +166,51 @@ def per_sample_percentile_cutoffs(percentiles=PERCENTILES, *, nbins=2000,
     """Per-sample TPM value at each within-sample percentile, computed over ALL
     genes in the compendium (not just CTAs) so a CTA's rank is relative to the
     whole transcriptome. Memory-bounded histogram pass over the full
-    log2(TPM+1) TSV (+ the linear-TPM parquet cohorts); cached to
-    ``outputs/_per_sample_pctile_cutoffs.parquet`` (keyed on TSV mtime)."""
-    cachef = CACHE / "_per_sample_pctile_cutoffs.parquet"
+    log2(TPM+1) TSV (+ the linear-TPM parquet cohorts); cached.
+
+    cDNA-identical loci are **collapsed (summed) into one entry before ranking**,
+    so the ranking universe holds one XAGE1 (=XAGE1A+XAGE1B), not the individual
+    members — otherwise a collapsed CTA would be ranked against a universe that
+    still contains its own components (#21)."""
+    cachef = CACHE / "_per_sample_pctile_cutoffs_v2.parquet"   # v2: cDNA-collapsed
     if (cache and cachef.exists()
             and cachef.stat().st_mtime >= TPM_TSV.stat().st_mtime):
         return pd.read_parquet(cachef)
+    from pirlygenes.expression.protein_groups import (
+        cdna_symbol_to_canonical_symbol)
+    sym2canon = {k.upper(): v for k, v in cdna_symbol_to_canonical_symbol().items()}
 
     edges = np.linspace(0.0, vmax_log2, nbins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     hist = None
     cols = None
+    accum: dict[str, np.ndarray] = {}      # canonical symbol -> per-sample LINEAR sum
     for chunk in pd.read_csv(TPM_TSV, sep="\t", chunksize=4000):
+        genes = chunk.iloc[:, 0].astype(str).str.upper()
         vals = chunk.iloc[:, 1:]
         if cols is None:
             cols = list(vals.columns)
             hist = np.zeros((len(cols), nbins), dtype=np.int64)
-        arr = vals.to_numpy(dtype=np.float32)            # genes(chunk) × samples
-        idx = np.clip(np.searchsorted(edges, arr, side="right") - 1, 0, nbins - 1)
-        # accumulate per-sample histograms: add 1 per (sample, bin) occurrence
-        for j in range(idx.shape[1]):
-            hist[j] += np.bincount(idx[:, j], minlength=nbins)
+        arr = vals.to_numpy(dtype=np.float32)            # genes(chunk) × samples (log2)
+        canon = genes.map(sym2canon)                     # canonical symbol or NaN
+        member = canon.notna().to_numpy()
+        # histogram the genes that are NOT in a cDNA-identical group, as-is
+        if (~member).any():
+            nm_idx = np.clip(np.searchsorted(edges, arr[~member], side="right") - 1,
+                             0, nbins - 1)
+            for j in range(nm_idx.shape[1]):
+                hist[j] += np.bincount(nm_idx[:, j], minlength=nbins)
+        # accumulate group members (linear) into their canonical's per-sample sum
+        if member.any():
+            lin = np.power(2.0, arr[member].astype(np.float64)) - 1.0
+            for gi, cs in enumerate(canon[member].to_numpy()):
+                accum.setdefault(cs, np.zeros(len(cols)))
+                accum[cs] += lin[gi]
+    # each collapsed group contributes ONE entry per sample (its summed value)
+    for linsum in accum.values():
+        log2v = np.log2(linsum + 1.0)
+        bins_c = np.clip(np.searchsorted(edges, log2v, side="right") - 1, 0, nbins - 1)
+        hist[np.arange(len(cols)), bins_c] += 1
 
     cum = np.cumsum(hist, axis=1)
     total = cum[:, -1].astype(float)
@@ -207,7 +231,10 @@ def per_sample_percentile_cutoffs(percentiles=PERCENTILES, *, nbins=2000,
         pf = pd.read_parquet(p)
         sample_cols = [c for c in pf.columns
                        if c not in ("Ensembl_Gene_ID", "Symbol")]
-        m = pf[sample_cols].to_numpy(dtype=float)
+        # collapse cDNA-identical loci (sum) before ranking, same as the TSV pass
+        canon = pf["Symbol"].astype(str).str.upper().map(sym2canon)
+        pf = pf.assign(_g=canon.fillna(pf["Symbol"].astype(str)))
+        m = pf.groupby("_g")[sample_cols].sum().to_numpy(dtype=float)
         rec = {}
         for col, vec in zip(sample_cols, m.T):
             rec[col] = {f"p{q}": float(np.percentile(vec, q)) for q in percentiles}

--- a/pirlygenes/expression/protein_groups.py
+++ b/pirlygenes/expression/protein_groups.py
@@ -288,6 +288,13 @@ def cdna_canonical_to_symbol() -> dict[str, str]:
     return dict(_cdna_canonical_to_symbol())
 
 
+def cdna_symbol_to_canonical_symbol() -> dict[str, str]:
+    """Public ``{member_symbol_upper: canonical_symbol}`` for collapsing a
+    **symbol**-keyed matrix (e.g. the percentile-reference transcriptome TSV) so
+    a cDNA-identical group is one entry in the ranking universe."""
+    return dict(_cdna_symbol_to_canonical_symbol())
+
+
 def collapse_cdna_identical_loci_long(
     df: pd.DataFrame,
     *,

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.63"
+__version__ = "5.22.64"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Your correctness rule: *after proteoform collapse, the individual gene IDs should not be part of the percentile calculation — don't rank XAGE1 against a set that includes XAGE1A and XAGE1B.*

`per_sample_percentile_cutoffs` computed the within-sample percentile over the **uncollapsed** transcriptome, so a collapsed CTA (XAGE1 = XAGE1A+XAGE1B summed) was ranked against a universe that still held its own components. Now cDNA-identical loci are **summed in linear space into one entry before** the histogram/percentile, for both the TSV pass and the parquet cohorts. Cache key → `_v2`.

Verified: p95 cutoff median change vs the old uncollapsed = **0.000%** (it touches ~326/58000 genes, as predicted) — the rule is honored with no material numeric shift. Public `cdna_symbol_to_canonical_symbol` accessor added. 558 pass.

Next in #21: CRC_MSI/CRC_MSS in the coverage cohorts, and aPD1 `cta_burden` → %-patients-≥95th-percentile.