### PR TITLE
Curate sarcoma aPD1 monotherapy ORR (SARC028) — sarcomas appear in ORR plots (#22)

### DIFF
--- a/pirlygenes/data/cancer-apd1-response.csv
+++ b/pirlygenes/data/cancer-apd1-response.csv
@@ -35,3 +35,10 @@ KIRP,25,pembrolizumab,KEYNOTE-427 cohort B,papillary RCC 1L,PMID:34272311,medium
 KICH,10,pembrolizumab,KEYNOTE-427 cohort B,chromophobe RCC 1L,PMID:34272311,low,chromophobe ORR 9.5% (small n)
 CHOL,6,pembrolizumab,KEYNOTE-158,advanced biliary,PMID:32319072,medium,biliary ORR 5.8% (6/104)
 UVM,4,nivolumab,pooled uveal series,metastatic uveal melanoma,PMID:27533448,low,uveal anti-PD-1 monotherapy ORR ~3-6% (checkpoint-refractory)
+SARC_UPS,23,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,medium,undifferentiated pleomorphic sarcoma; most ICI-responsive STS; expansion cohort ~23% (Burgess 2019)
+SARC_DDLPS,10,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,dedifferentiated liposarcoma; SARC028 STS subset
+SARC_SYN,10,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,synovial sarcoma 1/10; translocation sarcoma; immune-cold
+SARC_LMS,0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,leiomyosarcoma 0/10; immune-cold
+SARC_OS,5,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,osteosarcoma 1/22 in the bone cohort
+SARC_EWS,0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,Ewing sarcoma 0/13; immune-cold
+SARC_CHON,0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,chondrosarcoma 0/5

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.66"
+__version__ = "5.22.67"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Answers *'where are all the sarcomas?'* — `cancer-apd1-response.csv` had **0 sarcoma rows**, so every sarcoma dropped from the ORR-axis plots.

Added 7 subtypes from **SARC028** (Tawbi et al., Lancet Oncol 2017, PMID:28988646; pembrolizumab monotherapy):
| code | ORR | note |
|---|---|---|
| SARC_UPS | 23% | most ICI-responsive STS (expansion-confirmed) |
| SARC_DDLPS | 10% | dedifferentiated liposarcoma |
| SARC_SYN | 10% | synovial (translocation sarcoma) |
| SARC_OS | 5% | osteosarcoma 1/22 (bone cohort) |
| SARC_LMS / SARC_EWS / SARC_CHON | 0% | immune-cold |

**Not added** (deliberately, no fabrication):
- **SARC_ASPS** — its evidence is *atezolizumab* (anti-PD-**L1**), which doesn't belong in an anti-PD-1 monotherapy table (the test enforces pembrolizumab/nivolumab).
- **NUTM, ATRT** — no published anti-PD-1 *monotherapy* ORR exists for them (ultra-rare; case reports only).

apd1_vs_tmb now shows 40 cancers (was 33). 558 pass. **This completes the #20→#21→#22 series.**