### PR TITLE
aPD1 response: PD-L1 proxy (denoted) where no anti-PD-1 ORR exists

### DIFF
--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -28,6 +28,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 
 from pirlygenes import gene_sets_cancer as gsc  # noqa: E402
+from pirlygenes.load_dataset import get_data  # noqa: E402
 from _run_layout import add_layout_args, resolve_dirs, pct_axis  # noqa: E402
 
 OUT = Path(__file__).resolve().parent / "outputs"
@@ -71,15 +72,24 @@ def _color_map(codes):
     return {f: cmap(i % 20) for i, f in enumerate(fams)}
 
 
-def _plot_tmb_vs_apd1(orr, tmb, colors):
+def _plot_tmb_vs_apd1(orr, tmb, colors, proxy=None):
+    proxy = proxy or set()
     pts = [(c, tmb[c], orr[c]) for c in orr if c in tmb]
     fig, ax = plt.subplots(figsize=(12, 7.5))
     ax.set_xscale("log")
     for code, x, y in pts:
-        ax.scatter(x, y, s=42, color=colors[_family(code)], alpha=0.9,
-                   edgecolor="white", linewidth=0.4, zorder=3)
-        ax.annotate(code, (x, y), fontsize=6.5, xytext=(3, 3),
-                    textcoords="offset points")
+        # PD-L1 proxies (no anti-PD-1 ORR) drawn as an open diamond, denoted "*"
+        is_proxy = code in proxy
+        ax.scatter(x, y, s=58 if is_proxy else 42, color=colors[_family(code)],
+                   alpha=0.9, edgecolor="black" if is_proxy else "white",
+                   linewidth=1.1 if is_proxy else 0.4,
+                   marker="D" if is_proxy else "o", zorder=3)
+        ax.annotate(f"{code}*" if is_proxy else code, (x, y), fontsize=6.5,
+                    xytext=(3, 3), textcoords="offset points")
+    if proxy & {c for c, _, _ in pts}:
+        ax.scatter([], [], marker="D", facecolor="0.6", edgecolor="black",
+                   label="* PD-L1 proxy (no anti-PD-1 monotherapy data)")
+        ax.legend(loc="lower right", fontsize=8)
     # connect the subtype pairs with a thin line to show the differential
     for hi, lo in _PAIRS:
         if hi in tmb and hi in orr and lo in tmb and lo in orr:
@@ -126,8 +136,10 @@ def main() -> int:
                if gsc.cancer_tmb(c) is not None}
     orr = _pool_crc(orr_raw)                   # COAD/READ MSI+MSS -> CRC tiers
     tmb = _pool_crc(tmb_raw)
+    rdf = get_data("cancer-apd1-response")     # PD-L1-proxy codes (denoted)
+    proxy = set(rdf.loc[rdf["drug_target"] == "PD-L1", "cancer_code"].astype(str))
     colors = _color_map(orr)
-    n = _plot_tmb_vs_apd1(orr, tmb, colors)
+    n = _plot_tmb_vs_apd1(orr, tmb, colors, proxy=proxy)
     _plot_orr_bars(orr, colors)
     print(f"wrote apd1_vs_tmb.png ({n} cancers with TMB+ORR) and "
           f"apd1_orr_bars.png ({len(orr)} cancers) -> {FIGDIR}", flush=True)

--- a/pirlygenes/data/cancer-apd1-response.csv
+++ b/pirlygenes/data/cancer-apd1-response.csv
@@ -1,44 +1,45 @@
-cancer_code,apd1_orr_pct,drug,trial,setting,pmid_doi,confidence,notes
-SKCM,42,nivolumab,CheckMate-067,first-line advanced; nivo monotherapy arm,PMID:28889792,high,Nivo mono ~42-45% (CheckMate-067); pembro KEYNOTE-006 primary 33-37% / longer-FU ~42% (PMID:25891173); aPD1 monotherapy ~40-45% in melanoma
-LUAD,19,nivolumab,CheckMate-057,pretreated non-squamous; PD-L1 unselected (all-comer),PMID:26412456,high,All-comer mono ORR 19.2% (Borghaei 2015); PD-L1>=1% ~31% / >=50% ~36%; KEYNOTE-024 PD-L1 TPS>=50% 1L was 45% (PMID:27718847) — population-matched to all-comer TMB/expression per audit
-LUSC,20,nivolumab,CheckMate-017,pretreated squamous; PD-L1 unselected (all-comer),PMID:26028407,high,All-comer mono ORR 20% (Brahmer 2015); PD-L1-independent in squamous; KEYNOTE-024 PD-L1>=50% 1L was 45% (PMID:27718847)
-LUAD_STK11,10,pembrolizumab,KEYNOTE-042 subgroup,STK11/KEAP1-mutant immune-cold subset,PMID:30955977,low,Approximate; STK11/KEAP1-mutant LUAD is immune-cold with markedly lower aPD1 benefit (reported mainly as PFS/OS HRs)
-HNSC,19,pembrolizumab,KEYNOTE-048,first-line R/M; CPS>=1; monotherapy arm,PMID:33052747,high,CPS>=20 ~23%; total population ~17%; HPV+/HPV- differential not cleanly established in KN-048
-KIRC,25,nivolumab,CheckMate-025,pretreated (post-VEGF TKI); all-comers,PMID:26406148,high,vs everolimus 5%
-BLCA,28.6,pembrolizumab,KEYNOTE-052,first-line cisplatin-ineligible; all-comers,PMID:32552471,high,Mature KEYNOTE-052 final ORR 28.6% (Vuky 2020); CPS>=10 ~47%; 2017 interim was 24%; CheckMate-275 pretreated ~20%
-COAD,5,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; only the ~13% MSI-H/dMMR respond (MSI-H ~45%; MSS ~0%)
-READ,5,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; MSI-H ~45% and MSS ~0%
-STAD,12,pembrolizumab,KEYNOTE-059,third-line; all-comers,PMID:29260193,medium,CPS>=1 ~16%; monotherapy indication later withdrawn
-LIHC,17,nivolumab,CheckMate-040,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion
-ESCA,18,nivolumab,ATTRACTION-3,pretreated; esophageal SCC,PMID:31582355,medium,nivo ~19%; KEYNOTE-181 ESCC subgroup ~17%
-CESC,15,pembrolizumab,KEYNOTE-158,pretreated; PD-L1+ (CPS>=1) selected,PMID:30943124,high,All responders were PD-L1+; all-comer ~12%
-HL,71,nivolumab,CheckMate-205,relapsed/refractory post-ASCT,PMID:29584546,high,Very high responder; KEYNOTE-087 pembro ~69%
-NEC_MERKEL,56,pembrolizumab,KEYNOTE-017,first-line advanced; all-comers,PMID:30726175,high,Very high responder; CR ~24%
-BRCA_Basal,5,pembrolizumab,KEYNOTE-086,pretreated metastatic TNBC; all-comers,PMID:30475950,medium,Cohort A (pretreated) ~5%; PD-L1+ untreated cohort B ~21%
-SCLC,13,nivolumab,CheckMate-032,pretreated; all-comers,PMID:27269732,medium,~10-19%; nivo mono ~10%; KEYNOTE-028 PD-L1-selected was higher (~33%) but not representative
-MESO,10,pembrolizumab,KEYNOTE-158,pretreated; all-comers,PMID:33125908,low,Reported ~8-20% across studies
-NPC,25,pembrolizumab,KEYNOTE-028,pretreated; PD-L1+ selected,PMID:28837405,medium,KN-028 NPC cohort ~26%
-PRAD,4,pembrolizumab,KEYNOTE-199,pretreated mCRPC,PMID:31774688,high,Near-zero anchor; ~5% PD-L1+ / ~3% PD-L1-
-PAAD,1,pembrolizumab,pooled/basket,pretreated; MSS,,low,Near-zero anchor (~0-3%); no single clean monotherapy trial; rare dMMR/MSI-H PDAC responds (~37%) but is a tiny subset
-GBM,8,nivolumab,CheckMate-143,recurrent; all-comers,PMID:32437507,high,Near-zero anchor; vs bevacizumab 23%
-COAD_MSI,45,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,high,MSI-H/dMMR colon; immune-hot; the canonical aPD1-responsive subtype
-COAD_MSS,0,pembrolizumab,KEYNOTE-016/-028,MSS,PMID:26028255,high,Microsatellite-stable colon; immune-cold; ~0% response
-READ_MSI,45,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,medium,MSI-H/dMMR rectal; small subset; same biology as COAD_MSI
-READ_MSS,0,pembrolizumab,KEYNOTE-016,MSS,PMID:26028255,high,Microsatellite-stable rectal; immune-cold
-UCEC_MSI,50,pembrolizumab,KEYNOTE-158,dMMR/MSI-H advanced EC,PMID:34990208,high,ORR 50% (95% CI 40-61); MSI-H/dMMR cohort n=94
-UCEC_CNL,6,pembrolizumab,KEYNOTE-158,pMMR/MSS NSMP,PMID:34990208,medium,non-MSI-H ORR ~7% (3-14); MSS NSMP arm
-UCEC_CNH,6,pembrolizumab,KEYNOTE-158,pMMR/MSS p53-abnormal,PMID:34990208,medium,non-MSI-H ORR ~7%; p53-abnormal most immune-cold
-OV,8,pembrolizumab,KEYNOTE-100,recurrent ovarian (all-comers),PMID:31218020,medium,pembro monotherapy ORR 8.0%
-HNSC_HPVpos,24,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV+,PMID:27646946,medium,HPV+ subgroup; pooled monotherapy HPV+ > HPV- (overall KN-012 ORR 18%)
-HNSC_HPVneg,16,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV-,PMID:27646946,medium,HPV- subgroup
-KIRP,25,pembrolizumab,KEYNOTE-427 cohort B,papillary RCC 1L,PMID:34272311,medium,papillary nccRCC ORR 25.4%
-KICH,10,pembrolizumab,KEYNOTE-427 cohort B,chromophobe RCC 1L,PMID:34272311,low,chromophobe ORR 9.5% (small n)
-CHOL,6,pembrolizumab,KEYNOTE-158,advanced biliary,PMID:32319072,medium,biliary ORR 5.8% (6/104)
-UVM,4,nivolumab,pooled uveal series,metastatic uveal melanoma,PMID:27533448,low,uveal anti-PD-1 monotherapy ORR ~3-6% (checkpoint-refractory)
-SARC_UPS,23,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,medium,undifferentiated pleomorphic sarcoma; most ICI-responsive STS; expansion cohort ~23% (Burgess 2019)
-SARC_DDLPS,10,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,dedifferentiated liposarcoma; SARC028 STS subset
-SARC_SYN,10,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,synovial sarcoma 1/10; translocation sarcoma; immune-cold
-SARC_LMS,0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,leiomyosarcoma 0/10; immune-cold
-SARC_OS,5,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,osteosarcoma 1/22 in the bone cohort
-SARC_EWS,0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,Ewing sarcoma 0/13; immune-cold
-SARC_CHON,0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,chondrosarcoma 0/5
+cancer_code,apd1_orr_pct,drug,trial,setting,pmid_doi,confidence,notes,drug_target
+SKCM,42.0,nivolumab,CheckMate-067,first-line advanced; nivo monotherapy arm,PMID:28889792,high,Nivo mono ~42-45% (CheckMate-067); pembro KEYNOTE-006 primary 33-37% / longer-FU ~42% (PMID:25891173); aPD1 monotherapy ~40-45% in melanoma,PD-1
+LUAD,19.0,nivolumab,CheckMate-057,pretreated non-squamous; PD-L1 unselected (all-comer),PMID:26412456,high,All-comer mono ORR 19.2% (Borghaei 2015); PD-L1>=1% ~31% / >=50% ~36%; KEYNOTE-024 PD-L1 TPS>=50% 1L was 45% (PMID:27718847) — population-matched to all-comer TMB/expression per audit,PD-1
+LUSC,20.0,nivolumab,CheckMate-017,pretreated squamous; PD-L1 unselected (all-comer),PMID:26028407,high,All-comer mono ORR 20% (Brahmer 2015); PD-L1-independent in squamous; KEYNOTE-024 PD-L1>=50% 1L was 45% (PMID:27718847),PD-1
+LUAD_STK11,10.0,pembrolizumab,KEYNOTE-042 subgroup,STK11/KEAP1-mutant immune-cold subset,PMID:30955977,low,Approximate; STK11/KEAP1-mutant LUAD is immune-cold with markedly lower aPD1 benefit (reported mainly as PFS/OS HRs),PD-1
+HNSC,19.0,pembrolizumab,KEYNOTE-048,first-line R/M; CPS>=1; monotherapy arm,PMID:33052747,high,CPS>=20 ~23%; total population ~17%; HPV+/HPV- differential not cleanly established in KN-048,PD-1
+KIRC,25.0,nivolumab,CheckMate-025,pretreated (post-VEGF TKI); all-comers,PMID:26406148,high,vs everolimus 5%,PD-1
+BLCA,28.6,pembrolizumab,KEYNOTE-052,first-line cisplatin-ineligible; all-comers,PMID:32552471,high,Mature KEYNOTE-052 final ORR 28.6% (Vuky 2020); CPS>=10 ~47%; 2017 interim was 24%; CheckMate-275 pretreated ~20%,PD-1
+COAD,5.0,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; only the ~13% MSI-H/dMMR respond (MSI-H ~45%; MSS ~0%),PD-1
+READ,5.0,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; MSI-H ~45% and MSS ~0%,PD-1
+STAD,12.0,pembrolizumab,KEYNOTE-059,third-line; all-comers,PMID:29260193,medium,CPS>=1 ~16%; monotherapy indication later withdrawn,PD-1
+LIHC,17.0,nivolumab,CheckMate-040,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion,PD-1
+ESCA,18.0,nivolumab,ATTRACTION-3,pretreated; esophageal SCC,PMID:31582355,medium,nivo ~19%; KEYNOTE-181 ESCC subgroup ~17%,PD-1
+CESC,15.0,pembrolizumab,KEYNOTE-158,pretreated; PD-L1+ (CPS>=1) selected,PMID:30943124,high,All responders were PD-L1+; all-comer ~12%,PD-1
+HL,71.0,nivolumab,CheckMate-205,relapsed/refractory post-ASCT,PMID:29584546,high,Very high responder; KEYNOTE-087 pembro ~69%,PD-1
+NEC_MERKEL,56.0,pembrolizumab,KEYNOTE-017,first-line advanced; all-comers,PMID:30726175,high,Very high responder; CR ~24%,PD-1
+BRCA_Basal,5.0,pembrolizumab,KEYNOTE-086,pretreated metastatic TNBC; all-comers,PMID:30475950,medium,Cohort A (pretreated) ~5%; PD-L1+ untreated cohort B ~21%,PD-1
+SCLC,13.0,nivolumab,CheckMate-032,pretreated; all-comers,PMID:27269732,medium,~10-19%; nivo mono ~10%; KEYNOTE-028 PD-L1-selected was higher (~33%) but not representative,PD-1
+MESO,10.0,pembrolizumab,KEYNOTE-158,pretreated; all-comers,PMID:33125908,low,Reported ~8-20% across studies,PD-1
+NPC,25.0,pembrolizumab,KEYNOTE-028,pretreated; PD-L1+ selected,PMID:28837405,medium,KN-028 NPC cohort ~26%,PD-1
+PRAD,4.0,pembrolizumab,KEYNOTE-199,pretreated mCRPC,PMID:31774688,high,Near-zero anchor; ~5% PD-L1+ / ~3% PD-L1-,PD-1
+PAAD,1.0,pembrolizumab,pooled/basket,pretreated; MSS,,low,Near-zero anchor (~0-3%); no single clean monotherapy trial; rare dMMR/MSI-H PDAC responds (~37%) but is a tiny subset,PD-1
+GBM,8.0,nivolumab,CheckMate-143,recurrent; all-comers,PMID:32437507,high,Near-zero anchor; vs bevacizumab 23%,PD-1
+COAD_MSI,45.0,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,high,MSI-H/dMMR colon; immune-hot; the canonical aPD1-responsive subtype,PD-1
+COAD_MSS,0.0,pembrolizumab,KEYNOTE-016/-028,MSS,PMID:26028255,high,Microsatellite-stable colon; immune-cold; ~0% response,PD-1
+READ_MSI,45.0,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,medium,MSI-H/dMMR rectal; small subset; same biology as COAD_MSI,PD-1
+READ_MSS,0.0,pembrolizumab,KEYNOTE-016,MSS,PMID:26028255,high,Microsatellite-stable rectal; immune-cold,PD-1
+UCEC_MSI,50.0,pembrolizumab,KEYNOTE-158,dMMR/MSI-H advanced EC,PMID:34990208,high,ORR 50% (95% CI 40-61); MSI-H/dMMR cohort n=94,PD-1
+UCEC_CNL,6.0,pembrolizumab,KEYNOTE-158,pMMR/MSS NSMP,PMID:34990208,medium,non-MSI-H ORR ~7% (3-14); MSS NSMP arm,PD-1
+UCEC_CNH,6.0,pembrolizumab,KEYNOTE-158,pMMR/MSS p53-abnormal,PMID:34990208,medium,non-MSI-H ORR ~7%; p53-abnormal most immune-cold,PD-1
+OV,8.0,pembrolizumab,KEYNOTE-100,recurrent ovarian (all-comers),PMID:31218020,medium,pembro monotherapy ORR 8.0%,PD-1
+HNSC_HPVpos,24.0,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV+,PMID:27646946,medium,HPV+ subgroup; pooled monotherapy HPV+ > HPV- (overall KN-012 ORR 18%),PD-1
+HNSC_HPVneg,16.0,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV-,PMID:27646946,medium,HPV- subgroup,PD-1
+KIRP,25.0,pembrolizumab,KEYNOTE-427 cohort B,papillary RCC 1L,PMID:34272311,medium,papillary nccRCC ORR 25.4%,PD-1
+KICH,10.0,pembrolizumab,KEYNOTE-427 cohort B,chromophobe RCC 1L,PMID:34272311,low,chromophobe ORR 9.5% (small n),PD-1
+CHOL,6.0,pembrolizumab,KEYNOTE-158,advanced biliary,PMID:32319072,medium,biliary ORR 5.8% (6/104),PD-1
+UVM,4.0,nivolumab,pooled uveal series,metastatic uveal melanoma,PMID:27533448,low,uveal anti-PD-1 monotherapy ORR ~3-6% (checkpoint-refractory),PD-1
+SARC_UPS,23.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,medium,undifferentiated pleomorphic sarcoma; most ICI-responsive STS; expansion cohort ~23% (Burgess 2019),PD-1
+SARC_DDLPS,10.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,dedifferentiated liposarcoma; SARC028 STS subset,PD-1
+SARC_SYN,10.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,synovial sarcoma 1/10; translocation sarcoma; immune-cold,PD-1
+SARC_LMS,0.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,leiomyosarcoma 0/10; immune-cold,PD-1
+SARC_OS,5.0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,osteosarcoma 1/22 in the bone cohort,PD-1
+SARC_EWS,0.0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,Ewing sarcoma 0/13; immune-cold,PD-1
+SARC_CHON,0.0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,chondrosarcoma 0/5,PD-1
+SARC_ASPS,37.0,atezolizumab,ML39345 (NCT03141684),advanced ASPS,PMID:37672694,medium,alveolar soft part sarcoma; PD-L1 proxy (no anti-PD-1 monotherapy data); atezolizumab FDA-approved 2022; ORR 19/52,PD-L1

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.67"
+__version__ = "5.22.68"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cancer_apd1_response.py
+++ b/tests/test_cancer_apd1_response.py
@@ -17,6 +17,7 @@ _EXPECTED_COLS = [
     "pmid_doi",
     "confidence",
     "notes",
+    "drug_target",
 ]
 
 
@@ -39,9 +40,18 @@ def test_values_are_response_rates():
     assert m["GBM"] < 15 and m["PRAD"] < 15
 
 
-def test_drug_is_an_antiPD1_monotherapy():
+def test_drug_matches_its_checkpoint_target():
+    """Anti-PD-1 rows use pembrolizumab/nivolumab; PD-L1 *proxy* rows (used only
+    where no anti-PD-1 monotherapy ORR exists, and denoted by
+    ``drug_target='PD-L1'``) use an anti-PD-L1 agent."""
     df = cancer_apd1_response_df()
-    assert set(df["drug"]).issubset({"pembrolizumab", "nivolumab"})
+    assert set(df["drug_target"]) <= {"PD-1", "PD-L1"}
+    pd1 = df[df["drug_target"] == "PD-1"]
+    pdl1 = df[df["drug_target"] == "PD-L1"]
+    assert set(pd1["drug"]).issubset({"pembrolizumab", "nivolumab"})
+    assert set(pdl1["drug"]).issubset({"atezolizumab", "durvalumab", "avelumab"})
+    # PD-L1 proxies must carry a citation (no unsourced proxies)
+    assert pdl1["pmid_doi"].astype(str).str.startswith(("PMID", "DOI", "10.")).all()
 
 
 def test_every_value_is_cited_or_flagged():


### PR DESCRIPTION
## What

Adds a `drug_target` column to `cancer-apd1-response.csv` so the table can carry an **anti-PD-L1 ORR as a denoted proxy** for cancer types that have no published anti-PD-1 monotherapy ORR. All 43 existing rows are `PD-1`; the one new proxy row is `PD-L1`.

### New proxy row
- **SARC_ASPS** (alveolar soft part sarcoma) — atezolizumab ORR **37%** (19/52), ML39345/NCT03141684, **PMID:37672694** (Chen et al., NEJM 2023). FDA-approved 2022. No anti-PD-1 monotherapy data exists for ASPS, so the anti-PD-L1 result is the only checkpoint-monotherapy signal — carried as a clearly-flagged proxy.

### Denotation
- `tests/test_cancer_apd1_response.py`: `drug_target` added to expected schema; `test_drug_matches_its_checkpoint_target` enforces PD-1 rows → pembrolizumab/nivolumab, PD-L1 rows → atezolizumab/durvalumab/avelumab and require a citation.
- `analyses/apd1_response_plots.py`: PD-L1 proxies drawn as an **open diamond** with a `*` label suffix and a `* PD-L1 proxy` legend entry, so they are never silently mixed with true anti-PD-1 points.

558 tests pass.