### PR TITLE
Lineage groups: recognizable short labels (Sarcoma, Melanoma, Heme)

### DIFF
--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -70,8 +70,8 @@ def _lineage_map() -> dict:
     """{code: coarse histogenesis group} over the registry. The registry
     ``family`` column is uneven (CNS split into 6, carcinoma by organ), so we
     colour by the ~8 cell-of-origin classes from ``cancer_lineage_group``
-    (Epithelial / Mesenchymal / Hematolymphoid / CNS / Neuroendocrine /
-    Melanocytic / Germ cell / Embryonal) instead."""
+    (Epithelial / Sarcoma / Heme / CNS / Neuroendocrine /
+    Melanoma / Germ cell / Embryonal) instead."""
     codes = gsc.cancer_type_registry()["code"].astype(str)
     return {c: (gsc.cancer_lineage_group(c) or "other") for c in codes}
 

--- a/pirlygenes/data/cancer-lineage-groups.csv
+++ b/pirlygenes/data/cancer-lineage-groups.csv
@@ -10,12 +10,12 @@ carcinoma-skin,Epithelial
 salivary,Epithelial
 thymic,Epithelial
 endocrine-epithelial,Epithelial
-sarcoma,Mesenchymal
-heme-bcell,Hematolymphoid
-heme-tcell,Hematolymphoid
-heme-myeloid,Hematolymphoid
-heme-plasma,Hematolymphoid
-melanoma,Melanocytic
+sarcoma,Sarcoma
+heme-bcell,Heme
+heme-tcell,Heme
+heme-myeloid,Heme
+heme-plasma,Heme
+melanoma,Melanoma
 neuroendocrine,Neuroendocrine
 endocrine-neuroendocrine,Neuroendocrine
 germ-cell,Germ cell

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -820,8 +820,8 @@ def cancer_lineage_groups():
     the lineage *gene panels* need that resolution), so it ranges from a whole
     organ system (``carcinoma-gu``, 20 codes) down to single tumours
     (``cns-choroid``, 1). This rolls the 27 families up to ~8 cell-of-origin
-    classes — **Epithelial, Mesenchymal, Hematolymphoid, CNS, Neuroendocrine,
-    Melanocytic, Germ cell, Embryonal** — the consistent level for broad
+    classes — **Epithelial, Sarcoma, Heme, CNS, Neuroendocrine,
+    Melanoma, Germ cell, Embryonal** — the consistent level for broad
     cross-lineage reasoning and plot colouring. Distinct from
     :func:`cancer_family_groups`, which rolls up *gene-panel* families for
     scoring vetoes; this rolls up *registry* families by histogenesis."""
@@ -831,7 +831,7 @@ def cancer_lineage_groups():
 
 
 def cancer_lineage_group(cancer_type):
-    """Coarse histogenesis group (Epithelial / Mesenchymal / …) for a code,
+    """Coarse histogenesis group (Epithelial / Sarcoma / Melanoma / …) for a code,
     alias, or display name, resolved via its registry ``family``. Returns
     ``None`` if the type or its family doesn't resolve."""
     try:

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.73"
+__version__ = "5.22.74"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cancer_type_registry.py
+++ b/tests/test_cancer_type_registry.py
@@ -22,8 +22,8 @@ from pirlygenes.gene_sets_cancer import (
 
 
 _LINEAGE_GROUPS = {
-    "Epithelial", "Mesenchymal", "Hematolymphoid", "CNS",
-    "Neuroendocrine", "Melanocytic", "Germ cell", "Embryonal",
+    "Epithelial", "Sarcoma", "Heme", "CNS",
+    "Neuroendocrine", "Melanoma", "Germ cell", "Embryonal",
 }
 
 
@@ -42,19 +42,19 @@ def test_every_registry_family_has_a_lineage_group():
 
 
 def test_cancer_lineage_group_resolves_codes_and_histogenesis():
-    # carcinomas -> Epithelial; sarcomas -> Mesenchymal; gliomas/meningioma ->
-    # CNS; lymphoma/leukemia -> Hematolymphoid; melanoma -> Melanocytic.
+    # carcinomas -> Epithelial; sarcomas -> Sarcoma; gliomas/meningioma -> CNS;
+    # lymphoma/leukemia -> Heme; melanoma -> Melanoma.
     assert cancer_lineage_group("KIRC") == "Epithelial"
     assert cancer_lineage_group("KIRP") == "Epithelial"          # not sarcoma!
-    assert cancer_lineage_group("SARC_UPS") == "Mesenchymal"
+    assert cancer_lineage_group("SARC_UPS") == "Sarcoma"
     assert cancer_lineage_group("GBM") == "CNS"
     assert cancer_lineage_group("MENINGIOMA") == "CNS"
-    assert cancer_lineage_group("HL") == "Hematolymphoid"
-    assert cancer_lineage_group("SKCM") == "Melanocytic"
+    assert cancer_lineage_group("HL") == "Heme"
+    assert cancer_lineage_group("SKCM") == "Melanoma"
     assert cancer_lineage_group("TGCT") == "Germ cell"
     assert cancer_lineage_group("MBL") == "Embryonal"
     assert cancer_lineage_group("NET_PANCREAS") == "Neuroendocrine"
-    assert cancer_lineage_group("melanoma") == "Melanocytic"     # alias resolves
+    assert cancer_lineage_group("melanoma") == "Melanoma"        # alias resolves
     assert cancer_lineage_group("not-a-cancer") is None
 
 


### PR DESCRIPTION
Renames three histogenesis-group labels to the recognizable clinical names: **Mesenchymal→Sarcoma** (100% sarcomas), **Melanocytic→Melanoma** (SKCM+UVM), **Hematolymphoid→Heme** (shorter). Epithelial is kept over 'Carcinoma' because it includes thymoma (epithelial, not a carcinoma). Final 8: Epithelial, Sarcoma, Heme, CNS, Neuroendocrine, Melanoma, Germ cell, Embryonal. 560 tests pass.