### PR TITLE
Lineage groups: split NEC vs NET; neuroblastoma -> Embryonal

### DIFF
--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -70,8 +70,8 @@ def _lineage_map() -> dict:
     """{code: coarse histogenesis group} over the registry. The registry
     ``family`` column is uneven (CNS split into 6, carcinoma by organ), so we
     colour by the ~8 cell-of-origin classes from ``cancer_lineage_group``
-    (Epithelial / Sarcoma / Heme / CNS / Neuroendocrine /
-    Melanoma / Germ cell / Embryonal) instead."""
+    (Epithelial / Sarcoma / Heme / CNS / NEC / NET / Melanoma /
+    Germ cell / Embryonal) instead."""
     codes = gsc.cancer_type_registry()["code"].astype(str)
     return {c: (gsc.cancer_lineage_group(c) or "other") for c in codes}
 

--- a/pirlygenes/data/cancer-lineage-group-overrides.csv
+++ b/pirlygenes/data/cancer-lineage-group-overrides.csv
@@ -1,0 +1,5 @@
+code,lineage_group,basis
+SCLC,NEC,high-grade neuroendocrine carcinoma (WHO); immune-responsive; TP53/RB1
+NEC_MERKEL,NEC,cutaneous high-grade neuroendocrine carcinoma; aPD1 ORR ~56%
+NEC_LUNG_LARGECELL,NEC,large-cell neuroendocrine carcinoma of lung; high-grade
+NBL,Embryonal,peripheral neuroblastic (sympathoadrenal neural crest) embryonal tumour; MYCN; not an epithelial NEN

--- a/pirlygenes/data/cancer-lineage-groups.csv
+++ b/pirlygenes/data/cancer-lineage-groups.csv
@@ -16,8 +16,8 @@ heme-tcell,Heme
 heme-myeloid,Heme
 heme-plasma,Heme
 melanoma,Melanoma
-neuroendocrine,Neuroendocrine
-endocrine-neuroendocrine,Neuroendocrine
+neuroendocrine,NET
+endocrine-neuroendocrine,NET
 germ-cell,Germ cell
 embryonal,Embryonal
 cns-embryonal,Embryonal

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -820,8 +820,9 @@ def cancer_lineage_groups():
     the lineage *gene panels* need that resolution), so it ranges from a whole
     organ system (``carcinoma-gu``, 20 codes) down to single tumours
     (``cns-choroid``, 1). This rolls the 27 families up to ~8 cell-of-origin
-    classes — **Epithelial, Sarcoma, Heme, CNS, Neuroendocrine,
-    Melanoma, Germ cell, Embryonal** — the consistent level for broad
+    classes — **Epithelial, Sarcoma, Heme, CNS, NEC, NET, Melanoma,
+    Germ cell, Embryonal** (the neuroendocrine family is split NEC vs NET, see
+    cancer_lineage_group_overrides) — the consistent level for broad
     cross-lineage reasoning and plot colouring. Distinct from
     :func:`cancer_family_groups`, which rolls up *gene-panel* families for
     scoring vetoes; this rolls up *registry* families by histogenesis."""
@@ -830,10 +831,26 @@ def cancer_lineage_groups():
                 .itertuples(index=False, name=None))
 
 
+def cancer_lineage_group_overrides():
+    """Dict ``{code -> lineage_group}`` for codes whose coarse group differs from
+    their registry ``family`` default. The ``neuroendocrine`` family spans
+    histogenetically distinct entities, so it defaults to well-differentiated
+    ``NET`` and these rows pull out the exceptions: the high-grade neuroendocrine
+    carcinomas (SCLC, Merkel, lung LCNEC) -> ``NEC`` — a split that tracks
+    immunotherapy response (NEC immune-responsive vs NET immune-cold) — and
+    neuroblastoma -> ``Embryonal`` (a peripheral neuroblastic / neural-crest
+    embryonal tumour, not an epithelial NEN). Overrides inherit down the
+    ``parent_code`` chain, so e.g. SCLC_ASCL1 follows SCLC."""
+    df = get_data("cancer-lineage-group-overrides")
+    return dict(df[["code", "lineage_group"]].itertuples(index=False, name=None))
+
+
 def cancer_lineage_group(cancer_type):
-    """Coarse histogenesis group (Epithelial / Sarcoma / Melanoma / …) for a code,
-    alias, or display name, resolved via its registry ``family``. Returns
-    ``None`` if the type or its family doesn't resolve."""
+    """Coarse histogenesis group (Epithelial / Sarcoma / NEC / NET / CNS /
+    Melanoma / Heme / Germ cell / Embryonal) for a code, alias, or display name.
+    Resolution: a per-code override (inherited up the ``parent_code`` chain) if
+    one applies, else the registry ``family`` default. Returns ``None`` if the
+    type or its family doesn't resolve."""
     try:
         code = resolve_cancer_type(cancer_type)
     except ValueError:
@@ -843,6 +860,15 @@ def cancer_lineage_group(cancer_type):
     reg = cancer_type_registry().set_index("code")
     if code not in reg.index:
         return None
+    overrides = cancer_lineage_group_overrides()
+    cur, seen = code, set()
+    while cur and cur not in seen:                  # nearest override up the chain
+        seen.add(cur)
+        if cur in overrides:
+            return overrides[cur]
+        if cur not in reg.index:
+            break
+        cur = str(reg.loc[cur, "parent_code"] or "").strip() or None
     family = str(reg.loc[code, "family"] or "")
     return cancer_lineage_groups().get(family)
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.76"
+__version__ = "5.22.77"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cancer_type_registry.py
+++ b/tests/test_cancer_type_registry.py
@@ -22,8 +22,8 @@ from pirlygenes.gene_sets_cancer import (
 
 
 _LINEAGE_GROUPS = {
-    "Epithelial", "Sarcoma", "Heme", "CNS",
-    "Neuroendocrine", "Melanoma", "Germ cell", "Embryonal",
+    "Epithelial", "Sarcoma", "Heme", "CNS", "NEC", "NET",
+    "Melanoma", "Germ cell", "Embryonal",
 }
 
 
@@ -53,9 +53,24 @@ def test_cancer_lineage_group_resolves_codes_and_histogenesis():
     assert cancer_lineage_group("SKCM") == "Melanoma"
     assert cancer_lineage_group("TGCT") == "Germ cell"
     assert cancer_lineage_group("MBL") == "Embryonal"
-    assert cancer_lineage_group("NET_PANCREAS") == "Neuroendocrine"
     assert cancer_lineage_group("melanoma") == "Melanoma"        # alias resolves
     assert cancer_lineage_group("not-a-cancer") is None
+
+
+def test_neuroendocrine_split_nec_net_and_neuroblastoma():
+    # The neuroendocrine family splits by histogenesis + immunotherapy behaviour:
+    # high-grade NE carcinomas -> NEC (immune-responsive), well-differentiated
+    # NETs -> NET (immune-cold), and neuroblastoma is an embryonal neural-crest
+    # tumour, not an epithelial NEN.
+    assert cancer_lineage_group("SCLC") == "NEC"
+    assert cancer_lineage_group("SCLC_ASCL1") == "NEC"           # inherits via parent
+    assert cancer_lineage_group("NEC_MERKEL") == "NEC"
+    assert cancer_lineage_group("NEC_LUNG_LARGECELL") == "NEC"
+    assert cancer_lineage_group("NET_PANCREAS") == "NET"
+    assert cancer_lineage_group("NET_MIDGUT") == "NET"
+    assert cancer_lineage_group("MTC") == "NET"
+    assert cancer_lineage_group("NBL") == "Embryonal"
+    assert cancer_lineage_group("NBL_MYCNamp") == "Embryonal"    # inherits via parent
 
 
 def _parent_codes(value):


### PR DESCRIPTION
Answers the taxonomy question with WHO + immunotherapy evidence.

**NEC vs NET split.** WHO treats well-differentiated NETs (MEN1/DAXX/ATRX, indolent) and poorly-differentiated NECs (TP53/RB1, high-grade) as distinct entities, and they diverge on checkpoint immunotherapy: DART/S1609 high-grade NEC **44%** vs low/intermediate NET **0%** (PMID:31969335); Merkel aPD1 ~**56%** (KEYNOTE-017, PMID:30726175); well-diff NET **3.7%** (KEYNOTE-158, PMID:31980466). NCCN/ESMO maintain separate algorithms (NET: SSA/everolimus/PRRT; NEC: platinum-etoposide ± ICI). The neuroendocrine family now defaults to **NET**, with overrides for the high-grade carcinomas (SCLC, NEC_MERKEL, NEC_LUNG_LARGECELL) -> **NEC**.

**Neuroblastoma -> Embryonal.** It's a peripheral neuroblastic / sympathoadrenal neural-crest embryonal tumour (MYCN-driven), classified by WHO/INRG apart from epithelial NENs — its NE markers are a differentiation feature, not cell of origin. Now grouped with its real neighbours (retinoblastoma, medulloblastoma).

New `cancer-lineage-group-overrides.csv` + accessor with parent-chain inheritance (SCLC_ASCL1 -> NEC, NBL_MYCNamp -> Embryonal). 9 groups. 561 tests pass.