### PR TITLE
Keep NEC+NET as one Neuroendocrine group; keep NBL->Embryonal

### DIFF
--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -70,7 +70,7 @@ def _lineage_map() -> dict:
     """{code: coarse histogenesis group} over the registry. The registry
     ``family`` column is uneven (CNS split into 6, carcinoma by organ), so we
     colour by the ~8 cell-of-origin classes from ``cancer_lineage_group``
-    (Epithelial / Sarcoma / Heme / CNS / NEC / NET / Melanoma /
+    (Epithelial / Sarcoma / Heme / CNS / Neuroendocrine / Melanoma /
     Germ cell / Embryonal) instead."""
     codes = gsc.cancer_type_registry()["code"].astype(str)
     return {c: (gsc.cancer_lineage_group(c) or "other") for c in codes}

--- a/pirlygenes/data/cancer-lineage-group-overrides.csv
+++ b/pirlygenes/data/cancer-lineage-group-overrides.csv
@@ -1,5 +1,2 @@
 code,lineage_group,basis
-SCLC,NEC,high-grade neuroendocrine carcinoma (WHO); immune-responsive; TP53/RB1
-NEC_MERKEL,NEC,cutaneous high-grade neuroendocrine carcinoma; aPD1 ORR ~56%
-NEC_LUNG_LARGECELL,NEC,large-cell neuroendocrine carcinoma of lung; high-grade
 NBL,Embryonal,peripheral neuroblastic (sympathoadrenal neural crest) embryonal tumour; MYCN; not an epithelial NEN

--- a/pirlygenes/data/cancer-lineage-groups.csv
+++ b/pirlygenes/data/cancer-lineage-groups.csv
@@ -16,8 +16,8 @@ heme-tcell,Heme
 heme-myeloid,Heme
 heme-plasma,Heme
 melanoma,Melanoma
-neuroendocrine,NET
-endocrine-neuroendocrine,NET
+neuroendocrine,Neuroendocrine
+endocrine-neuroendocrine,Neuroendocrine
 germ-cell,Germ cell
 embryonal,Embryonal
 cns-embryonal,Embryonal

--- a/pirlygenes/gene_sets_cancer.py
+++ b/pirlygenes/gene_sets_cancer.py
@@ -820,9 +820,8 @@ def cancer_lineage_groups():
     the lineage *gene panels* need that resolution), so it ranges from a whole
     organ system (``carcinoma-gu``, 20 codes) down to single tumours
     (``cns-choroid``, 1). This rolls the 27 families up to ~8 cell-of-origin
-    classes — **Epithelial, Sarcoma, Heme, CNS, NEC, NET, Melanoma,
-    Germ cell, Embryonal** (the neuroendocrine family is split NEC vs NET, see
-    cancer_lineage_group_overrides) — the consistent level for broad
+    classes — **Epithelial, Sarcoma, Heme, CNS, Neuroendocrine, Melanoma,
+    Germ cell, Embryonal** — the consistent level for broad
     cross-lineage reasoning and plot colouring. Distinct from
     :func:`cancer_family_groups`, which rolls up *gene-panel* families for
     scoring vetoes; this rolls up *registry* families by histogenesis."""
@@ -833,20 +832,17 @@ def cancer_lineage_groups():
 
 def cancer_lineage_group_overrides():
     """Dict ``{code -> lineage_group}`` for codes whose coarse group differs from
-    their registry ``family`` default. The ``neuroendocrine`` family spans
-    histogenetically distinct entities, so it defaults to well-differentiated
-    ``NET`` and these rows pull out the exceptions: the high-grade neuroendocrine
-    carcinomas (SCLC, Merkel, lung LCNEC) -> ``NEC`` — a split that tracks
-    immunotherapy response (NEC immune-responsive vs NET immune-cold) — and
-    neuroblastoma -> ``Embryonal`` (a peripheral neuroblastic / neural-crest
-    embryonal tumour, not an epithelial NEN). Overrides inherit down the
-    ``parent_code`` chain, so e.g. SCLC_ASCL1 follows SCLC."""
+    their registry ``family`` default. NEC and NET are kept together under one
+    ``Neuroendocrine`` group; the one exception is neuroblastoma -> ``Embryonal``
+    (a peripheral neuroblastic / neural-crest embryonal tumour, not an epithelial
+    NEN). Overrides inherit down the ``parent_code`` chain, so e.g. NBL_MYCNamp
+    follows NBL."""
     df = get_data("cancer-lineage-group-overrides")
     return dict(df[["code", "lineage_group"]].itertuples(index=False, name=None))
 
 
 def cancer_lineage_group(cancer_type):
-    """Coarse histogenesis group (Epithelial / Sarcoma / NEC / NET / CNS /
+    """Coarse histogenesis group (Epithelial / Sarcoma / Neuroendocrine / CNS /
     Melanoma / Heme / Germ cell / Embryonal) for a code, alias, or display name.
     Resolution: a per-code override (inherited up the ``parent_code`` chain) if
     one applies, else the registry ``family`` default. Returns ``None`` if the

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.77"
+__version__ = "5.22.78"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_cancer_type_registry.py
+++ b/tests/test_cancer_type_registry.py
@@ -22,7 +22,7 @@ from pirlygenes.gene_sets_cancer import (
 
 
 _LINEAGE_GROUPS = {
-    "Epithelial", "Sarcoma", "Heme", "CNS", "NEC", "NET",
+    "Epithelial", "Sarcoma", "Heme", "CNS", "Neuroendocrine",
     "Melanoma", "Germ cell", "Embryonal",
 }
 
@@ -57,18 +57,15 @@ def test_cancer_lineage_group_resolves_codes_and_histogenesis():
     assert cancer_lineage_group("not-a-cancer") is None
 
 
-def test_neuroendocrine_split_nec_net_and_neuroblastoma():
-    # The neuroendocrine family splits by histogenesis + immunotherapy behaviour:
-    # high-grade NE carcinomas -> NEC (immune-responsive), well-differentiated
-    # NETs -> NET (immune-cold), and neuroblastoma is an embryonal neural-crest
-    # tumour, not an epithelial NEN.
-    assert cancer_lineage_group("SCLC") == "NEC"
-    assert cancer_lineage_group("SCLC_ASCL1") == "NEC"           # inherits via parent
-    assert cancer_lineage_group("NEC_MERKEL") == "NEC"
-    assert cancer_lineage_group("NEC_LUNG_LARGECELL") == "NEC"
-    assert cancer_lineage_group("NET_PANCREAS") == "NET"
-    assert cancer_lineage_group("NET_MIDGUT") == "NET"
-    assert cancer_lineage_group("MTC") == "NET"
+def test_neuroendocrine_grouping_and_neuroblastoma():
+    # NEC and NET are kept together under one coarse Neuroendocrine group, but
+    # neuroblastoma is pulled out to Embryonal — it's a peripheral neuroblastic
+    # neural-crest embryonal tumour, not an epithelial NEN (override, inherited
+    # down the parent_code chain).
+    assert cancer_lineage_group("SCLC") == "Neuroendocrine"
+    assert cancer_lineage_group("NEC_MERKEL") == "Neuroendocrine"
+    assert cancer_lineage_group("NET_PANCREAS") == "Neuroendocrine"
+    assert cancer_lineage_group("MTC") == "Neuroendocrine"
     assert cancer_lineage_group("NBL") == "Embryonal"
     assert cancer_lineage_group("NBL_MYCNamp") == "Embryonal"    # inherits via parent
 


### PR DESCRIPTION
Per request: fold NEC/NET back into a single **Neuroendocrine** coarse group (the split was finer than wanted for colouring). The one retained override is **neuroblastoma -> Embryonal**. Back to 8 groups.