### PR TITLE
Plot batch: uniform collapse + ICI naming + integer axis + label de-overlap

### DIFF
--- a/analyses/apd1_response_plots.py
+++ b/analyses/apd1_response_plots.py
@@ -141,12 +141,16 @@ def _plot_tmb_vs_apd1(orr, tmb, colors, proxy=None, dual=None, *,
             ax.scatter(x, y, s=42, color=fam_color, edgecolor="white",
                        linewidth=0.4, marker="o", zorder=3)
             suffix = ""
-        texts.append(ax.text(x, y, f"{code}{suffix}", fontsize=6.5))
-    # de-overlap the labels (adjustText if available; else a fixed nudge)
+        texts.append(ax.text(x, y, f"{code}{suffix}", fontsize=6))
+    # de-overlap the labels. Stronger repulsion + more iterations untangles the
+    # dense low-TMB/low-ORR lower-left cluster; min_arrow_len drops the short
+    # leader lines (which just add clutter when a label barely moved) and keeps
+    # one only when a label is pulled far enough to need its anchor.
     if adjust_text is not None and texts:
-        adjust_text(texts, ax=ax,
-                    arrowprops=dict(arrowstyle="-", color="0.6", lw=0.4),
-                    expand=(1.05, 1.2))
+        adjust_text(texts, ax=ax, expand=(1.25, 1.6),
+                    force_text=(0.5, 0.8), max_move=60, iter_lim=200,
+                    min_arrow_len=12,
+                    arrowprops=dict(arrowstyle="-", color="0.6", lw=0.3))
     else:
         for t in texts:
             t.set_position((t.get_position()[0], t.get_position()[1]))

--- a/analyses/cta_covering_set.py
+++ b/analyses/cta_covering_set.py
@@ -28,6 +28,7 @@ import pandas as pd
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
 
 import pirlygenes.expression.accessors as accessors
 import pirlygenes.gene_sets_cancer as gsc
@@ -72,7 +73,9 @@ def cta_matrices() -> dict[str, pd.DataFrame]:
     type), so q3 is the clinically relevant bar for "a meaningful fraction
     of patients have this target" — median alone hides them.
     """
-    df = accessors.cancer_reference_expression()
+    # collapse cDNA-identical loci (centralized proteoform collapse) so a covering
+    # set counts one XAGE1 (=XAGE1A+XAGE1B), not split paralogs.
+    df = accessors.cancer_reference_expression(collapse_cdna_identical=True)
     rep = _representative_source(df)
     keep = set(zip(rep["cancer_code"], rep["source_cohort"]))
     cta_ids = set(gsc.CTA_gene_ids())
@@ -197,6 +200,7 @@ def main() -> None:
     pct_axis(ax, "y")
     ax.set_title("CTA covering set — cumulative patient coverage")
     ax.set_xlim(left=1)
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))  # panel size is a count
     ax.legend(title="actionable if TPM> bar at:")
     ax.grid(True, alpha=0.3)
     fig.tight_layout()

--- a/analyses/cta_expression_heatmaps.py
+++ b/analyses/cta_expression_heatmaps.py
@@ -356,7 +356,10 @@ def main() -> None:
     args = ap.parse_args()
     _, FIGDIR = resolve_dirs(args, OUT_DIR)
     print("loading cancer reference expression...")
-    df = accessors.cancer_reference_expression()
+    # collapse cDNA-identical loci (the centralized proteoform collapse) so the
+    # heatmap shows one XAGE1 (=XAGE1A+XAGE1B), not split paralogs — same view as
+    # every other CTA quant site.
+    df = accessors.cancer_reference_expression(collapse_cdna_identical=True)
 
     matrices: dict = {}
     for metric, metric_label in COHORT_METRICS:

--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -1211,10 +1211,13 @@ def _tmb_axis() -> _XAxis:
 
 @lru_cache(maxsize=1)
 def _apd1_axis() -> _XAxis:
-    # Empty sweet_label -> no shaded sweet-spot band on the aPD-1 axis.
+    # cancer_apd1_response() now returns mixed immune-checkpoint classes
+    # (anti-PD-1 mono + anti-PD-L1 proxy + dual ipi+nivo), so this axis is the
+    # ICI response, not strictly anti-PD-1. Slug "ici" -> cta_*_vs_ici folders.
+    # Empty sweet_label -> no shaded sweet-spot band.
     return _XAxis(
-        "apd1", "anti-PD-1 response",
-        "anti-PD-1 monotherapy ORR", False,
+        "ici", "immune-checkpoint (ICI) response",
+        "ICI objective response rate", False,
         _axis_value_map(gsc.cancer_apd1_response()), 10.0, "", pct=True)
 
 
@@ -1576,14 +1579,14 @@ def _tmb_vs_apd1():
                     arrowprops=dict(arrowstyle="-", color="0.6", lw=0.4))
     except ImportError:
         pass
-    ax.set_title(f"anti-PD-1 ORR vs TMB by cancer type (n={len(pts)} cohorts)",
+    ax.set_title(f"ICI response vs TMB by cancer type (n={len(pts)} cohorts)",
                  fontsize=10)
     fig.tight_layout()
-    # single-plot output: write flat (apd1_vs_tmb.png), no one-file folder
+    # single-plot output: write flat (ici_vs_tmb.png), no one-file folder
     FIGDIR.mkdir(parents=True, exist_ok=True)
-    fig.savefig(FIGDIR / "apd1_vs_tmb.png", dpi=300)
+    fig.savefig(FIGDIR / "ici_vs_tmb.png", dpi=300)
     plt.close(fig)
-    print(f"      apd1_vs_tmb: {len(pts)} cohorts", flush=True)
+    print(f"      ici_vs_tmb: {len(pts)} cohorts", flush=True)
 
 
 def _mean_ctas_per_sample(mat, cols, thr, pctile_cutoffs):

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.78"
+__version__ = "5.22.79"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Knocks out four review items:
- **#24 proteoform collapse uniform** — `cta_expression_heatmaps` + `cta_covering_set` were the only quant sites not opting into the centralized cDNA collapse (default False), so they showed XAGE1A vs XAGE1B split. Now pass `collapse_cdna_identical=True`. Audit: every gene-quant site now uses the one shared collapse.
- **#26 ICI naming** — the cohort scatters' axis pulls `cancer_apd1_response()`, which now holds mixed checkpoint classes, so it's relabelled **immune-checkpoint (ICI)** and the slug `apd1`->`ici` (`cta_*_vs_ici`, context `ici_vs_tmb.png`).
- **#27 integer axis** — '# CTAs in panel' forced to integer ticks.
- **#29 labels** — stronger repulsion + `min_arrow_len` drops short leader lines in the dense lower-left.

Lint passes.