### PR TITLE
Fold COAD/READ into CRC after aggregate built (#28 follow-up)

### DIFF
--- a/analyses/cta_patient_counts.py
+++ b/analyses/cta_patient_counts.py
@@ -466,12 +466,10 @@ def _add_crc_subtype_cohorts(cohorts):
             added.append(f"{agg}(n={len(pooled)})")
         for m in members:                      # fold the components into the tier
             cohorts.pop(m, None)
-    if "CRC" in cohorts:                        # prefer the colorectal aggregate
-        for organ in ("COAD", "READ"):
-            cohorts.pop(organ, None)
+    # NB: plain COAD/READ are folded into the CRC aggregate in main(), AFTER
+    # _add_aggregate_cohorts builds CRC (it doesn't exist yet here).
     if added:
-        print(f"      + CRC subtype cohorts: {', '.join(added)} "
-              f"(COAD/READ folded in)", flush=True)
+        print(f"      + CRC subtype cohorts: {', '.join(added)}", flush=True)
     return cohorts
 
 
@@ -676,7 +674,13 @@ def main():
     mat = extract_cta_matrix(ensg_to_sym)
     mat, cohorts = _add_parquet_cohorts(mat, cohorts, ctas)
     cohorts = _add_crc_subtype_cohorts(cohorts)
-    cohorts = _add_aggregate_cohorts(cohorts)
+    cohorts = _add_aggregate_cohorts(cohorts)   # materialises CRC = COAD+READ
+    # now that the colorectal aggregate exists, fold the organ-split halves into
+    # it (KEYNOTE-177 etc. report *colorectal*) — done here, not in
+    # _add_crc_subtype_cohorts, because CRC isn't built until the line above.
+    if "CRC" in cohorts:
+        for organ in ("COAD", "READ"):
+            cohorts.pop(organ, None)
     cohorts = _add_subtype_intermediates(cohorts)
     mat, ensg_to_sym = _merge_proteins(mat, ensg_to_sym)
     print(f"      matrix {mat.shape[0]} CTA proteins × {mat.shape[1]} samples, "

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.81"
+__version__ = "5.22.82"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
The plain COAD/READ->CRC fold was guarded on `CRC in cohorts` but CRC is materialised *later* by `_add_aggregate_cohorts`, so the guard never fired and COAD/READ kept appearing next to CRC in the regenerated coverage table. Moved the drop to right after CRC is built. (MSI/MSS pooling already worked; NUTM n=4 confirmed.)