### PR TITLE
Secreted-exclusion 4-gene panel (TGFB1+WNT5A+WNT11+IL10) + per-gene heatmap columns

### DIFF
--- a/analyses/ici_landscape.py
+++ b/analyses/ici_landscape.py
@@ -54,9 +54,13 @@ _WNT = "aPD1_exclusion_Wnt"
 #   WNT11 — secreted Wnt drives beta-catenin CD8 exclusion (down CXCL10/CCL4) and
 #           anti-PD-1 resistance (Lu et al. 2025, Nat Commun, 10.1038/s41467-025-56714-z);
 #           upregulated in ovarian-serous / gastric / papillary-RCC.
-# (WNT5A — Holtzhausen 2015 tolerogenic-DC Wnt — is the obvious third if a panel
-# is preferred over a strict pair.)
-_SECRETED_INHIBITORY = ["TGFB1", "WNT11"]
+#   WNT5A — secreted Wnt drives tolerogenic DCs (IDO -> Treg) / immune evasion
+#           (Holtzhausen 2015, Cancer Immunol Res, PMID 26041736).
+#   IL10  — general secreted immunosuppressive cytokine (Treg/M2); included to
+#           check whether it carries any per-cohort signal vs the exclusion genes.
+# Shown as individual columns in the causal heatmap (each gene's Spearman vs ORR
+# visible) and averaged into the favourability suppression term.
+_SECRETED_INHIBITORY = ["TGFB1", "WNT5A", "WNT11", "IL10"]
 
 
 def _z(s):
@@ -104,21 +108,23 @@ def _factors():
         "Wnt/β-catenin": sigscore(_WNT),
     })
     inhib = [g for g in _SECRETED_INHIBITORY if g in mat.columns]
-    df["secreted inhibitory"] = (mat[inhib].apply(_z).mean(axis=1) if inhib
-                                 else np.nan)
+    for g in inhib:                     # individual z-cols (shown in the heatmap)
+        df[g] = _z(mat[g])
+    df["secreted inhibitory"] = df[inhib].mean(axis=1) if inhib else np.nan
     return df
 
 
 # --------------------------------------------------------------------------
 def _causal_heatmap(df):
     drivers = ["ICI ORR", "TMB", "CTA burden", "viral"]
-    suppr = ["TGFβ", "Wnt/β-catenin"]
+    genes = [g for g in _SECRETED_INHIBITORY if g in df.columns]
+    suppr = ["TGFβ", "Wnt/β-catenin"] + genes      # pathway signatures + secreted genes
     cols = drivers + suppr
     Z = df[cols].apply(_z)
     order = df["ICI ORR"].sort_values(ascending=False).index
     Zo = Z.loc[order]
 
-    fig, ax = plt.subplots(figsize=(7.5, max(8, 0.21 * len(order))))
+    fig, ax = plt.subplots(figsize=(0.7 * len(cols) + 4.5, max(8, 0.21 * len(order))))
     norm = TwoSlopeNorm(vmin=-2.0, vcenter=0.0, vmax=2.0)
     im = ax.imshow(Zo.values, cmap="RdBu_r", norm=norm, aspect="auto")
     ax.set_xticks(range(len(cols)))
@@ -172,7 +178,7 @@ def _antigen_load(df):
 def _favorability(df):
     """Net ICI-favourability composite = mean of the DIRECTIONAL percentile-ranks
     of the antigen drivers (CTA burden, TMB, viral — high is favourable) and the
-    secreted suppression term (TGFB1+WNT11 — high is UNfavourable, so its rank is
+    secreted suppression term (TGFB1/WNT5A/WNT11/IL10 — high is UNfavourable, so its rank is
     inverted). A single 0-100 score combining 'how much antigen' with 'how much
     secreted brake'."""
     pos = df[["CTA burden", "TMB", "viral"]].rank(pct=True)
@@ -187,11 +193,11 @@ def _favorability(df):
     ax.set_yticks(range(len(score)))
     ax.set_yticklabels(score.index, fontsize=7)
     ax.set_xlabel("ICI-favourability  (mean directional rank: +CTA +TMB +viral "
-                  "−secreted TGFB1/WNT11)")
+                  "−secreted exclusion panel)")
     ax.set_xlim(0, 100)
     ax.set_title("Net ICI-favourability composite by cancer type\n"
                  "antigen load (CTA + TMB + viral) minus secreted exclusion "
-                 "(TGFB1 + WNT11)", fontsize=10)
+                 "(TGFB1 + WNT5A + WNT11 + IL10)", fontsize=10)
     ax.grid(axis="x", alpha=0.3)
     handles = [Line2D([], [], marker="o", linestyle="", color=colors[g], label=g)
                for g in sorted(colors)]

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.86"
+__version__ = "5.22.87"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,


### PR DESCRIPTION
Per request: WNT5A added (Holtzhausen 2015 tolerogenic-DC Wnt), IL10 kept in to test for signal. The causal heatmap now shows each secreted gene as its own column with Spearman-vs-ORR; the favourability composite averages the 4-gene panel as the rank-inverted suppression term.

**Honest finding:** at cohort/pseudobulk level all four 'suppressors' weakly *positively* correlate with ORR (TGFB1 +0.20, WNT5A +0.15, WNT11 +0.21, IL10 +0.21) — they co-express with immune infiltrate, so the exclusion sign is confounded at this resolution (the suppression effect is per-sample/spatial). IL10 carries about the same weak signal as the exclusion genes.