### PR TITLE
perf: store provenance columns as category (10x faster reference-frame load)

### DIFF
--- a/pirlygenes/load_dataset.py
+++ b/pirlygenes/load_dataset.py
@@ -130,12 +130,23 @@ def get_all_csv_paths() -> list:
 # repeated across every gene row — the ~130 distinct `notes` strings alone span
 # 4.8M rows (3.3 GB as object). Stored as `object` the concatenated
 # cancer-reference-expression frame is ~8 GB and its cached-parquet read ~10 s;
-# casting just these three to `category` drops it to ~2.9 GB and ~2 s — paid once
-# per process (every xdist worker, script and plot run). Deliberately limited to
-# columns that are pure display/provenance and never participate in computation:
-# the cohort-availability and pooling code reindex-/fillna-/assign on
-# source_cohort / source_project / tumor_origin / cancer_code, where a
-# categorical's "no new category" rule would break callers, so those stay object.
+# casting just these three to `category` drops it to ~3 GB and ~1 s — paid once
+# per process (every xdist worker, script and plot run).
+#
+# A `category` is only a codes+dictionary *encoding* of the same strings: the
+# values, NaNs, ==, .str and groupby results are byte-identical to the object
+# column (asserted element-wise in test_load_dataset). Only operations that
+# introduce a NEW category at the array level (.loc/.iloc/.at setitem, .fillna,
+# .replace, reindex-fill) raise on a categorical — so this is deliberately
+# limited to columns that are pure display/provenance and never computed on:
+# the cohort-availability code reindex-/fillna-s on source_cohort /
+# source_project / tumor_origin / cancer_code (a categorical's "no new category"
+# rule would break those), so they stay object.
+#
+# NOTE the pooling path does `g["processing_pipeline"] = "pooled_n_weighted"`,
+# a value not among the categories. That stays safe ONLY because whole-column
+# scalar assignment REPLACES the column (-> a fresh object column), not an
+# in-place categorical setitem; do not switch it to .loc/.fillna on these cols.
 _LOW_CARDINALITY_METADATA_COLS = (
     "source_version", "processing_pipeline", "notes",
 )
@@ -183,7 +194,7 @@ def _load_shard_directory(shard_dir: Path) -> pd.DataFrame:
         pass  # any cache-read problem -> rebuild from the authoritative CSVs
     df = pd.concat([pd.read_csv(str(p), low_memory=False) for p in paths],
                    ignore_index=True)
-    _categorize_metadata(df)
+    df = _categorize_metadata(df)
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
         df.to_parquet(cache_file, index=False)

--- a/pirlygenes/load_dataset.py
+++ b/pirlygenes/load_dataset.py
@@ -135,7 +135,8 @@ def get_all_csv_paths() -> list:
 #
 # A `category` is only a codes+dictionary *encoding* of the same strings: the
 # values, NaNs, ==, .str and groupby results are byte-identical to the object
-# column (asserted element-wise in test_load_dataset). Only operations that
+# column (asserted element-wise on representative data in test_load_dataset).
+# Only operations that
 # introduce a NEW category at the array level (.loc/.iloc/.at setitem, .fillna,
 # .replace, reindex-fill) raise on a categorical — so this is deliberately
 # limited to columns that are pure display/provenance and never computed on:
@@ -156,7 +157,8 @@ _SHARD_CACHE_FORMAT = 3
 
 
 def _categorize_metadata(df: pd.DataFrame) -> pd.DataFrame:
-    """Cast the low-cardinality provenance columns to ``category`` in place."""
+    """Cast the low-cardinality provenance columns to ``category`` in place and
+    return ``df`` (returned for convenient chaining at the call sites)."""
     for col in _LOW_CARDINALITY_METADATA_COLS:
         if col in df.columns and not isinstance(
                 df[col].dtype, pd.CategoricalDtype):

--- a/pirlygenes/load_dataset.py
+++ b/pirlygenes/load_dataset.py
@@ -126,21 +126,51 @@ def get_all_csv_paths() -> list:
     return list(seen.values())
 
 
+# Pure-text provenance columns: a handful of distinct values (long strings)
+# repeated across every gene row — the ~130 distinct `notes` strings alone span
+# 4.8M rows (3.3 GB as object). Stored as `object` the concatenated
+# cancer-reference-expression frame is ~8 GB and its cached-parquet read ~10 s;
+# casting just these three to `category` drops it to ~2.9 GB and ~2 s — paid once
+# per process (every xdist worker, script and plot run). Deliberately limited to
+# columns that are pure display/provenance and never participate in computation:
+# the cohort-availability and pooling code reindex-/fillna-/assign on
+# source_cohort / source_project / tumor_origin / cancer_code, where a
+# categorical's "no new category" rule would break callers, so those stay object.
+_LOW_CARDINALITY_METADATA_COLS = (
+    "source_version", "processing_pipeline", "notes",
+)
+# Bump when the cached dtype scheme changes so stale object-dtype parquets in an
+# existing ``~/.cache/pirlygenes/shard_cache/`` rebuild instead of being reused.
+_SHARD_CACHE_FORMAT = 3
+
+
+def _categorize_metadata(df: pd.DataFrame) -> pd.DataFrame:
+    """Cast the low-cardinality provenance columns to ``category`` in place."""
+    for col in _LOW_CARDINALITY_METADATA_COLS:
+        if col in df.columns and not isinstance(
+                df[col].dtype, pd.CategoricalDtype):
+            df[col] = df[col].astype("category")
+    return df
+
+
 def _load_shard_directory(shard_dir: Path) -> pd.DataFrame:
     """Concatenate every ``*.csv[.gz]`` shard in a sharded dataset directory.
 
-    Parsing ~70 gzipped CSVs into a ~1M-row frame is the slowest single step in
-    the test suite, and a fresh process repeats it every run. So we keep a
+    Parsing ~70 gzipped CSVs into a multi-million-row frame is the slowest single
+    step in the test suite, and a fresh process repeats it every run. So we keep a
     best-effort **parquet cache** of the concatenated frame in
     ``~/.cache/pirlygenes/shard_cache/``, keyed on a signature of the shard
-    files (count + total size + newest mtime). A subsequent run reads one parquet
-    (~5-10x faster) instead of re-parsing every gzip; the cache auto-invalidates
-    when any shard changes, and any cache error silently falls back to the CSVs.
+    files (count + total size + newest mtime) and the cache format. A subsequent
+    run reads one parquet (~7-10x faster) instead of re-parsing every gzip; the
+    cache auto-invalidates when any shard changes, and any cache error silently
+    falls back to the CSVs. Low-cardinality provenance columns are stored as
+    ``category`` (see :data:`_LOW_CARDINALITY_METADATA_COLS`).
     """
     paths = _shard_paths(shard_dir)
     if not paths:
         raise FileNotFoundError(f"no CSV shards found under {shard_dir}")
-    sig = repr((len(paths), sum(p.stat().st_size for p in paths),
+    sig = repr((_SHARD_CACHE_FORMAT, len(paths),
+                sum(p.stat().st_size for p in paths),
                 max(p.stat().st_mtime_ns for p in paths)))
     cache_dir = Path.home() / ".cache" / "pirlygenes" / "shard_cache"
     cache_file = cache_dir / f"{shard_dir.name}.parquet"
@@ -148,11 +178,12 @@ def _load_shard_directory(shard_dir: Path) -> pd.DataFrame:
     try:
         if (cache_file.exists() and sig_file.exists()
                 and sig_file.read_text() == sig):
-            return pd.read_parquet(cache_file)
+            return _categorize_metadata(pd.read_parquet(cache_file))
     except Exception:
         pass  # any cache-read problem -> rebuild from the authoritative CSVs
     df = pd.concat([pd.read_csv(str(p), low_memory=False) for p in paths],
                    ignore_index=True)
+    _categorize_metadata(df)
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
         df.to_parquet(cache_file, index=False)

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.103"
+__version__ = "5.22.104"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -497,3 +497,45 @@ def test_stem_cell_marker_panels_355():
     df = gsc.stem_cell_panels_df()
     assert (df["Ensembl_Gene_ID"].str.match(r"^ENSG\d+$")).all()
     assert set(df["program"]) == {"pluripotent", "tissue_specific"}
+
+
+def test_reference_provenance_columns_are_categorical():
+    """Regression guard for the shard-cache memory/load-time optimization: the
+    pure-text provenance columns must load as ``category`` (a future change that
+    drops one from the set, or a pandas upgrade that re-materializes objects,
+    would otherwise silently regress the ~10x load speedup)."""
+    df = ld.get_data("cancer-reference-expression", copy=False)
+    for col in ld._LOW_CARDINALITY_METADATA_COLS:
+        assert isinstance(df[col].dtype, pd.CategoricalDtype), col
+        # builders always stamp these, so a NaN here would signal a load bug
+        assert df[col].notna().all(), col
+
+
+def test_categorize_metadata_is_a_lossless_encoding(tmp_path):
+    """A ``category`` is only a codes+dictionary encoding — it must never change a
+    value. Guards the specific worry that the dtype switch could alter the
+    strings: every value (incl. NaN, unicode, long repeated strings) survives the
+    cast AND a parquet round-trip byte-identical to the original object column."""
+    import numpy as np
+    raw = pd.DataFrame({
+        "notes": ["a long provenance sentence — with unicode é/μ", "x", np.nan,
+                  "a long provenance sentence — with unicode é/μ", "x"],
+        "source_version": ["v1.0", "v1.0", "v2.0", "v1.0", np.nan],
+        "processing_pipeline": ["p_a", "p_b", "p_a", "p_a", "p_b"],
+        "cancer_code": ["AAA", "BBB", "AAA", "CCC", "BBB"],  # not in the set
+    })
+    before = raw.copy()
+    out = ld._categorize_metadata(raw)
+    for col in ld._LOW_CARDINALITY_METADATA_COLS:
+        assert isinstance(out[col].dtype, pd.CategoricalDtype)
+        pd.testing.assert_series_equal(
+            out[col].astype(object), before[col].astype(object), check_names=False)
+    # untouched column keeps its dtype
+    assert out["cancer_code"].dtype == object
+    # survives the parquet cache round-trip unchanged
+    path = tmp_path / "roundtrip.parquet"
+    out.to_parquet(path, index=False)
+    back = pd.read_parquet(path)
+    for col in ld._LOW_CARDINALITY_METADATA_COLS:
+        pd.testing.assert_series_equal(
+            back[col].astype(object), before[col].astype(object), check_names=False)

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -516,7 +517,6 @@ def test_categorize_metadata_is_a_lossless_encoding(tmp_path):
     value. Guards the specific worry that the dtype switch could alter the
     strings: every value (incl. NaN, unicode, long repeated strings) survives the
     cast AND a parquet round-trip byte-identical to the original object column."""
-    import numpy as np
     raw = pd.DataFrame({
         "notes": ["a long provenance sentence — with unicode é/μ", "x", np.nan,
                   "a long provenance sentence — with unicode é/μ", "x"],

--- a/tests/test_load_dataset_and_gene_sets.py
+++ b/tests/test_load_dataset_and_gene_sets.py
@@ -530,8 +530,10 @@ def test_categorize_metadata_is_a_lossless_encoding(tmp_path):
         assert isinstance(out[col].dtype, pd.CategoricalDtype)
         pd.testing.assert_series_equal(
             out[col].astype(object), before[col].astype(object), check_names=False)
-    # untouched column keeps its dtype
-    assert out["cancer_code"].dtype == object
+    # untouched column keeps its original dtype (whatever pandas inferred —
+    # object on pandas 2, the new StringDtype on pandas 3) and is NOT categorical
+    assert out["cancer_code"].dtype == before["cancer_code"].dtype
+    assert not isinstance(out["cancer_code"].dtype, pd.CategoricalDtype)
     # survives the parquet cache round-trip unchanged
     path = tmp_path / "roundtrip.parquet"
     out.to_parquet(path, index=False)


### PR DESCRIPTION
## Win

| metric | before | after |
|---|---|---|
| reference-frame load (per process) | ~10 s | ~1 s |
| in-memory size | 7.9 GB | 3.0 GB |
| full test suite | ~130 s | ~60 s |

## Why
The concatenated `cancer-reference-expression` frame is **4.8M rows**; three pure-text provenance columns dominate it: `notes` (~130 distinct 553-char strings repeated across every gene row = **3.3 GB**), `source_version` (1.2 GB), `processing_pipeline` (0.6 GB). As `object` the frame is ~8 GB and its cached-parquet read ~10 s — paid once per process by every xdist worker, script, and plot run.

## What
Cast just those three columns to `category` in the shard-cache parquet. The parquet already dictionary-encoded the strings, so file size barely changes — the speedup is from not materializing 4.8M Python string objects on read.

Limited to pure display/provenance columns that never participate in computation. `source_cohort`/`source_project`/`tumor_origin`/`cancer_code` stay `object`: the cohort-availability and pooling code reindex/fillna/assign on them, where a categorical's no-new-category rule breaks callers (verified: categorizing those → 13 failures; this scope → 567 pass). Cache format tag bumped so stale caches rebuild.