### PR TITLE
gene_ids: cached cross-release union id-index (kill per-id sqlite fallback)

### DIFF
--- a/pirlygenes/gene_ids.py
+++ b/pirlygenes/gene_ids.py
@@ -147,13 +147,20 @@ _MIN_SANE_GENE_COUNT = 1000
 _MIN_SANE_TRANSCRIPT_COUNT = 5000
 
 
-def _load_index_cache(release: int):
+def _load_index_cache(release: int, installed_releases=None):
     """Return (gene_dict, transcript_dict) from the pickle cache, or None.
 
     Each subprocess pays ~2s to walk pyensembl's gene/transcript tables
     when first resolving Ensembl IDs. Loading the prebuilt dicts from
-    a single ~5MB pickle is sub-300ms and is shared across the OS page
-    cache when many processes mmap the same file."""
+    a single ~14MB pickle is sub-300ms and is shared across the OS page
+    cache when many processes mmap the same file.
+
+    The cached map is a *union* across every installed release (see
+    ``_build_indexes``), so it is keyed not just by the newest release but
+    by the full installed-release list: pass ``installed_releases`` and the
+    cache is rejected (forcing a rebuild) when that set has changed — e.g. a
+    new annotation was downloaded, or a previously-empty release gained data.
+    """
     import pickle as _pickle
     path = _index_cache_path(release)
     if not path.exists():
@@ -164,6 +171,11 @@ def _load_index_cache(release: int):
         if not isinstance(payload, dict):
             return None
         if payload.get("release") != release:
+            return None
+        if installed_releases is not None and payload.get(
+            "installed_releases"
+        ) != list(installed_releases):
+            # Built against a different set of installed releases — stale.
             return None
         gene_map = payload["gene_id_to_name"]
         transcript_map = payload["transcript_id_to_gene_name"]
@@ -178,7 +190,19 @@ def _load_index_cache(release: int):
         return None
 
 
-def _store_index_cache(release: int, gene_map: dict, transcript_map: dict) -> None:
+def _store_index_cache(
+    release: int, gene_map: dict, transcript_map: dict, installed_releases=None
+) -> None:
+    if (
+        len(gene_map) < _MIN_SANE_GENE_COUNT
+        or len(transcript_map) < _MIN_SANE_TRANSCRIPT_COUNT
+    ):
+        # Refuse to persist a degenerate index. An empty/partial build (e.g. the
+        # newest installed release has no usable GTF, so its tables come back
+        # empty) must never be written — a tiny pickle would otherwise be loaded
+        # back as "the index" and force every lookup onto the slow per-id sqlite
+        # fallback. (This is what produced the stray 79-byte caches.)
+        return
     import pickle as _pickle
     path = _index_cache_path(release)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -188,6 +212,9 @@ def _store_index_cache(release: int, gene_map: dict, transcript_map: dict) -> No
             _pickle.dump(
                 {
                     "release": release,
+                    "installed_releases": list(installed_releases)
+                    if installed_releases is not None
+                    else None,
                     "gene_id_to_name": gene_map,
                     "transcript_id_to_gene_name": transcript_map,
                 },
@@ -200,6 +227,55 @@ def _store_index_cache(release: int, gene_map: dict, transcript_map: dict) -> No
             tmp.unlink(missing_ok=True)
 
 
+def _release_id_maps(genome):
+    """Return ``(gene_id->name, transcript_id->gene_name)`` for one release.
+
+    Fast path: query the release's gtf sqlite directly — a single
+    ``SELECT transcript_id, gene_name FROM transcript`` pulls a full human
+    release in ~0.3s, versus ~130s to walk ``genome.transcripts()`` (which
+    materializes a Python ``Transcript`` object per row). The direct query is
+    also the natural "does this release actually have data?" probe: a release
+    whose GTF was never built raises here, so we return ``(None, None)`` and
+    skip it instead of indexing an empty map.
+
+    Compatibility path: if the direct query fails (older/newer pyensembl with
+    a different schema, or a non-pyensembl genome such as a unit-test fake),
+    fall back to the public ``genes()`` / ``transcripts()`` walk so the union
+    is still correct, just slower.
+    """
+    # Fast path — direct SQL against the gtf sqlite.
+    try:
+        conn = genome.db.connection
+        tx_rows = conn.execute(
+            "SELECT transcript_id, gene_name FROM transcript"
+        ).fetchall()
+        gene_rows = conn.execute("SELECT gene_id, gene_name FROM gene").fetchall()
+        txs = {strip_version(t): n for t, n in tx_rows if t and n}
+        if len(txs) >= _MIN_SANE_TRANSCRIPT_COUNT:
+            genes = {strip_version(gid): n for gid, n in gene_rows if gid and n}
+            return genes, txs
+    except Exception:
+        pass
+    # Compatibility path — public object walk (also covers test fakes).
+    genes: dict = {}
+    txs = {}
+    try:
+        for gene in genome.genes():
+            if gene.id and gene.name:
+                genes[strip_version(gene.id)] = gene.name
+    except Exception:
+        pass
+    try:
+        for t in genome.transcripts():
+            if t.id and t.gene_name:
+                txs[strip_version(t.id)] = t.gene_name
+    except Exception:
+        pass
+    if not genes and not txs:
+        return None, None
+    return genes, txs
+
+
 def _build_indexes():
     global _gene_id_to_name, _transcript_id_to_gene_name, _indexes_built
     if _indexes_built:
@@ -207,32 +283,53 @@ def _build_indexes():
     if not genomes:
         _indexes_built = True
         return
-    g = genomes[0]
-    cached = _load_index_cache(g.release)
+    # Build (and cache) a *union* id->name map across every installed release,
+    # newest-first so the newest annotation wins on conflict. This is the eager,
+    # precomputed form of the lazy per-id older-release fallback below: a
+    # transcript retired before the newest release still resolves as a single
+    # dict hit instead of a per-id sqlite probe across older genomes.
+    #
+    # Keyed on the newest installed release but validated against the full
+    # installed-release list, so the cache rebuilds when annotations change. The
+    # newest *installed* release can have no usable GTF (pyensembl lists it but
+    # its tables are empty); indexing that release alone used to poison the cache
+    # with an empty map and push EVERY lookup onto the slow fallback (~1.5M
+    # sqlite queries per file). The union naturally skips such empty releases.
+    installed = [g.release for g in genomes]
+    key_release = installed[0]
+    cached = _load_index_cache(key_release, installed_releases=installed)
     if cached is not None:
         _gene_id_to_name, _transcript_id_to_gene_name = cached
         print(
             f"[index] Loaded {len(_gene_id_to_name)} genes, "
             f"{len(_transcript_id_to_gene_name)} transcripts from cache "
-            f"(release {g.release})"
+            f"(release {key_release}, union of {installed})"
         )
         _indexes_built = True
         return
-    print(f"[index] Building gene/transcript index from Ensembl release {g.release}...")
-    try:
-        for gene in g.genes():
-            _gene_id_to_name[strip_version(gene.id)] = gene.name
-    except Exception:
-        pass
-    try:
-        for t in g.transcripts():
-            _transcript_id_to_gene_name[strip_version(t.id)] = t.gene_name
-    except Exception:
-        pass
     print(
-        f"[index] {len(_gene_id_to_name)} genes, {len(_transcript_id_to_gene_name)} transcripts indexed"
+        f"[index] Building union gene/transcript index across installed "
+        f"releases {installed}..."
     )
-    _store_index_cache(g.release, _gene_id_to_name, _transcript_id_to_gene_name)
+    for genome in genomes:  # newest-first; setdefault => newest name wins
+        genes, txs = _release_id_maps(genome)
+        if genes:
+            for gid, name in genes.items():
+                _gene_id_to_name.setdefault(gid, name)
+        if txs:
+            for tid, name in txs.items():
+                _transcript_id_to_gene_name.setdefault(tid, name)
+    print(
+        f"[index] {len(_gene_id_to_name)} genes, "
+        f"{len(_transcript_id_to_gene_name)} transcripts indexed "
+        f"(union of {installed})"
+    )
+    _store_index_cache(
+        key_release,
+        _gene_id_to_name,
+        _transcript_id_to_gene_name,
+        installed_releases=installed,
+    )
     _indexes_built = True
 
 

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.104"
+__version__ = "5.22.105"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/tests/test_gene_ids_unit.py
+++ b/tests/test_gene_ids_unit.py
@@ -150,6 +150,76 @@ def test_lookup_functions_fall_back_to_older_release_on_latest_miss(
     )
 
 
+def test_build_indexes_skips_empty_newest_release_and_eager_unions_older(
+    monkeypatch, tmp_path,
+):
+    """The newest *installed* release can have no usable GTF (empty tables).
+    Indexing it alone used to poison the cache with an empty map and force every
+    lookup onto the per-id sqlite fallback. The union build must skip the empty
+    newest release and index the older release *eagerly* (the id lands in the
+    map directly, not via the lazy fallback)."""
+    tx = SimpleNamespace(gene_name="REALGENE")
+    genomes = [
+        FakeGenome(release=115),  # newest, no data
+        FakeGenome(
+            release=114,
+            gene_by_id_map={"ENSGREAL": FakeGene("ENSGREAL", "REALGENE")},
+            tx_by_id_map={"ENSTREAL": tx},
+        ),
+    ]
+    monkeypatch.setattr(gi, "genomes", genomes)
+    monkeypatch.setattr(gi, "_indexes_built", False)
+    monkeypatch.setattr(gi, "_gene_id_to_name", {})
+    monkeypatch.setattr(gi, "_transcript_id_to_gene_name", {})
+    monkeypatch.setattr(gi, "_gene_id_miss_cache", set())
+    monkeypatch.setattr(gi, "_transcript_id_miss_cache", set())
+    monkeypatch.setattr(
+        gi, "_index_cache_path",
+        lambda release: tmp_path / f"fake-ensembl-{release}-id-index.pkl",
+    )
+
+    gi._build_indexes()
+
+    # Eagerly indexed (present in the map *before* any per-id fallback runs).
+    assert gi._transcript_id_to_gene_name.get("ENSTREAL") == "REALGENE"
+    assert gi._gene_id_to_name.get("ENSGREAL") == "REALGENE"
+    # And the lazy fallback was never needed for it.
+    assert "ENSTREAL" not in gi._transcript_id_miss_cache
+
+
+def test_index_cache_invalidates_when_installed_release_set_changes(tmp_path):
+    """A union cache built against one installed-release list is rejected once
+    that list changes (e.g. a new annotation is downloaded)."""
+    gene_map = {f"ENSG{i}": "G" for i in range(gi._MIN_SANE_GENE_COUNT + 1)}
+    tx_map = {f"ENST{i}": "G" for i in range(gi._MIN_SANE_TRANSCRIPT_COUNT + 1)}
+    path = tmp_path / "idx.pkl"
+    import pirlygenes.gene_ids as _gi
+    orig = _gi._index_cache_path
+    _gi._index_cache_path = lambda release: path
+    try:
+        _gi._store_index_cache(114, gene_map, tx_map, installed_releases=[114])
+        # Same release set → hit.
+        assert _gi._load_index_cache(114, installed_releases=[114]) is not None
+        # Newer release downloaded → the cached union is stale → miss.
+        assert _gi._load_index_cache(114, installed_releases=[115, 114]) is None
+    finally:
+        _gi._index_cache_path = orig
+
+
+def test_store_index_cache_refuses_degenerate_map(tmp_path):
+    """An empty/partial build must never be persisted — a tiny pickle would be
+    loaded back as 'the index' and defeat the whole fast path."""
+    path = tmp_path / "idx.pkl"
+    import pirlygenes.gene_ids as _gi
+    orig = _gi._index_cache_path
+    _gi._index_cache_path = lambda release: path
+    try:
+        _gi._store_index_cache(115, {"ENSG1": "G"}, {"ENST1": "G"})
+        assert not path.exists()
+    finally:
+        _gi._index_cache_path = orig
+
+
 def test_ncbi_synonym_official_symbol_casing(monkeypatch):
     monkeypatch.setattr(gi, "_ncbi_symbol_synonyms", lambda: {"GNB2L1": "RACK1"})
     assert gi.ncbi_synonym_official_symbol("gnb2l1") == "RACK1"


### PR DESCRIPTION
Finishes the optimization from #263 (and the backed-out work-in-progress commit) as a clean PR.

## Problem
Resolving an Ensembl id walks pyensembl's gene/transcript tables (~2s per process), and an id retired before the newest installed release falls through to a **per-id sqlite probe across every older genome** — up to ~1.5M sqlite queries for a large file. The newest *installed* release can also have an empty GTF, which used to poison the on-disk cache with an empty map and force **every** lookup onto that slow fallback (the "79-byte cache" bug).

## Fix
- Build a **union** id→name map across every installed release, newest-first (`setdefault` → newest annotation wins). A retired id is now a single dict hit, not a per-id sqlite probe. The lazy older-release fallback stays as a backstop.
- `_release_id_maps()`: pull each release via a **direct gtf-sqlite query** (`SELECT transcript_id, gene_name FROM transcript`) — ~0.2s/release vs ~130s walking `genome.transcripts()` — with a compatibility fallback to the public `genes()`/`transcripts()` walk (also covers test fakes).
- Refuse to persist a **degenerate** index (empty/partial build), fixing the poison-cache bug.
- Cache key validated against the full **installed-release list**, so downloading a new annotation correctly invalidates the union.

## Validation (real pyensembl, 34 installed releases)
- Cold union build: **6.84s** (one-time, disk-cached, shared across processes) → 88,709 genes / 372,100 transcripts.
- Warm cache load: **0.07s** (was ~2s+ per process, every process).
- Direct-SQL path confirmed: 42,670 genes / 222,590 tx for one release in 0.24s; TP53 → ENSG00000141510.

## Tests
3 new unit tests: skip-empty-newest + eager-union, cache-invalidation on installed-release change, degenerate-map refusal. 572 pass.

No API change, no schema change.