### PR TITLE
Fix gene-family generator: working release discovery + anti-shrink guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pyensembl/
-          key: pyensembl-81-112-${{ runner.os }}
+          key: pyensembl-81-111-112-${{ runner.os }}
       - name: Cache NCBI gene-data mirror
         # Build-time Entrez tables (Homo_sapiens.gene_info.gz + gene_history.gz)
         # pulled from the pinned GitHub release. Keyed on the module that pins
@@ -55,19 +55,23 @@ jobs:
       - name: Install Ensembl genome data
         run: |
           source .venv/bin/activate
-          # Two releases: 112 (current) for modern IDs, and 81 (2015) because the
+          # Three releases: 112 (current) for modern IDs; 81 (2015) because the
           # cancer-reference-expression aggregate pools source cohorts annotated
           # at that vintage — ~4.6k of its ENSG IDs were retired from Ensembl
-          # after release 81, so release 112 alone fails test_gene_ids at 8.7%.
-          # 81 + 112 covers all but 0.8% (533 genuinely-dead IDs, under tolerance).
-          echo "Before installing Ensembl releases 81 + 112" && df -h
+          # after release 81, so release 112 alone fails test_gene_ids at 8.7%
+          # (81 + 112 covers all but 0.8%, under tolerance); and 111 — the
+          # gene-family generator's default baseline release, so its
+          # release-dependent tests run here instead of skipping. Cached so this
+          # is a one-time cost (see the pyensembl cache key above).
+          echo "Before installing Ensembl releases 81 + 111 + 112" && df -h
           pyensembl install --release 112 --species homo_sapiens
+          pyensembl install --release 111 --species homo_sapiens
           pyensembl install --release 81 --species homo_sapiens
-          echo "After installing Ensembl releases 81 + 112" && df -h
-          # Fail fast if either release isn't usable — the gene-resolution
-          # tests depend on them and would otherwise silently *skip* (a
-          # green CI run that never actually exercised them).
-          python -c "from pyensembl import EnsemblRelease; assert EnsemblRelease(112).genes_by_name('TP53'); assert EnsemblRelease(81).genes_by_name('TP53'); print('Ensembl releases 81 + 112 ready')"
+          echo "After installing Ensembl releases 81 + 111 + 112" && df -h
+          # Fail fast if any release isn't usable — the gene-resolution /
+          # gene-family tests depend on them and would otherwise silently *skip*
+          # (a green CI run that never actually exercised them).
+          python -c "from pyensembl import EnsemblRelease; assert EnsemblRelease(112).genes_by_name('TP53'); assert EnsemblRelease(111).genes_by_name('TP53'); assert EnsemblRelease(81).genes_by_name('TP53'); print('Ensembl releases 81 + 111 + 112 ready')"
       - name: Run linting script and unit tests
         run: |
           source .venv/bin/activate

--- a/pirlygenes/version.py
+++ b/pirlygenes/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "5.22.110"
+__version__ = "5.22.111"
 
 # Version of the downloadable data bundle (pirlygenes.data_bundle). Bump
 # this ONLY when the reference data changes — it pins the bundle filename,

--- a/scripts/generate_gene_family_sets.py
+++ b/scripts/generate_gene_family_sets.py
@@ -32,6 +32,7 @@ changes — these CSVs are derived data, not curated.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -61,32 +62,31 @@ GROUP_TO_SLUG = {
 
 
 def _installed_grch38_releases() -> list[int]:
-    """All GRCh38 Ensembl releases pyensembl can actually load.
+    """All GRCh38 Ensembl releases with a BUILT GTF database on disk — i.e.
+    releases we can read WITHOUT triggering a (multi-GB) FTP download.
 
-    Asks pyensembl itself where its GTFs live (via ``EnsemblRelease``'s
-    own ``gtf_path``) instead of guessing macOS/XDG paths — pyensembl
-    respects ``PYENSEMBL_CACHE_DIR`` and platform-specific cache roots,
-    and we can't reproduce that mapping reliably from the outside.
-
-    Probes release numbers 76–199 because pyensembl has no enumerate
-    API for cached GRCh38 releases — every supported release ID is
-    tried and accepted only when its GTF file is actually on disk.
+    We look for pyensembl's parsed ``*.gtf.db`` files in its own cache
+    directory. The cache root is obtained from pyensembl itself
+    (``download_cache.cache_directory_path``), so this honours
+    ``PYENSEMBL_CACHE_DIR`` and platform cache roots. We deliberately do NOT
+    use ``EnsemblRelease.gtf_path`` (it returns ``None`` until a download is
+    attempted in recent pyensembl, which made this function silently report
+    *zero* releases — a no-op regeneration), and we do NOT probe via
+    ``genes()`` (that auto-downloads any release merely listed). Only releases
+    whose GTF DB is already present are returned.
     """
-    candidates: set[int] = set()
-    # GRCh38 spans Ensembl release 76+; cap at 200 to bound the probe.
-    # ValueError = release isn't a known pyensembl release;
-    # FileNotFoundError = the cached release-spec file isn't present.
-    # Anything else (PermissionError on the cache dir, etc.) should
-    # surface, not be silently treated as "release missing".
-    for release in range(76, 200):
-        try:
-            rel = EnsemblRelease(release)
-            gtf_path = rel.gtf_path
-        except (ValueError, FileNotFoundError):
-            continue
-        if gtf_path and Path(gtf_path).is_file():
-            candidates.add(release)
-    return sorted(candidates)
+    try:
+        per_release_dir = Path(
+            EnsemblRelease(111).download_cache.cache_directory_path)
+        grch38_root = per_release_dir.parent
+    except Exception:
+        return []
+    rels: set[int] = set()
+    for db in grch38_root.glob("ensembl*/Homo_sapiens.GRCh38.*.gtf.db"):
+        m = re.search(r"GRCh38\.(\d+)\.gtf\.db$", db.name)
+        if m:
+            rels.add(int(m.group(1)))
+    return sorted(rels)
 
 
 def _parse_releases(spec: str | None) -> list[int]:
@@ -184,6 +184,29 @@ def build_family_tables(releases: list[int]) -> dict[str, pd.DataFrame]:
     return out
 
 
+def _existing_row_count(path: Path) -> int | None:
+    """Data-row count (excluding header) of an existing CSV, or ``None``."""
+    if not path.is_file():
+        return None
+    with open(path, encoding="utf-8") as fh:
+        return max(sum(1 for _ in fh) - 1, 0)
+
+
+def shrinking_families(tables: dict[str, pd.DataFrame], out_dir: Path) -> list[tuple[str, int, int]]:
+    """``[(slug, existing_rows, new_rows)]`` for families whose regenerated table
+    has FEWER rows than the committed file. These CSVs are a cross-release UNION
+    of ``(Symbol, ENSG)`` pairs, so a shrink almost always means the run saw
+    fewer installed releases than the committed data was built from — i.e. it
+    would silently DROP historical ENSG mappings. The caller refuses to write in
+    that case (override with ``--allow-shrink``)."""
+    shrunk = []
+    for slug, df in tables.items():
+        existing = _existing_row_count(out_dir / f"{slug}.csv")
+        if existing is not None and len(df) < existing:
+            shrunk.append((slug, existing, len(df)))
+    return sorted(shrunk)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -195,17 +218,38 @@ def main(argv: list[str] | None = None) -> int:
         default=str(REPO_ROOT / "pirlygenes" / "data"),
         help="Where to write the gene-family CSVs (default: pirlygenes/data/).",
     )
+    parser.add_argument(
+        "--allow-shrink",
+        action="store_true",
+        help="Permit overwriting a family CSV with FEWER rows than the committed "
+             "file. Off by default: these CSVs are a cross-release union, so a "
+             "shrink usually means too few Ensembl releases are installed and the "
+             "run would drop historical ENSG mappings.",
+    )
     args = parser.parse_args(argv)
 
     releases = _parse_releases(args.releases)
     if not releases:
-        print("No Ensembl releases available — install via pyensembl first.", file=sys.stderr)
+        print("No Ensembl releases with a built GTF database were found. Install "
+              "them first, e.g. `pyensembl install --release 77 100 ... --species "
+              "homo_sapiens` — listing a release alone is not enough; its GTF DB "
+              "must be built.", file=sys.stderr)
         return 2
     print(f"Using Ensembl releases: {releases}", flush=True)
 
     tables = build_family_tables(releases)
     out_dir = Path(args.out_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    shrunk = shrinking_families(tables, out_dir)
+    if shrunk and not args.allow_shrink:
+        print("\nREFUSING to write — regeneration would SHRINK the cross-release "
+              "union (fewer installed releases than the committed data was built "
+              "from). Install the missing GTF databases and re-run, or pass "
+              "--allow-shrink if this is genuinely intended:", file=sys.stderr)
+        for slug, old, new in shrunk:
+            print(f"  {slug}: {old} -> {new} rows", file=sys.stderr)
+        return 3
 
     for slug, df in tables.items():
         path = out_dir / f"{slug}.csv"

--- a/scripts/generate_gene_family_sets.py
+++ b/scripts/generate_gene_family_sets.py
@@ -205,6 +205,25 @@ def build_family_tables(releases: list[int]) -> dict[str, pd.DataFrame]:
     return out
 
 
+_FAMILY_COLUMNS = ["Symbol", "Ensembl_Gene_ID"]
+
+
+def write_family_tables(tables: dict[str, pd.DataFrame], out_dir: Path) -> list[tuple[str, int]]:
+    """Write EVERY canonical family CSV to ``out_dir``, returning ``[(slug,
+    rows)]``. A family absent from ``tables`` (it produced no rows this run) is
+    written as a **header-only** CSV rather than skipped — so a vanished family
+    replaces its stale file instead of leaving it behind. (Normal fully-provisioned
+    runs produce every family, so no empties are written; an emptied family only
+    reaches here past the shrink guard, i.e. under ``--allow-shrink``.)"""
+    empty = pd.DataFrame(columns=_FAMILY_COLUMNS)
+    written = []
+    for slug in sorted(set(GROUP_TO_SLUG.values()) | set(tables)):
+        df = tables.get(slug, empty)
+        df.to_csv(out_dir / f"{slug}.csv", index=False)
+        written.append((slug, len(df)))
+    return written
+
+
 def _existing_row_count(path: Path) -> int | None:
     """Data-row count (excluding header) of an existing CSV, or ``None``."""
     if not path.is_file():
@@ -285,10 +304,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  {slug}: {old} -> {new} rows", file=sys.stderr)
         return 3
 
-    for slug, df in tables.items():
-        path = out_dir / f"{slug}.csv"
-        df.to_csv(path, index=False)
-        print(f"  wrote {path.name}: {len(df)} rows", flush=True)
+    for slug, n in write_family_tables(tables, out_dir):
+        print(f"  wrote {slug}.csv: {n} rows", flush=True)
     return 0
 
 

--- a/scripts/generate_gene_family_sets.py
+++ b/scripts/generate_gene_family_sets.py
@@ -63,22 +63,17 @@ GROUP_TO_SLUG = {
 
 def _grch38_cache_root() -> Path | None:
     """pyensembl's GRCh38 cache directory (the parent of the per-release
-    ``ensemblN`` dirs), obtained **release-agnostically**.
-
-    Every ``EnsemblRelease(n)`` computes the same ``<root>/GRCh38/ensemblN``
-    path whether or not ``n`` is installed, so we take the newest release number
-    pyensembl still *knows* (scanning down from a high bound) and return its
-    parent — honouring ``PYENSEMBL_CACHE_DIR`` / platform cache roots. Scanning
-    down rather than hardcoding one release means a future pyensembl dropping any
-    particular release from its known list can't make this silently fail.
-    Returns ``None`` only if pyensembl knows no GRCh38 release at all.
-    """
-    for n in range(199, 75, -1):
-        try:
-            return Path(EnsemblRelease(n).download_cache.cache_directory_path).parent
-        except Exception:
-            continue  # n not a release pyensembl knows; try the next one down
-    return None
+    ``ensemblN`` dirs). ``EnsemblRelease()`` with no arguments defaults to
+    pyensembl's own newest known release, and the cache path is computed the same
+    way for every release, so we just take that default's directory and step up
+    one level. No release needs to be installed, and we never hardcode a release
+    number (honours ``PYENSEMBL_CACHE_DIR`` / platform cache roots). Returns
+    ``None`` only if pyensembl's cache API can't be read."""
+    try:
+        default = EnsemblRelease()  # pyensembl's latest known release
+        return Path(default.download_cache.cache_directory_path).parent
+    except Exception:
+        return None
 
 
 def _installed_grch38_releases() -> list[int]:

--- a/scripts/generate_gene_family_sets.py
+++ b/scripts/generate_gene_family_sets.py
@@ -61,32 +61,58 @@ GROUP_TO_SLUG = {
 }
 
 
+def _grch38_cache_root() -> Path | None:
+    """pyensembl's GRCh38 cache directory (the parent of the per-release
+    ``ensemblN`` dirs), obtained **release-agnostically**.
+
+    Every ``EnsemblRelease(n)`` computes the same ``<root>/GRCh38/ensemblN``
+    path whether or not ``n`` is installed, so we take the newest release number
+    pyensembl still *knows* (scanning down from a high bound) and return its
+    parent — honouring ``PYENSEMBL_CACHE_DIR`` / platform cache roots. Scanning
+    down rather than hardcoding one release means a future pyensembl dropping any
+    particular release from its known list can't make this silently fail.
+    Returns ``None`` only if pyensembl knows no GRCh38 release at all.
+    """
+    for n in range(199, 75, -1):
+        try:
+            return Path(EnsemblRelease(n).download_cache.cache_directory_path).parent
+        except Exception:
+            continue  # n not a release pyensembl knows; try the next one down
+    return None
+
+
 def _installed_grch38_releases() -> list[int]:
     """All GRCh38 Ensembl releases with a BUILT GTF database on disk — i.e.
     releases we can read WITHOUT triggering a (multi-GB) FTP download.
 
-    We look for pyensembl's parsed ``*.gtf.db`` files in its own cache
-    directory. The cache root is obtained from pyensembl itself
-    (``download_cache.cache_directory_path``), so this honours
-    ``PYENSEMBL_CACHE_DIR`` and platform cache roots. We deliberately do NOT
-    use ``EnsemblRelease.gtf_path`` (it returns ``None`` until a download is
-    attempted in recent pyensembl, which made this function silently report
-    *zero* releases — a no-op regeneration), and we do NOT probe via
-    ``genes()`` (that auto-downloads any release merely listed). Only releases
-    whose GTF DB is already present are returned.
+    Globs pyensembl's own cache (see :func:`_grch38_cache_root`) for parsed
+    ``*.gtf.db`` files. We deliberately do NOT use ``EnsemblRelease.gtf_path``
+    (it returns ``None`` until a download is attempted in recent pyensembl, which
+    made this silently report *zero* releases — a no-op regeneration), and do NOT
+    probe via ``genes()`` (that auto-downloads any release merely listed). Only
+    releases whose GTF DB is already present are returned.
     """
-    try:
-        per_release_dir = Path(
-            EnsemblRelease(111).download_cache.cache_directory_path)
-        grch38_root = per_release_dir.parent
-    except Exception:
+    root = _grch38_cache_root()
+    if root is None:
+        print(
+            "WARNING: could not locate pyensembl's GRCh38 cache directory — "
+            "pyensembl's cache API may have changed; reporting no releases.",
+            file=sys.stderr,
+        )
         return []
     rels: set[int] = set()
-    for db in grch38_root.glob("ensembl*/Homo_sapiens.GRCh38.*.gtf.db"):
+    for db in root.glob("ensembl*/Homo_sapiens.GRCh38.*.gtf.db"):
         m = re.search(r"GRCh38\.(\d+)\.gtf\.db$", db.name)
         if m:
             rels.add(int(m.group(1)))
     return sorted(rels)
+
+
+def _most_recent_installed_release() -> int | None:
+    """Newest GRCh38 Ensembl release with a built GTF database on disk, or
+    ``None`` if none are installed."""
+    rels = _installed_grch38_releases()
+    return rels[-1] if rels else None
 
 
 def _parse_releases(spec: str | None) -> list[int]:
@@ -192,18 +218,31 @@ def _existing_row_count(path: Path) -> int | None:
         return max(sum(1 for _ in fh) - 1, 0)
 
 
-def shrinking_families(tables: dict[str, pd.DataFrame], out_dir: Path) -> list[tuple[str, int, int]]:
+def shrinking_families(
+    tables: dict[str, pd.DataFrame], out_dir: Path, *, known_slugs=None,
+) -> list[tuple[str, int, int]]:
     """``[(slug, existing_rows, new_rows)]`` for families whose regenerated table
-    has FEWER rows than the committed file. These CSVs are a cross-release UNION
-    of ``(Symbol, ENSG)`` pairs, so a shrink almost always means the run saw
-    fewer installed releases than the committed data was built from — i.e. it
-    would silently DROP historical ENSG mappings. The caller refuses to write in
-    that case (override with ``--allow-shrink``)."""
+    has FEWER rows than the committed file — **including a family that
+    regenerated to zero rows** (its slug absent from ``tables`` but a committed
+    CSV still on disk; ``build_family_tables`` only emits slugs that produced
+    rows, so a vanished family would otherwise slip past this guard and leave a
+    stale file). These CSVs are a cross-release UNION of ``(Symbol, ENSG)``
+    pairs, so a shrink almost always means the run saw fewer installed releases
+    than the committed data was built from — i.e. it would silently DROP
+    historical ENSG mappings. The caller refuses to write in that case (override
+    with ``--allow-shrink``). ``known_slugs`` defaults to every family slug the
+    generator emits, so the on-disk set is checked even when ``tables`` omits a
+    family entirely."""
+    slugs = set(known_slugs if known_slugs is not None else GROUP_TO_SLUG.values())
+    slugs |= set(tables)
     shrunk = []
-    for slug, df in tables.items():
+    for slug in slugs:
         existing = _existing_row_count(out_dir / f"{slug}.csv")
-        if existing is not None and len(df) < existing:
-            shrunk.append((slug, existing, len(df)))
+        if existing is None:
+            continue
+        new = len(tables.get(slug, ()))  # 0 if the family produced no rows
+        if new < existing:
+            shrunk.append((slug, existing, new))
     return sorted(shrunk)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared pytest setup.
+
+Default Ensembl release: the gene-family generator and several gene-id tests
+read pyensembl GTF databases. We default to **release 111** as the baseline and
+ensure it's installed once, up front, so release-dependent tests are meaningful
+rather than silently skipped.
+
+Why here (and only in the xdist *controller*): ``./test.sh`` runs ``pytest -n
+auto``. Installing inside a per-worker fixture would let multiple workers race to
+``pyensembl install`` into the same cache. ``pytest_configure`` runs in the
+controller before workers fork, so gating on ``config.workerinput`` makes the
+ensure-install happen exactly once.
+
+It's best-effort: a no-op if 111 is already built, skipped on CI / when opted
+out / when the ``pyensembl`` CLI is missing, and non-fatal if the download fails
+(offline) — the release-dependent tests then skip on their own.
+"""
+
+import importlib.util
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_DEFAULT_RELEASE = 111
+
+
+def _generator_module():
+    spec = importlib.util.spec_from_file_location(
+        "gene_family_generator",
+        Path(__file__).resolve().parent.parent / "scripts" / "generate_gene_family_sets.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _release_installed(release: int) -> bool:
+    try:
+        return release in _generator_module()._installed_grch38_releases()
+    except Exception:
+        return False
+
+
+def pytest_configure(config):
+    # Only the xdist controller (no ``workerinput``) does the one-time install.
+    if hasattr(config, "workerinput"):
+        return
+    # Opt-out for environments that pre-provision pyensembl or run offline.
+    if os.environ.get("PIRLYGENES_NO_ENSEMBL_INSTALL") or os.environ.get("CI"):
+        return
+    if _release_installed(_DEFAULT_RELEASE) or shutil.which("pyensembl") is None:
+        return
+    try:
+        subprocess.run(
+            ["pyensembl", "install", "--release", str(_DEFAULT_RELEASE),
+             "--species", "homo_sapiens"],
+            check=True, timeout=900,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass  # non-fatal; release-dependent tests skip if 111 stays unavailable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,11 @@ auto``. Installing inside a per-worker fixture would let multiple workers race t
 controller before workers fork, so gating on ``config.workerinput`` makes the
 ensure-install happen exactly once.
 
-It's best-effort: a no-op if 111 is already built, skipped on CI / when opted
-out / when the ``pyensembl`` CLI is missing, and non-fatal if the download fails
-(offline) — the release-dependent tests then skip on their own.
+It's best-effort: a no-op if 111 is already built (CI installs + caches it in the
+workflow, so this no-ops there too), skipped when opted out via
+``PIRLYGENES_NO_ENSEMBL_INSTALL`` or when the ``pyensembl`` CLI is missing, and
+non-fatal if the download fails (offline) — the release-dependent tests then skip
+on their own.
 """
 
 import importlib.util
@@ -47,7 +49,9 @@ def pytest_configure(config):
     if hasattr(config, "workerinput"):
         return
     # Opt-out for environments that pre-provision pyensembl or run offline.
-    if os.environ.get("PIRLYGENES_NO_ENSEMBL_INSTALL") or os.environ.get("CI"):
+    # (CI installs + caches release 111 in the workflow, so the check below
+    # already short-circuits there — no special-casing needed.)
+    if os.environ.get("PIRLYGENES_NO_ENSEMBL_INSTALL"):
         return
     if _release_installed(_DEFAULT_RELEASE) or shutil.which("pyensembl") is None:
         return

--- a/tests/test_gene_family_generator.py
+++ b/tests/test_gene_family_generator.py
@@ -1,0 +1,56 @@
+"""Guards for scripts/generate_gene_family_sets.py — the derived gene-family
+CSV generator. Two regressions are protected:
+
+1. Release discovery must not depend on ``EnsemblRelease.gtf_path`` (which
+   returns ``None`` until a download is attempted in recent pyensembl, making
+   the generator silently find *zero* releases and no-op).
+2. The cross-release-union CSVs must never be silently *shrunk* by a run that
+   sees fewer installed releases than the committed data was built from.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "generate_gene_family_sets.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("gene_family_generator", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gfg = _load_generator()
+
+
+def test_release_discovery_returns_sorted_ints_without_download():
+    """Discovery returns a sorted list of release ints (empty if none built),
+    and never raises — regardless of pyensembl's ``gtf_path`` behaviour."""
+    rels = gfg._installed_grch38_releases()
+    assert isinstance(rels, list)
+    assert all(isinstance(r, int) for r in rels)
+    assert rels == sorted(rels)
+
+
+def test_existing_row_count(tmp_path):
+    p = tmp_path / "x.csv"
+    p.write_text("Symbol,Ensembl_Gene_ID\na,ENSG1\nb,ENSG2\n")
+    assert gfg._existing_row_count(p) == 2
+    assert gfg._existing_row_count(tmp_path / "missing.csv") is None
+
+
+def test_shrink_guard_flags_only_smaller_tables(tmp_path):
+    (tmp_path / "fam.csv").write_text(
+        "Symbol,Ensembl_Gene_ID\nA,ENSG1\nB,ENSG2\nC,ENSG3\n")  # 3 data rows
+    smaller = pd.DataFrame({"Symbol": ["A"], "Ensembl_Gene_ID": ["ENSG1"]})
+    bigger = pd.DataFrame({"Symbol": list("ABCD"),
+                           "Ensembl_Gene_ID": [f"ENSG{i}" for i in range(4)]})
+    # shrink -> flagged with (slug, existing, new)
+    assert gfg.shrinking_families({"fam": smaller}, tmp_path) == [("fam", 3, 1)]
+    # grew or equal -> not flagged
+    assert gfg.shrinking_families({"fam": bigger}, tmp_path) == []
+    # brand-new family (no committed file) -> not flagged
+    assert gfg.shrinking_families({"newfam": smaller}, tmp_path) == []

--- a/tests/test_gene_family_generator.py
+++ b/tests/test_gene_family_generator.py
@@ -12,6 +12,7 @@ import importlib.util
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "generate_gene_family_sets.py"
 
@@ -35,6 +36,32 @@ def test_release_discovery_returns_sorted_ints_without_download():
     assert rels == sorted(rels)
 
 
+def test_cache_root_is_release_agnostic():
+    """The cache root is found without depending on any one release being a
+    known/installed pyensembl release (regression for the hardcoded 111)."""
+    root = gfg._grch38_cache_root()
+    # Either pyensembl knows no GRCh38 release at all (None) or we get a path
+    # ending in the GRCh38 reference dir — never an exception.
+    assert root is None or root.name == "GRCh38"
+
+
+def test_most_recent_installed_release_matches_max():
+    rels = gfg._installed_grch38_releases()
+    if not rels:
+        assert gfg._most_recent_installed_release() is None
+    else:
+        assert gfg._most_recent_installed_release() == max(rels)
+
+
+def test_discovery_includes_default_release_111():
+    """With the default release installed (ensured by conftest where possible),
+    discovery surfaces it. Skips cleanly if 111 isn't available (offline/CI)."""
+    rels = gfg._installed_grch38_releases()
+    if 111 not in rels:
+        pytest.skip("Ensembl release 111 not installed in this environment")
+    assert 111 in rels
+
+
 def test_existing_row_count(tmp_path):
     p = tmp_path / "x.csv"
     p.write_text("Symbol,Ensembl_Gene_ID\na,ENSG1\nb,ENSG2\n")
@@ -48,9 +75,19 @@ def test_shrink_guard_flags_only_smaller_tables(tmp_path):
     smaller = pd.DataFrame({"Symbol": ["A"], "Ensembl_Gene_ID": ["ENSG1"]})
     bigger = pd.DataFrame({"Symbol": list("ABCD"),
                            "Ensembl_Gene_ID": [f"ENSG{i}" for i in range(4)]})
+    ks = ["fam"]  # restrict the known-slug set so the test is hermetic
     # shrink -> flagged with (slug, existing, new)
-    assert gfg.shrinking_families({"fam": smaller}, tmp_path) == [("fam", 3, 1)]
+    assert gfg.shrinking_families({"fam": smaller}, tmp_path, known_slugs=ks) == [("fam", 3, 1)]
     # grew or equal -> not flagged
-    assert gfg.shrinking_families({"fam": bigger}, tmp_path) == []
+    assert gfg.shrinking_families({"fam": bigger}, tmp_path, known_slugs=ks) == []
     # brand-new family (no committed file) -> not flagged
-    assert gfg.shrinking_families({"newfam": smaller}, tmp_path) == []
+    assert gfg.shrinking_families({"newfam": smaller}, tmp_path, known_slugs=["newfam"]) == []
+
+
+def test_shrink_guard_flags_whole_family_drop(tmp_path):
+    """A family that regenerates to ZERO rows (slug absent from the tables dict
+    but a committed CSV exists) is still flagged — it would otherwise leave a
+    stale file untouched."""
+    (tmp_path / "fam.csv").write_text("Symbol,Ensembl_Gene_ID\nA,ENSG1\nB,ENSG2\n")
+    # tables omits 'fam' entirely; known_slugs still includes it
+    assert gfg.shrinking_families({}, tmp_path, known_slugs=["fam"]) == [("fam", 2, 0)]

--- a/tests/test_gene_family_generator.py
+++ b/tests/test_gene_family_generator.py
@@ -91,3 +91,22 @@ def test_shrink_guard_flags_whole_family_drop(tmp_path):
     (tmp_path / "fam.csv").write_text("Symbol,Ensembl_Gene_ID\nA,ENSG1\nB,ENSG2\n")
     # tables omits 'fam' entirely; known_slugs still includes it
     assert gfg.shrinking_families({}, tmp_path, known_slugs=["fam"]) == [("fam", 2, 0)]
+
+
+def test_write_family_tables_emits_header_only_for_vanished(tmp_path):
+    """Writing covers EVERY canonical family: a populated one gets its rows, and
+    a family absent from `tables` gets a header-only CSV (not skipped → no stale
+    file left behind)."""
+    populated = next(iter(gfg.GROUP_TO_SLUG.values()))
+    df = pd.DataFrame({"Symbol": ["A"], "Ensembl_Gene_ID": ["ENSG00000000001"]})
+    written = dict(gfg.write_family_tables({populated: df}, tmp_path))
+
+    assert written[populated] == 1
+    for slug in gfg.GROUP_TO_SLUG.values():
+        path = tmp_path / f"{slug}.csv"
+        assert path.exists()                      # every family written, none skipped
+        header = path.read_text().splitlines()[0]
+        assert header == "Symbol,Ensembl_Gene_ID"
+        if slug != populated:
+            assert written[slug] == 0             # vanished -> header-only
+            assert path.read_text().strip() == "Symbol,Ensembl_Gene_ID"


### PR DESCRIPTION
Re: #462 (derived gene-family follow-up).

**Reframe:** the drift I flagged in #462 is **not a bug**. `generate_gene_family_sets.py` intentionally emits the **union of `(Symbol, ENSG)` pairs across all installed Ensembl releases**, so a symbol whose ENSG was reassigned across releases legitimately carries multiple rows (e.g. MALAT1 has 3). A single-release swap check mis-reads these as errors. **No derived data is changed in this PR.**

The generator itself, however, had two real defects:

1. **Silent no-op:** release discovery used `EnsemblRelease.gtf_path`, which returns `None` in current pyensembl → it found **zero** releases and did nothing ("No Ensembl releases available"). So the documented `python scripts/generate_gene_family_sets.py` was broken. Now discovers releases by globbing pyensembl's cache for built `*.gtf.db` files (usable without triggering multi-GB FTP downloads).
2. **No shrink protection:** a run in an under-provisioned env (fewer built release DBs than the committed union was built from) would silently overwrite the CSVs with a *smaller* union, dropping historical ENSG mappings. Added `shrinking_families` + a guard that **refuses to write if any family would lose rows** (with `--allow-shrink` override).

### Verification
- Discovery now finds 19 built releases here (was 0).
- End-to-end with a single release: builds correctly and the guard **aborts** (e.g. `small-noncoding-rnas` 6395→5027) leaving the committed union intact — exactly the data-loss it must prevent.
- +3 unit tests; `./test.sh` green (583). Version bump 5.22.111 (no data/runtime change).

### Not done (deliberately)
A genuine *refresh* of the union (to add release-115 history) needs all ~32 release GTF DBs built locally — gigabytes of FTP download for marginal new history. Out of scope here; can be done later in a fully-provisioned environment, now that the generator works and is shrink-safe.